### PR TITLE
server: Remove conns for replicas that die

### DIFF
--- a/readyset-server/src/worker/replica.rs
+++ b/readyset-server/src/worker/replica.rs
@@ -21,9 +21,9 @@ use strawpoll::Strawpoll;
 use time::Duration;
 use tokio::io::{AsyncReadExt, BufReader, BufStream, BufWriter};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tokio_stream::wrappers::IntervalStream;
-use tracing::{debug, error, info_span, instrument, trace, warn, Span};
+use tracing::{debug, error, info, info_span, instrument, trace, warn, Span};
 
 use super::ChannelCoordinator;
 
@@ -257,7 +257,10 @@ impl Replica {
             }
 
             let tx = match connections.entry(replica_address) {
-                Occupied(entry) => entry.into_mut(),
+                Occupied(entry) => {
+                    trace!(%replica_address, "Reusing existing domain connection");
+                    entry.into_mut()
+                }
                 Vacant(entry) => {
                     let Some(addr) = coord.get_addr(&replica_address) else {
                         trace!(
@@ -277,6 +280,7 @@ impl Replica {
                         continue;
                     }
 
+                    debug!(%replica_address, %addr, "Establishing connection to domain");
                     entry.insert(coord.builder_for(&replica_address)?.build_async()?)
                 }
             };
@@ -349,6 +353,8 @@ impl Replica {
             init_state_reqs,
         } = &mut self;
 
+        let mut channel_changes = coord.subscribe();
+
         loop {
             // we have three logical input sources: receives from local domains, receives from
             // remote domains, and remote mutators.
@@ -372,6 +378,33 @@ impl Replica {
 
                     connections.insert(token, tcp);
                 },
+
+                // Handle changes to the addresses of individual domain replicas
+                replica_addr = channel_changes.recv() => {
+                    match replica_addr {
+                        Ok(replica_addr) => {
+                            // We've received a notification that the socket address for a replica
+                            // has changed - remove its cached connection from `outputs` so that
+                            // when we try to send to it later we re-lookup the addr and reconnect
+                            if outputs.lock().await.remove(&replica_addr).is_some() {
+                                info!(%replica_addr, "Removed connection for replica");
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            // If we've lagged behind, that means we've missed some changes to
+                            // replica addresses, so we need to consider all connections invalid
+                            warn!(
+                                %skipped,
+                                "Coordinator change broadcast receiver lagged behind; reconnecting \
+                                to all replicas"
+                            );
+                            outputs.lock().await.clear();
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            panic!("ChannelCoordinator dropped!");
+                        }
+                    }
+                }
 
                 // Handle domain requests
                 domain_req = requests.recv() => match domain_req {


### PR DESCRIPTION
Within a running Replica, we maintain a map of established connections
for other domain replicas, to avoid having to re-establish a connection
on every message. If one of those replicas *died*, however, we'd never
remove the established connection from that map, meaning we'd never be
able to send messages to it if it ever came back.

Now, the `ChannelCoordinator` has a `tokio::sync::broadcast` channel
which can notify interested subscribers when the socket address for a
ReplicaAddress is changed - we subscribe to this in the Replica's
select-loop to remove the entry from that map of connections when we're
removing the configured socket from the channel coordinator.

This fixes an issue where after a worker died and came back, it'd never
be able to receive domain messages (such as full replay packets!).

This reverts commit 922f5028f2f75cc969805ec73033ceaf0f54320d.

Note that there is a *significant* performance issue here for large
deployments - there empirically seems to be a roughly quadratic slowdown
in `tokio::sync::broadcast::Sender::send` as the number of active
receivers increases - I've seen `send` take *minutes* when there are
more than like 100 receivers. We're band-aid-ing this issue (which is
why 922f5028f (Revert "server: Remove conns for replicas that die",
2023-08-03) happened in the first place) by avoiding sending anything on
the channel unless we *definitely* have to - but we ought to fix this at
some point in the future (it might be a tokio bug - I've reported it as
https://github.com/tokio-rs/tokio/issues/5923 and we'll see how that
goes).

