### PR TITLE
clustertests: Add test covering domain panic handling

### DIFF
--- a/readyset-clustertest/src/readyset_postgres.rs
+++ b/readyset-clustertest/src/readyset_postgres.rs
@@ -228,3 +228,120 @@ async fn embedded_readers_adapters_lt_replicas() {
 
     deployment.teardown().await.unwrap();
 }
+
+/// Test that a (partial or full) reader domain panicking in a deployment eventually recovers
+#[clustertest]
+async fn reader_domain_panic_handling() {
+    let deployment_name = "reader_domain_panic_handling";
+    let mut deployment = DeploymentBuilder::new(DatabaseType::PostgreSQL, deployment_name)
+        .deploy_upstream()
+        .reader_replicas(1)
+        .with_adapters(1)
+        .with_servers(1, ServerParams::default().no_readers())
+        .embedded_readers(true)
+        .allow_full_materialization()
+        .start()
+        .await
+        .unwrap();
+
+    let mut adapter = deployment.first_adapter().await;
+
+    adapter.query_drop("CREATE TABLE t (x int);").await.unwrap();
+    adapter
+        .query_drop("INSERT INTO t (x) VALUES (1);")
+        .await
+        .unwrap();
+
+    // 1. full readers
+
+    eventually! {
+        adapter
+            .query_drop("CREATE CACHE FROM SELECT x FROM t;")
+            .await
+            .is_ok()
+    }
+
+    eventually! {
+        run_test: {
+            let res: Vec<Vec<DfValue>> = adapter
+                .query("SELECT x FROM t")
+                .await
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let dest = last_statement_destination(&mut adapter).await;
+            (res, dest)
+        },
+        then_assert: |(res, dest)| {
+            assert_eq!(dest, QueryDestination::Readyset);
+            assert_eq!(res, vec![vec![1.into()]]);
+        }
+    }
+
+    // Force the reader domain to panic *once* by setting a failpoint then sending it a write
+    deployment
+        .adapter_handle(0)
+        .unwrap()
+        .set_failpoint("handle-packet", "1*panic->off")
+        .await;
+
+    adapter
+        .query_drop("INSERT INTO t (x) VALUES (1);")
+        .await
+        .unwrap();
+
+    eventually! {
+        run_test: {
+            let res: Vec<Vec<DfValue>> = adapter
+                .query("SELECT x FROM t")
+                .await
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let dest = last_statement_destination(&mut adapter).await;
+            (res, dest)
+        },
+        then_assert: |(res, dest)| {
+            assert_eq!(dest, QueryDestination::Readyset);
+            assert_eq!(res, vec![vec![1.into()], vec![1.into()]]);
+        }
+    }
+
+    // 2. partial readers
+
+    adapter
+        .query_drop("CREATE CACHE FROM SELECT count(*) FROM t where x = ?;")
+        .await
+        .unwrap();
+
+    // Force the reader domain to panic *once* by setting a failpoint then sending a replay request
+    deployment
+        .adapter_handle(0)
+        .unwrap()
+        .set_failpoint("handle-packet", "1*panic->off")
+        .await;
+
+    adapter
+        .query_drop("select count(*) from t where x = 1")
+        .await
+        .unwrap();
+
+    eventually! {
+        run_test: {
+            let res: Vec<Vec<DfValue>> = adapter
+                .execute(&"select count(*) from t where x = $1", &[DfValue::from(1i32)])
+                .await
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let dest = last_statement_destination(&mut adapter).await;
+            (res, dest)
+        },
+        then_assert: |(res, dest)| {
+            assert_eq!(dest, QueryDestination::Readyset);
+            assert_eq!(res, vec![vec![2.into()]]);
+        }
+    }
+
+    deployment.teardown().await.unwrap();
+}


### PR DESCRIPTION
Add a clustertest testing that if a (reader, for now) domain panics, we
eventually recover and can serve the query from ReadySet. This covers
both fully and partially materialized queries.

Fixes: REA-3341
