### PR TITLE
client: Allow making controller handle from raw URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,6 +4651,7 @@ dependencies = [
  "deadpool-postgres",
  "derive_more",
  "failpoint-macros",
+ "hyper",
  "mysql_async",
  "nom-sql",
  "petgraph",

--- a/readyset-errors/Cargo.toml
+++ b/readyset-errors/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 consulrs = { workspace = true }
+hyper = "0.14.10"
 thiserror = "1.0.26"
 mysql_async = { workspace = true }
 tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-eui48-1", "with-uuid-0_8", "with-serde_json-1", "with-bit-vec-0_6"] }

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -310,6 +310,10 @@ pub enum ReadySetError {
     #[error("Internal error: {0}")]
     Internal(String),
 
+    /// An error has occurred during an HTTP request
+    #[error("{0}")]
+    HttpError(String),
+
     /// The user fed ReadySet bad input (and there's no more specific error).
     #[error("Bad request: {0}")]
     BadRequest(String),
@@ -1144,6 +1148,7 @@ impl_from_to_string!(io::Error, IOError);
 impl_from_to_string!(tikv_jemalloc_ctl::Error, JemallocCtlError);
 impl_from_to_string!(consulrs::error::ClientError, ConsulError);
 impl_from_to_string!(tokio_native_tls::native_tls::Error, NativeTlsError);
+impl_from_to_string!(hyper::Error, HttpError);
 
 impl From<Size0Error> for ReadySetError {
     fn from(_: Size0Error) -> Self {


### PR DESCRIPTION
Sometimes instead of having an authority handle, we have access to the
raw URL of the controller itself. This is currently the case inside the
Worker, which gets notified *proactively* about changes to the URL of
the controller. We'd like to be able to make *requests* to the
controller in this case using the same mechanism and wrapper methods we
use to make requests to the controller via the ReadySetHandle.

To that end, this commit introduces some new functionality to the
readyset_client::controller module: First, a RawController struct, which
wraps the controller Url and some extra state and config and impls
Service<ControllerRequest> in the same way Controller does albeit
without the retry logic used to re-look-up the controller's URL (using a
factored-out `controller_request` function which performs the actual
logic for both). Then, the inner service inside of ReadySetHandle is
replaced with a `tower::util::Either` of Controller and RawController,
and a new `make_raw` constructor method is added, so that we can have a
"raw" version of the ControllerHandle which can be constructed from only
a URL and used to make the same set of controller requests.

