### PR TITLE
domain: Make tags in `ReplayPaths::by_dst` a HashSet

### DIFF
--- a/logictests/shared_ingress.test
+++ b/logictests/shared_ingress.test
@@ -1,0 +1,86 @@
+statement ok
+CREATE TABLE articles (
+  id int(11) NOT NULL PRIMARY KEY,
+  title text
+) ;
+
+statement ok
+insert into articles (id, title)
+values
+(1, 'a'),
+(2, 'b'),
+(3, 'c'),
+(4, 'd'),
+(5, 'e');
+
+statement ok
+CREATE TABLE recommendations (
+  user_id int(11) NOT NULL,
+  article_id int(11) NOT NULL
+);
+
+statement ok
+insert into recommendations
+(user_id, article_id)
+values
+(1, 1),
+(1, 2),
+(1, 5),
+(2, 1),
+(2, 3),
+(2, 4),
+(3, 3),
+(3, 4),
+(3, 5);
+
+onlyif readyset
+statement ok
+create cache from
+select A.id, A.title
+FROM articles A, recommendations R
+WHERE A.id = R.article_id AND R.user_id BETWEEN ? AND ?
+ORDER BY A.title, A.id LIMIT 20
+
+onlyif readyset
+statement ok
+create cache from
+SELECT A.id
+FROM articles A, recommendations R
+WHERE A.id = R.article_id AND R.user_id BETWEEN ? AND ?
+ORDER BY A.title, A.id LIMIT 20
+
+query IT rowsort
+select A.id, A.title
+FROM articles A, recommendations R
+WHERE A.id = R.article_id AND R.user_id BETWEEN ? AND ?
+ORDER BY A.title, A.id LIMIT 20
+? = 1
+? = 2
+----
+1
+a
+1
+a
+2
+b
+3
+c
+4
+d
+5
+e
+
+query I nosort
+SELECT A.id
+FROM articles A, recommendations R
+WHERE A.id = R.article_id AND R.user_id BETWEEN ? AND ?
+ORDER BY A.title, A.id LIMIT 20
+? = 1
+? = 2
+----
+1
+1
+2
+3
+4
+5

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -2892,6 +2892,11 @@ impl Domain {
                                 key: k.clone(),
                             })
                         });
+                    } else if !self.reader_triggered.contains_key(dst) {
+                        internal!(
+                            "Received replay targeted at node {dst} that is not waiting for any \
+                             replays"
+                        );
                     }
 
                     if let Some(prev) = self.reader_triggered.get(dst) {
@@ -3419,9 +3424,8 @@ impl Domain {
 
                                         // TODO: could there have been multiple
                                         invariant_eq!(tags.len(), 1);
-                                        #[allow(clippy::indexing_slicing)]
-                                        // we check len is 1 first
-                                        evict_tags.push(tags[0]);
+                                        #[allow(clippy::unwrap_used)] // we check len is 1 first
+                                        evict_tags.push(*tags.iter().next().unwrap());
                                     }
                                 }
                             }


### PR DESCRIPTION
Now that as of e6f42f252 (server: Always add indexes during recovery,
2023-07-26) we're always adding indexes when planning out replay paths,
we can end up in a place where the message to setup a replay path in a
particular node gets sent more than once, eg if an ingress node is
shared by multiple downstream nodes. This is *mostly* fine, except that
due to the way the data structures work calling `ReplayPaths::insert`
wasn't properly idempotent if the same replay path was inserted more
than once. Having the same tag in this map multiple times would then
cause the same key to be replayed multiple times across the same replay
path, even though it had only been inserted into `self.waiting` once.
The first replay would then remove from `self.waiting`, causing the
second replay to *not* have its keys filtered out (since we don't do any
restricting of `for_keys` if nothing has been found in `self.waiting`
for the node). Then, when actually going to fill the holes for that
second replay, we'd (correcly!) panic in single_state due to trying to
fill an already-filled hole.

This commit fixes this by changing the deepest key type in
`ReplayPaths::by_dst` into a `HashSet` from a `Vec`, effectively making
`ReplayPaths::insert` idempotent. To avoid even getting to the place
where we try to fill an already-filled key, we also fail earlier with an
`internal` error if we get a replay piece targeting a node that is not
waiting for any keys at all.

This was found by system-benchmarks, but this commit covers it with a
logictest with two queries that setup nodes that share the same ingress,
which reproduced the original bug before the change to use a HashSet.

Fixes: REA-3261
