### PR TITLE
dataflow-state: Add stateful proptest for weak indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ version = "0.0.1"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
+ "async-trait",
  "bincode",
  "clap 4.3.2",
  "criterion",
@@ -1235,6 +1236,7 @@ dependencies = [
  "partial-map",
  "pretty_assertions",
  "proptest",
+ "proptest-stateful",
  "rand 0.7.3",
  "readyset-alloc",
  "readyset-client",

--- a/dataflow-state/Cargo.toml
+++ b/dataflow-state/Cargo.toml
@@ -39,6 +39,8 @@ partial-map = { path = "../partial-map" }
 replication-offset = { path = "../replication-offset" }
 
 [dev-dependencies]
+proptest-stateful = { path = "../proptest-stateful" }
+async-trait = "0.1"
 pretty_assertions = "0.7.2"
 lazy_static = "1.0.0"
 criterion = { version = "0.3", features=['real_blackbox', 'async_tokio'] }

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -119,14 +119,14 @@ impl State for MemoryState {
                 // we need to check that we're not erroneously filling any holes
                 // there are two cases here:
                 //
-                //  - if the incoming record is a partial replay (i.e., partial.is_some()), then we
-                //    *know* that we are the target of the replay, and therefore we *know* that the
-                //    materialization must already have marked the given key as "not a hole".
-                //  - if the incoming record is a normal message (i.e., partial.is_none()), then we
-                //    need to be careful. since this materialization is partial, it may be that we
-                //    haven't yet replayed this `r`'s key, in which case we shouldn't forward that
-                //    record! if all of our indices have holes for this record, there's no need for
-                //    us to forward it. it would just be wasted work.
+                //  - if the incoming record is a partial replay (i.e., partial_tag.is_some()), then
+                //    we *know* that we are the target of the replay, and therefore we *know* that
+                //    the materialization must already have marked the given key as "not a hole".
+                //  - if the incoming record is a normal message (i.e., partial_tag.is_none()), then
+                //    we need to be careful. since this materialization is partial, it may be that
+                //    we haven't yet replayed this `r`'s key, in which case we shouldn't forward
+                //    that record! if all of our indices have holes for this record, there's no need
+                //    for us to forward it. it would just be wasted work.
                 //
                 //    XXX: we could potentially save come computation here in joins by not forcing
                 //    `right` to backfill the lookup key only to then throw the record away

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -396,8 +396,8 @@ impl State for MemoryState {
     }
 
     fn add_weak_key(&mut self, index: Index) {
-        let state = KeyedState::from(&index);
-        self.weak_indices.insert(index.columns, state);
+        let weak_index = KeyedState::from(&index);
+        self.weak_indices.insert(index.columns, weak_index);
     }
 
     fn lookup_weak<'a>(&'a self, columns: &[usize], key: &PointKey) -> Option<RecordResult<'a>> {


### PR DESCRIPTION
This isn't quite complete yet, but it was surprisingly easy and
straightforward to write, and runs extremely quickly. The ultimate goal
is to test that the contents of weak indexes are correct, but for now
I've gotten the test to run through creating strict indexes and
inserting and removing rows without crashing, so I'm committing here as
a checkpoint.

