### PR TITLE
clustertest: Add a test for adding a new adapter to a deployment

### DIFF
--- a/readyset-clustertest/src/lib.rs
+++ b/readyset-clustertest/src/lib.rs
@@ -1330,7 +1330,7 @@ impl DeploymentHandle {
 
         self.adapters.push(AdapterHandle {
             metrics_port,
-            conn_str: format!("mysql://127.0.0.1:{}", port),
+            conn_str: format!("{}://127.0.0.1:{}/{}", database_type, port, &self.name),
             process,
         });
 

--- a/readyset-clustertest/src/readyset.rs
+++ b/readyset-clustertest/src/readyset.rs
@@ -495,16 +495,17 @@ async fn server_auto_restarts() {
 async fn assert_deployment_health(mut dh: DeploymentHandle) {
     let mut adapter = dh.first_adapter().await;
     adapter
-        .query_drop(
-            r"CREATE TABLE t1 (
-        uid INT NOT NULL,
-        value INT NOT NULL
-    );",
-        )
+        .query_drop(format!(
+            r"CREATE TABLE {}.t1 (
+                uid INT NOT NULL,
+                value INT NOT NULL
+            );",
+            dh.name()
+        ))
         .await
         .unwrap();
     adapter
-        .query_drop(r"INSERT INTO t1 VALUES (1, 4);")
+        .query_drop(format!(r"INSERT INTO {}.t1 VALUES (1, 4);", dh.name()))
         .await
         .unwrap();
 


### PR DESCRIPTION
Add a step to the `embedded_readers_adapters_lt_replicas` test to spin
up a second adapter and check that it joins the cluster, starts
healthily serving cached results, and receives writes from the server.

Fixes: REA-3356
