### PR TITLE
readyset-errors: Consider tokio-tower errors networking

### DIFF
--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -796,6 +796,11 @@ impl ReadySetError {
             matches!(
                 e,
                 Self::RpcFailed { .. }
+                    | Self::ClientDropped
+                    | Self::TransportFull
+                    | Self::Desynchronized
+                    | Self::TransportSendFailed(..)
+                    | Self::TransportRecvFailed
                     | Self::IOError(..)
                     | Self::TcpSendError(..)
                     | Self::ServiceUnavailable


### PR DESCRIPTION
Consider tokio-tower errors as "networking related", so that things
which behave differently (eg with regards to retries) on
networking-related errors do so for those errors.

