### PR TITLE
sql: Add support for NOT IN with subqueries

### DIFF
--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -44,3 +44,10 @@ OR y = 2
 ----
 1
 2
+
+query I rowsort
+select y from t1
+where x not in (select x from t2)
+----
+2
+3

--- a/nom-sql/src/column.rs
+++ b/nom-sql/src/column.rs
@@ -23,6 +23,12 @@ pub struct Column {
     pub table: Option<Relation>,
 }
 
+impl From<SqlIdentifier> for Column {
+    fn from(name: SqlIdentifier) -> Self {
+        Column { name, table: None }
+    }
+}
+
 impl<'a> From<&'a str> for Column {
     fn from(c: &str) -> Column {
         match c.split_once('.') {


### PR DESCRIPTION
Add support for compiling NOT IN queries with subqueries, compiled
similarly to IN with subqueries, except that the join uses an "antijoin"
idiom - a LEFT JOIN followed by an IS NULL on a column projected on the
right-hand side.

Release-Note-Core: Add support for queries with a WHERE clause
  containing NOT IN with subqueries on the right-hand side
