### PR TITLE
nom-sql: Parse fractional seconds precision on MySQL CURRENT_TIMESTAMP function

### DIFF
--- a/nom-sql/src/analysis/visit.rs
+++ b/nom-sql/src/analysis/visit.rs
@@ -858,7 +858,7 @@ pub fn walk_column_constraint<'a, V: Visitor<'a>>(
         | ColumnConstraint::AutoIncrement
         | ColumnConstraint::PrimaryKey
         | ColumnConstraint::Unique
-        | ColumnConstraint::OnUpdateCurrentTimestamp => Ok(()),
+        | ColumnConstraint::OnUpdateCurrentTimestamp(_) => Ok(()),
     }
 }
 

--- a/nom-sql/src/analysis/visit_mut.rs
+++ b/nom-sql/src/analysis/visit_mut.rs
@@ -875,7 +875,7 @@ pub fn walk_column_constraint<'a, V: VisitorMut<'a>>(
         | ColumnConstraint::AutoIncrement
         | ColumnConstraint::PrimaryKey
         | ColumnConstraint::Unique
-        | ColumnConstraint::OnUpdateCurrentTimestamp => Ok(()),
+        | ColumnConstraint::OnUpdateCurrentTimestamp(_) => Ok(()),
     }
 }
 

--- a/nom-sql/src/column.rs
+++ b/nom-sql/src/column.rs
@@ -88,7 +88,7 @@ pub enum ColumnConstraint {
     Unique,
     /// NOTE(grfn): Yes, this really is its own special thing, not just an expression - see
     /// <https://dev.mysql.com/doc/refman/8.0/en/timestamp-initialization.html>
-    OnUpdateCurrentTimestamp,
+    OnUpdateCurrentTimestamp(Option<Expr>),
 }
 
 impl ColumnConstraint {
@@ -102,7 +102,13 @@ impl ColumnConstraint {
             Self::AutoIncrement => write!(f, "AUTO_INCREMENT"),
             Self::PrimaryKey => write!(f, "PRIMARY KEY"),
             Self::Unique => write!(f, "UNIQUE"),
-            Self::OnUpdateCurrentTimestamp => write!(f, "ON UPDATE CURRENT_TIMESTAMP"),
+            Self::OnUpdateCurrentTimestamp(opt) => {
+                write!(f, "ON UPDATE CURRENT_TIMESTAMP")?;
+                if let Some(expr) = opt {
+                    write!(f, "({})", expr.display(dialect))?;
+                }
+                Ok(())
+            }
         })
     }
 }
@@ -181,19 +187,23 @@ fn default(
     }
 }
 
-pub fn on_update_current_timestamp(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], ColumnConstraint> {
-    let (i, _) = tag_no_case("on")(i)?;
-    let (i, _) = whitespace1(i)?;
-    let (i, _) = tag_no_case("update")(i)?;
-    let (i, _) = whitespace1(i)?;
-    let (i, _) = alt((
-        tag_no_case("current_timestamp"),
-        tag_no_case("now"),
-        tag_no_case("localtime"),
-        tag_no_case("localtimestamp"),
-    ))(i)?;
-    let (i, _) = opt(tag("()"))(i)?;
-    Ok((i, ColumnConstraint::OnUpdateCurrentTimestamp))
+pub fn on_update_current_timestamp(
+    dialect: Dialect,
+) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], ColumnConstraint> {
+    move |i| {
+        let (i, _) = tag_no_case("on")(i)?;
+        let (i, _) = whitespace1(i)?;
+        let (i, _) = tag_no_case("update")(i)?;
+        let (i, _) = whitespace1(i)?;
+        let (i, _) = alt((
+            tag_no_case("current_timestamp"),
+            tag_no_case("now"),
+            tag_no_case("localtime"),
+            tag_no_case("localtimestamp"),
+        ))(i)?;
+        let (i, expr) = opt(delimited(tag("("), expression(dialect), tag(")")))(i)?;
+        Ok((i, ColumnConstraint::OnUpdateCurrentTimestamp(expr)))
+    }
 }
 
 pub fn column_constraint(
@@ -254,7 +264,7 @@ pub fn column_constraint(
             unique,
             character_set,
             collate,
-            on_update_current_timestamp,
+            on_update_current_timestamp(dialect),
         ))(i)
     }
 }
@@ -357,6 +367,58 @@ mod tests {
                 cspec.constraints[0],
                 ColumnConstraint::DefaultValue(Expr::Literal(Literal::Boolean(true)))
             ));
