### PR TITLE
server: Add controller RPC for notifying about domain failure

### DIFF
--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -26,7 +26,7 @@ use url::Url;
 use crate::consensus::{Authority, AuthorityControl};
 use crate::debug::info::GraphInfo;
 use crate::debug::stats;
-use crate::internal::DomainIndex;
+use crate::internal::{DomainIndex, ReplicaAddress};
 use crate::metrics::MetricsDump;
 use crate::recipe::changelist::ChangeList;
 use crate::recipe::{ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
@@ -932,5 +932,13 @@ impl ReadySetHandle {
         action: String,
     ) -> impl Future<Output = ReadySetResult<()>> + '_ {
         self.rpc("failpoint", (name, action), self.request_timeout)
+    }
+
+    /// Notify the controller that a running domain replica has died
+    pub fn domain_died(
+        &mut self,
+        replica_address: ReplicaAddress,
+    ) -> impl Future<Output = ReadySetResult<()>> + '_ {
+        self.rpc("domain_died", replica_address, self.request_timeout)
     }
 }


### PR DESCRIPTION
Add a controller RPC that a worker can use to notify the controller that
only one of the domain replicas running on that worker has failed. This:

1. Removes the domain replica's worker assignment from the df state
2. Kills all downstream domains of that replica (without regard for
   replica index - which is fine for now since we only fan-out replicas
   at reader domains, but for efficiency's sake should be fixed to track
   replica fanout once we allow replicating internal and/or base
   domains)
3. Runs recovery (in the background!) to try to re-place the failed and
   killed domains.

That background recovery process uses a new, somewhat general mechanism
in the controller for notifying about background task failure - this
could hypothetically be reused elsewhere for more fallible
controller-related background tasks

Note that this whole thing is *quite* deadlock-prone without running the
entire process (most notably the acquisition of the dataflow state
handle's writer lock) in the background: since lots of things in the
controller hold on to the dataflow state handle's write lock while
blocking on requests to workers, we need to make sure that we're *never*
holding the dataflow state handle's writer lock while the worker is
waiting on a request *to the controller* (eg in the other direction).

Refs: REA-3186
