### PR TITLE
clustertest: Use the right conn_str for newly added adapters

### DIFF
--- a/readyset-clustertest/src/lib.rs
+++ b/readyset-clustertest/src/lib.rs
@@ -1330,7 +1330,7 @@ impl DeploymentHandle {
 
         self.adapters.push(AdapterHandle {
             metrics_port,
-            conn_str: format!("mysql://127.0.0.1:{}", port),
+            conn_str: format!("{}://127.0.0.1:{}/{}", database_type, port, &self.name),
             process,
         });
 

--- a/readyset-clustertest/src/readyset.rs
+++ b/readyset-clustertest/src/readyset.rs
@@ -495,16 +495,17 @@ async fn server_auto_restarts() {
 async fn assert_deployment_health(mut dh: DeploymentHandle) {
     let mut adapter = dh.first_adapter().await;
     adapter
-        .query_drop(
-            r"CREATE TABLE t1 (
-        uid INT NOT NULL,
-        value INT NOT NULL
-    );",
-        )
+        .query_drop(format!(
+            r"CREATE TABLE {}.t1 (
+                uid INT NOT NULL,
+                value INT NOT NULL
+            );",
+            dh.name()
+        ))
         .await
         .unwrap();
     adapter
-        .query_drop(r"INSERT INTO t1 VALUES (1, 4);")
+        .query_drop(format!(r"INSERT INTO {}.t1 VALUES (1, 4);", dh.name()))
         .await
         .unwrap();
 


### PR DESCRIPTION
Use the correct connection string - with the right database type and
database name - for new adapters added with
DeploymentHandle::start_adapter, rather than hardcoding the mysql
connection string with the port of the adapter.

To work around REA-2787, this also db-qualifies table references in one
clustertest so that we can find tables to insert into.

Refs: REA-3356