+        }
+
+        #[test]
+        fn on_update_current_timestamp_no_precision() {
+            let input = b"`lastModified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP";
+            let (_, res) = column_specification(Dialect::MySQL)(LocatedSpan::new(input)).unwrap();
+            let cspec = ColumnSpecification {
+                column: Column {
+                    name: "lastModified".into(),
+                    table: None,
+                },
+                sql_type: SqlType::DateTime(Some(6)),
+                comment: None,
+                constraints: vec![
+                    ColumnConstraint::NotNull,
+                    ColumnConstraint::DefaultValue(Expr::Call(FunctionExpr::Call {
+                        name: "CURRENT_TIMESTAMP".into(),
+                        arguments: vec![Expr::Literal(Literal::UnsignedInteger(6))],
+                    })),
+                    ColumnConstraint::OnUpdateCurrentTimestamp(None),
+                ],
+            };
+            assert_eq!(res, cspec);
+            let res = cspec.display(Dialect::MySQL).to_string();
+            assert_eq!(res, String::from_utf8(input.to_vec()).unwrap());
+        }
+
+        #[test]
+        fn on_update_current_timestamp_precision() {
+            let input = b"`lastModified` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)";
+            let (_, res) = column_specification(Dialect::MySQL)(LocatedSpan::new(input)).unwrap();
+            let cspec = ColumnSpecification {
+                column: Column {
+                    name: "lastModified".into(),
+                    table: None,
+                },
+                sql_type: SqlType::DateTime(Some(6)),
+                comment: None,
+                constraints: vec![
+                    ColumnConstraint::NotNull,
+                    ColumnConstraint::DefaultValue(Expr::Call(FunctionExpr::Call {
+                        name: "CURRENT_TIMESTAMP".into(),
+                        arguments: vec![Expr::Literal(Literal::UnsignedInteger(6))],
+                    })),
+                    ColumnConstraint::OnUpdateCurrentTimestamp(Some(Expr::Literal(
+                        Literal::UnsignedInteger(6),
+                    ))),
+                ],
+            };
+            assert_eq!(res, cspec);
+            let res = cspec.display(Dialect::MySQL).to_string();
+            assert_eq!(res, String::from_utf8(input.to_vec()).unwrap());
         }
     }
 

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -800,7 +800,10 @@ mod tests {
     use crate::column::Column;
     use crate::create_table_options::{CharsetName, CollationName};
     use crate::table::Relation;
-    use crate::{BinaryOperator, ColumnConstraint, Expr, LimitClause, Literal, SqlType, TableExpr};
+    use crate::{
+        BinaryOperator, ColumnConstraint, Expr, FunctionExpr, LimitClause, Literal, SqlType,
+        TableExpr,
+    };
 
     #[test]
     fn field_spec() {
@@ -2453,5 +2456,39 @@ PRIMARY KEY (`id`));";
 
         let res = test_parse!(create_table(Dialect::MySQL), qstring);
         assert_eq!(res.table.name, "spree_zones");
+    }
+
+    #[test]
+    fn on_update_current_timestamp_precision() {
+        let qstring = b"CREATE TABLE foo (
+          `lastModified` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+        );";
+        let res = test_parse!(create_table(Dialect::MySQL), qstring);
+        assert_eq!(res.table.name, "foo");
+        assert_eq!(
+            res,
+            CreateTableStatement {
+                if_not_exists: false,
+                table: "foo".into(),
+                body: Ok(CreateTableBody {
+                    fields: vec![ColumnSpecification::with_constraints(
+                        "lastModified".into(),
+                        SqlType::DateTime(Some(6)),
+                        vec![
+                            ColumnConstraint::NotNull,
+                            ColumnConstraint::DefaultValue(Expr::Call(FunctionExpr::Call {
+                                name: "CURRENT_TIMESTAMP".into(),
+                                arguments: vec![Expr::Literal(Literal::UnsignedInteger(6,),),],
+                            },),),
+                            ColumnConstraint::OnUpdateCurrentTimestamp(Some(Expr::Literal(
+                                Literal::UnsignedInteger(6,),
+                            ),),),
+                        ],
+                    ),],
+                    keys: None,
+                }),
+                options: Ok(vec![]),
+            }
+        )
     }
 }

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -2480,9 +2480,9 @@ PRIMARY KEY (`id`));";
                                 name: "CURRENT_TIMESTAMP".into(),
                                 arguments: vec![Expr::Literal(Literal::UnsignedInteger(6,),),],
                             },),),
-                            ColumnConstraint::OnUpdateCurrentTimestamp(Some(Expr::Literal(
-                                Literal::UnsignedInteger(6,),
-                            ),),),
+                            ColumnConstraint::OnUpdateCurrentTimestamp(Some(
+                                Literal::UnsignedInteger(6)
+                            ),),
                         ],
                     ),],
                     keys: None,


### PR DESCRIPTION
Fixes https://github.com/readysettech/readyset/issues/56
