### PR TITLE
replicators: Don't deny replication on networking errors

### DIFF
--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -967,6 +967,10 @@ impl NoriaAdapter {
                 // In some cases, we may fail to replicate because of unsupported operations, stop
                 // replicating a table if we encounter this type of error.
                 Err(ReadySetError::TableError { table, source }) => {
+                    if source.is_networking_related() {
+                        // Don't deny replication of the error is caused by networking
+                        return Err(ReadySetError::TableError { table, source });
+                    }
                     self.deny_replication_for_table(table, source).await?;
                     continue;
                 }


### PR DESCRIPTION
An RPC to write some data to a table failing for networking reasons
isn't cause for us to consider that table completely and irreperably
broken - instead, we should just fail using the normal means and restart
the replicator later

Fixes: REA-3186
