### PR TITLE
fix: use toYaml for custom annotations in helm chart

### DIFF
--- a/helm/readyset/templates/_helpers.adapters.tpl
+++ b/helm/readyset/templates/_helpers.adapters.tpl
@@ -219,7 +219,7 @@ spec:
         {{- end }}
         {{- if .adapter.annotations }}
       annotations:
-          {{- tpl .adapter.annotations . | nindent 8 }}
+          {{- toYaml .adapter.annotations | nindent 8 }}
         {{- end }}
     spec:
       serviceAccountName: {{ include "readyset.adapter.serviceAccountName" (dict "root" $.Values "releaseName" .Release.Name) }}

--- a/helm/readyset/templates/_helpers.server.tpl
+++ b/helm/readyset/templates/_helpers.server.tpl
@@ -43,7 +43,7 @@ spec:
         {{- end }}
         {{- if .server.annotations }}
       annotations:
-          {{- tpl .server.annotations . | nindent 8 }}
+          {{- toYaml .server.annotations | nindent 8 }}
         {{- end }}
     spec:
     {{- if .server.affinity }}


### PR DESCRIPTION
in trying to do something like this in the helm chart values:

```yaml
      adapter:
        annotations:
          custom_annotation: foobar
```

i noticed that the underlying templates were using `tpl` in a way where they expected a string, instead of a map, which caused the chart to fail validation

here, im modifying the usage, which i tested locally, where the user can provide the annotations in a map (similar to how the templates expect `.extraLabels`)