### PR TITLE
errors: Attempt to unravel the tokio_tower::Error tangle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,6 +4651,7 @@ dependencies = [
  "deadpool-postgres",
  "derive_more",
  "failpoint-macros",
+ "futures",
  "hyper",
  "mysql_async",
  "nom-sql",
@@ -4663,6 +4664,7 @@ dependencies = [
  "tikv-jemalloc-ctl",
  "tokio-native-tls",
  "tokio-postgres",
+ "tokio-tower",
  "url",
  "vec1",
 ]

--- a/readyset-client/src/table.rs
+++ b/readyset-client/src/table.rs
@@ -496,9 +496,13 @@ impl Table {
                 let request = Tagged::from(i);
                 let _guard = span.as_ref().map(Span::enter);
                 trace!("submit request");
-                future::Either::Left(future::Either::Right(
-                    table_rpc.call(request).map_err(rpc_err!("Table::input")),
-                ))
+                future::Either::Left(future::Either::Right(table_rpc.call(request).map_err(
+                    rpc_err!(
+                        "Table::input",
+                        multiplex::MultiplexTransport<Transport, Tagger>,
+                        Tagged<PacketData>,
+                    ),
+                )))
             }
             _ => {
                 let key_len = self.key.len();
@@ -583,7 +587,11 @@ impl Table {
                 future::Either::Right(
                     wait_for
                         .try_for_each(|_| async { Ok(()) })
-                        .map_err(rpc_err!("Table::input"))
+                        .map_err(rpc_err!(
+                            "Table::input",
+                            multiplex::MultiplexTransport<Transport, Tagger>,
+                            Tagged<PacketData>,
+                        ))
                         .map_ok(Tagged::from),
                 )
             }
@@ -600,11 +608,11 @@ impl Table {
         match self.shards.first_mut() {
             Some(table_rpc) if nshards == 1 => {
                 let request = Tagged::from(t);
-                future::Either::Left(
-                    table_rpc
-                        .call(request)
-                        .map_err(rpc_err!("Table::timestamp")),
-                )
+                future::Either::Left(table_rpc.call(request).map_err(rpc_err!(
+                    "Table::timestamp",
+                    multiplex::MultiplexTransport<Transport, Tagger>,
+                    Tagged<PacketData>,
+                )))
             }
             _ => {
                 if self.key.is_empty() {
@@ -628,7 +636,11 @@ impl Table {
                 future::Either::Right(future::Either::Right(
                     wait_for
                         .try_for_each(|_| async { Ok(()) })
-                        .map_err(rpc_err!("Table::timestamp"))
+                        .map_err(rpc_err!(
+                            "Table::timestamp",
+                            multiplex::MultiplexTransport<Transport, Tagger>,
+                            Tagged<PacketData>,
+                        ))
                         .map_ok(Tagged::from),
                 ))
             }

--- a/readyset-client/src/view.rs
+++ b/readyset-client/src/view.rs
@@ -1222,7 +1222,11 @@ impl Service<ViewQuery> for ReaderHandle {
                 self.shards
                     .first_mut()
                     .call(request)
-                    .map_err(rpc_err!("<View as Service<ViewQuery>>::call"))
+                    .map_err(rpc_err!(
+                        "<View as Service<ViewQuery>>::call",
+                        multiplex::MultiplexTransport<Transport, Tagger>,
+                        Instrumented<Tagged<ReadQuery>>,
+                    ))
                     .and_then(move |reply| {
                         let future = async move {
                             reply

--- a/readyset-clustertest/src/readyset_postgres.rs
+++ b/readyset-clustertest/src/readyset_postgres.rs
@@ -228,3 +228,120 @@ async fn embedded_readers_adapters_lt_replicas() {
 
     deployment.teardown().await.unwrap();
 }
+
+/// Test that a (partial or full) reader domain panicking in a deployment eventually recovers
+#[clustertest]
+async fn reader_domain_panic_handling() {
+    let deployment_name = "reader_domain_panic_handling";
+    let mut deployment = DeploymentBuilder::new(DatabaseType::PostgreSQL, deployment_name)
+        .deploy_upstream()
+        .reader_replicas(1)
+        .with_adapters(1)
+        .with_servers(1, ServerParams::default().no_readers())
+        .embedded_readers(true)
+        .allow_full_materialization()
+        .start()
+        .await
+        .unwrap();
+
+    let mut adapter = deployment.first_adapter().await;
+
+    adapter.query_drop("CREATE TABLE t (x int);").await.unwrap();
+    adapter
+        .query_drop("INSERT INTO t (x) VALUES (1);")
+        .await
+        .unwrap();
+
+    // 1. full readers
+
+    eventually! {
+        adapter
+            .query_drop("CREATE CACHE FROM SELECT x FROM t;")
+            .await
+            .is_ok()
+    }
+
+    eventually! {
+        run_test: {
+            let res: Vec<Vec<DfValue>> = adapter
+                .query("SELECT x FROM t")
+                .await
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let dest = last_statement_destination(&mut adapter).await;
+            (res, dest)
+        },
+        then_assert: |(res, dest)| {
+            assert_eq!(dest, QueryDestination::Readyset);
+            assert_eq!(res, vec![vec![1.into()]]);
+        }
+    }
+
+    // Force the reader domain to panic *once* by setting a failpoint then sending it a write
+    deployment
+        .adapter_handle(0)
+        .unwrap()
+        .set_failpoint("handle-packet", "1*panic->off")
+        .await;
+
+    adapter
+        .query_drop("INSERT INTO t (x) VALUES (1);")
+        .await
+        .unwrap();
+
+    eventually! {
+        run_test: {
+            let res: Vec<Vec<DfValue>> = adapter
+                .query("SELECT x FROM t")
+                .await
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let dest = last_statement_destination(&mut adapter).await;
+            (res, dest)
+        },
+        then_assert: |(res, dest)| {
+            assert_eq!(dest, QueryDestination::Readyset);
+            assert_eq!(res, vec![vec![1.into()], vec![1.into()]]);
+        }
+    }
+
+    // 2. partial readers
+
+    adapter
+        .query_drop("CREATE CACHE FROM SELECT count(*) FROM t where x = ?;")
+        .await
+        .unwrap();
+
+    // Force the reader domain to panic *once* by setting a failpoint then sending a replay request
+    deployment
+        .adapter_handle(0)
+        .unwrap()
+        .set_failpoint("handle-packet", "1*panic->off")
+        .await;
+
+    adapter
+        .query_drop("select count(*) from t where x = 1")
+        .await
+        .unwrap();
+
+    eventually! {
+        run_test: {
+            let res: Vec<Vec<DfValue>> = adapter
+                .execute(&"select count(*) from t where x = $1", &[DfValue::from(1i32)])
+                .await
+                .unwrap()
+                .try_into()
+                .unwrap();
+            let dest = last_statement_destination(&mut adapter).await;
+            (res, dest)
+        },
+        then_assert: |(res, dest)| {
+            assert_eq!(dest, QueryDestination::Readyset);
+            assert_eq!(res, vec![vec![2.into()]]);
+        }
+    }
+
+    deployment.teardown().await.unwrap();
+}

--- a/readyset-errors/Cargo.toml
+++ b/readyset-errors/Cargo.toml
@@ -8,12 +8,14 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 consulrs = { workspace = true }
+futures = "0.3"
 hyper = "0.14.10"
 thiserror = "1.0.26"
 mysql_async = { workspace = true }
 tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-eui48-1", "with-uuid-0_8", "with-serde_json-1", "with-bit-vec-0_6"] }
 petgraph = { version = "0.5", features = ["serde-1"] }
 rmp-serde = "1.0.0"
+tokio-tower = "0.5.1"
 url = { version = "2.2", features = ["serde"] }
 serde_json = { version = "1.0.2", features = ["arbitrary_precision"] }
 derive_more = "0.99.11"

--- a/readyset-errors/src/rpc.rs
+++ b/readyset-errors/src/rpc.rs
@@ -1,0 +1,115 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::{Sink, Stream, TryStream};
+
+use crate::{internal_err, ReadySetError};
+
+/// A type that implements [`Sink`] and [`TryStream`] for use as a placeholder associated type for
+/// [`tokio_tower::Error`]'s type parameters when we aren't trying to downcast to a
+/// [`tokio_tower::Error`] during calls to `rpc_err`
+pub struct NullSink;
+
+impl<I> Sink<I> for NullSink {
+    type Error = !;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+
+    fn start_send(self: Pin<&mut Self>, _item: I) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+}
+
+impl Stream for NullSink {
+    type Item = Result<(), !>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+}
+
+/// Make a new [`ReadySetError::RpcFailed`] with the provided string-able `during` value
+/// and the provided `err` as cause.
+///
+/// This attempts to downcast the `err` into a `Box<ReadySetError>`. If the downcasting
+/// fails, the error is formatted as a [`ReadySetError::Internal`].
+pub fn rpc_err<T, S, I>(during: T, err: Box<dyn std::error::Error>) -> ReadySetError
+where
+    T: Into<String>,
+    S: Sink<I> + TryStream + 'static,
+    <S as Sink<I>>::Error: std::error::Error,
+    <S as TryStream>::Error: std::error::Error,
+    I: 'static,
+{
+    let source = if let Some(err) = err.downcast_ref::<tokio_tower::Error<S, I>>() {
+        Box::new(err.into())
+    } else {
+        err.downcast::<ReadySetError>()
+            .unwrap_or_else(|e| Box::new(internal_err!("{e}")))
+    };
+    ReadySetError::RpcFailed {
+        during: during.into(),
+        source,
+    }
+}
+
+impl<S, I> From<&tokio_tower::Error<S, I>> for ReadySetError
+where
+    S: Sink<I> + TryStream + 'static,
+    <S as Sink<I>>::Error: std::error::Error,
+    <S as TryStream>::Error: std::error::Error,
+    I: 'static,
+{
+    fn from(err: &tokio_tower::Error<S, I>) -> Self {
+        match err {
+            tokio_tower::Error::TransportFull => ReadySetError::TransportFull,
+            tokio_tower::Error::ClientDropped => ReadySetError::ClientDropped,
+            tokio_tower::Error::Desynchronized => ReadySetError::Desynchronized,
+            tokio_tower::Error::BrokenTransportSend(e) => {
+                ReadySetError::TransportSendFailed(e.to_string())
+            }
+            tokio_tower::Error::BrokenTransportRecv(_) => ReadySetError::TransportRecvFailed,
+        }
+    }
+}
+
+/// Generates a closure, suitable as an argument to `.map_err()`, that maps the provided error
+/// argument into a [`ReadySetError::RpcFailed`] with the given `during` argument (anything
+/// that implements `Display`).
+///
+/// Optionally, the transport and request type parameters for [`tokio_tower::Error`] can be given,
+/// to attempt downcasting to that error type for more detailed error values.
+///
+/// When building in debug mode, the `during` argument generated also captures file, line, and
+/// column information for further debugging purposes.
+///
+/// # Example
+///
+/// ```ignore
+/// let rpc_result = do_rpc_call()
+///     .map_err(rpc_err!("do_rpc_call"));
+/// ```
+#[macro_export]
+macro_rules! rpc_err {
+    ($during:expr) => {
+        rpc_err!($during, $crate::rpc::NullSink, ())
+    };
+    ($during:expr, $s: ty, $i: ty $(,)?) => {
+        |e| {
+            $crate::rpc::rpc_err::<_, $s, $i>(
+                format!("{}{}", $during, $crate::__location_info!()),
+                e,
+            )
+        }
+    };
+}


### PR DESCRIPTION
This commit makes a first attempt at trying to get actual useful errors
by downcasting rpc errors. I did a fair bit of poking around, and it
looks like the primary underlying error type we get if eg the server
side of something like a table rpc is dropped (for example, because the
domain has died) is a `tokio_tower::Error`. Downcasting to this to get
any actual useful data out of it is *remarkably* annoying since there
are a couple of associated types that it uses that're the actual
underlying stream/sink and request types for the transport, which took a
little finagling to get out (and pass to the rpc_err downcasting
function). That all works here (though this is tough to test
automatically).

To keep things clean and separated, I've also broken the `rpc_err`
stuff, including a placeholder sink type to pass in in the case where we
*don't* care about trying to downcast to a tokio_tower::Error.

