### PR TITLE
sql: Support (NOT) IN in projected fields

### DIFF
--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -51,3 +51,20 @@ where x not in (select x from t2)
 ----
 2
 3
+
+query III rowsort
+select
+    y,
+    x in (select x from t2),
+    x not in (select x from t2)
+from t1
+----
+1
+1
+0
+2
+0
+1
+3
+0
+1


### PR DESCRIPTION
Support projecting IN and NOT IN in the results of a query, by compiling
a LEFT JOIN with a DISTINCT and a marker column on the rhs, followed by
an IS NULL expr for the result.

Release-Note-Core: Add support for queries with a IN and NOT IN
  expressions with subqueries on the right-hand side in the projected
  field list
