### PR TITLE
readyset-server: Forbid full materialization by default

### DIFF
--- a/readyset-server/src/builder.rs
+++ b/readyset-server/src/builder.rs
@@ -73,8 +73,8 @@ impl Builder {
         if opts.no_partial {
             builder.disable_partial();
         }
-        if opts.forbid_full_materialization {
-            builder.forbid_full_materialization();
+        if opts.allow_full_materialization {
+            builder.allow_full_materialization();
         }
         if opts.enable_packet_filters {
             builder.enable_packet_filters();
@@ -114,6 +114,7 @@ impl Builder {
     pub fn for_tests() -> Self {
         let mut builder = Self::default();
         builder.set_abort_on_task_failure(false);
+        builder.allow_full_materialization();
         builder
     }
 
@@ -139,14 +140,14 @@ impl Builder {
         self.config.materialization_config.frontier_strategy = f;
     }
 
-    /// Forbid the creation of all fully materialized nodes.
+    /// Allow the creation of all fully materialized nodes.
     ///
-    /// After this is called, any migrations that add fully materialized nodes will return
+    /// Unless this is called, any migrations that add fully materialized nodes will return
     /// [`ReadySetError::Unsupported`]
-    pub fn forbid_full_materialization(&mut self) {
+    pub fn allow_full_materialization(&mut self) {
         self.config
             .materialization_config
-            .allow_full_materialization = false;
+            .allow_full_materialization = true;
     }
 
     /// Set sharding policy for all subsequent migrations; `None` or `Some(x)` where x <= 1 disables

--- a/readyset-server/src/controller/migrate/materialization/mod.rs
+++ b/readyset-server/src/controller/migrate/materialization/mod.rs
@@ -95,7 +95,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             packet_filters_enabled: false,
-            allow_full_materialization: true,
+            allow_full_materialization: false,
             partial_enabled: true,
             frontier_strategy: FrontierStrategy::None,
         }

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -8462,7 +8462,6 @@ async fn forbid_full_materialization() {
         let mut builder = Builder::for_tests();
         builder.set_sharding(Some(DEFAULT_SHARDING));
         builder.set_persistence(get_persistence_params("forbid_full_materialization"));
-        builder.forbid_full_materialization();
         builder
             .start_local_custom(Arc::new(Authority::from(LocalAuthority::new_with_store(
                 Arc::new(LocalAuthorityStore::new()),

--- a/readyset-server/src/lib.rs
+++ b/readyset-server/src/lib.rs
@@ -574,9 +574,9 @@ pub struct WorkerOptions {
     #[clap(long = "nopartial", hide = true)]
     pub no_partial: bool,
 
-    /// Forbid the creation of fully materialized nodes
-    #[clap(long, env = "FORBID_FULL_MATERIALIZATION")]
-    pub forbid_full_materialization: bool,
+    /// Allow the creation of fully materialized nodes.
+    #[clap(long, env = "ALLOW_FULL_MATERIALIZATION")]
+    pub allow_full_materialization: bool,
 
     /// Enable packet filters in egresses before readers
     #[clap(long, hide = true)]


### PR DESCRIPTION
Until we can cleanly handle full materializations that exceed the
available system memory, make the default behavior be to forbid the
creation of full materializations.

Release-Note-Core: By default, ReadySet now does not support creating
  fully materialized nodes. There is a flag `--allow-full-materilization`
  that allows this behavior to be configured, which replaces the previous
  `--forbid-full-materialization` when this behavior was reversed. This
  default prevents issues when a full materialization would have needed
  to allocate more memory than the system has available.


----
<sub>[Gerrit Change (for ReadySet employees)](https://gerrit.readyset.name/c/readyset/+/5673)</sub>