### PR TITLE
nom-sql: Parse MySQL Bit-Value literals

### DIFF
--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -2454,4 +2454,35 @@ PRIMARY KEY (`id`));";
         let res = test_parse!(create_table(Dialect::MySQL), qstring);
         assert_eq!(res.table.name, "spree_zones");
     }
+
+    #[test]
+    fn bit_literal() {
+        let qstring = b"CREATE TABLE `table` (
+            `enabled` bit(1) NOT NULL DEFAULT b'0'
+          )";
+
+        let res = test_parse!(create_table(Dialect::MySQL), qstring);
+
+        assert_eq!(
+            res,
+            CreateTableStatement {
+                if_not_exists: false,
+                table: "table".into(),
+                body: Ok(CreateTableBody {
+                    fields: vec![ColumnSpecification::with_constraints(
+                        "enabled".into(),
+                        SqlType::Bit(Some(1)),
+                        vec![
+                            ColumnConstraint::NotNull,
+                            ColumnConstraint::DefaultValue(Expr::Literal(Literal::BitVector(
+                                vec![0]
+                            ))),
+                        ],
+                    ),],
+                    keys: None,
+                }),
+                options: Ok(vec![])
+            }
+        );
+    }
 }

--- a/nom-sql/src/dialect.rs
+++ b/nom-sql/src/dialect.rs
@@ -47,8 +47,8 @@ fn hex_bytes(input: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], Vec<u8>> {
     )(input)
 }
 
-/// Bit vector literal value (PostgreSQL)
-fn raw_bit_vector_psql(input: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], BitVec> {
+/// Bit vector literal value
+fn raw_bit_vector(input: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], BitVec> {
     delimited(tag_no_case("b'"), bits, tag("'"))(input)
 }
 
@@ -219,13 +219,7 @@ impl Dialect {
 
     /// Parse the raw (byte) content of a bit vector literal using this Dialect.
     pub fn bitvec_literal(self) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], BitVec> {
-        move |input| match self {
-            Dialect::PostgreSQL => raw_bit_vector_psql(input),
-            Dialect::MySQL => Err(nom::Err::Error(NomSqlError {
-                input,
-                kind: nom::error::ErrorKind::Many0,
-            })),
-        }
+        move |input| raw_bit_vector(input)
     }
 
     /// Parses the MySQL specific `{offset}, {limit}` part in a `LIMIT` clause


### PR DESCRIPTION
Fixes https://github.com/readysettech/readyset/issues/54

Refactors existing PostgreSQL functionality for compatibility with MySQL due to shared syntax  