### PR TITLE
dataflow-state: Add proptest op to create weak indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ version = "0.0.1"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
+ "async-trait",
  "bincode",
  "clap 4.3.2",
  "criterion",
@@ -1235,6 +1236,7 @@ dependencies = [
  "partial-map",
  "pretty_assertions",
  "proptest",
+ "proptest-stateful",
  "rand 0.7.3",
  "readyset-alloc",
  "readyset-client",

--- a/dataflow-state/Cargo.toml
+++ b/dataflow-state/Cargo.toml
@@ -39,6 +39,8 @@ partial-map = { path = "../partial-map" }
 replication-offset = { path = "../replication-offset" }
 
 [dev-dependencies]
+proptest-stateful = { path = "../proptest-stateful" }
+async-trait = "0.1"
 pretty_assertions = "0.7.2"
 lazy_static = "1.0.0"
 criterion = { version = "0.3", features=['real_blackbox', 'async_tokio'] }

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -1014,7 +1014,6 @@ mod tests {
             #[allow(unused)]
             ReplayKey(Tag, TestRow),
             CreateStrictIndex(Vec<usize>, Tag),
-            #[allow(unused)]
             CreateWeakIndex(Vec<usize>),
         }
 
@@ -1022,7 +1021,6 @@ mod tests {
         struct IndexModelState {
             rows: Vec<TestRow>,
             strict_indexes: BTreeMap<Tag, Vec<usize>>,
-            #[allow(unused)]
             weak_indexes: Vec<Vec<usize>>,
         }
 
@@ -1083,9 +1081,9 @@ mod tests {
 
                 let insert_row_strat = gen_insert_row().boxed();
                 let create_strict_strat = gen_create_strict(self.next_tag()).boxed();
-                //let create_weak_strat = gen_create_weak().boxed();
+                let create_weak_strat = gen_create_weak().boxed();
 
-                let mut ops = vec![insert_row_strat, create_strict_strat];
+                let mut ops = vec![insert_row_strat, create_strict_strat, create_weak_strat];
 
                 if !self.rows.is_empty() {
                     let delete_row_strat = gen_delete_row(self.rows.clone()).boxed();
@@ -1117,6 +1115,9 @@ mod tests {
                     Operation::CreateStrictIndex(columns, tag) => {
                         self.strict_indexes.insert(*tag, columns.clone());
                     }
+                    Operation::CreateWeakIndex(columns) => {
+                        self.weak_indexes.push(columns.clone());
+                    }
                     _ => todo!(),
                 }
             }
@@ -1139,6 +1140,10 @@ mod tests {
                     Operation::CreateStrictIndex(columns, tag) => {
                         let index = Index::new(IndexType::HashMap, columns.clone());
                         ctxt.add_key(index, Some(vec![*tag]));
+                    }
+                    Operation::CreateWeakIndex(columns) => {
+                        let index = Index::new(IndexType::HashMap, columns.clone());
+                        ctxt.add_weak_key(index);
                     }
                     _ => todo!(),
                 }

--- a/nom-sql/src/explain.rs
+++ b/nom-sql/src/explain.rs
@@ -22,6 +22,9 @@ pub enum ExplainStatement {
     LastStatement,
     /// List domain shard replicas and what worker they're running on
     Domains,
+    /// List all CREATE CACHE statements that have been executed, for the
+    /// purpose of exporting them
+    Caches,
 }
 
 impl Display for ExplainStatement {
@@ -36,6 +39,7 @@ impl Display for ExplainStatement {
             }
             ExplainStatement::LastStatement => write!(f, "LAST STATEMENT;"),
             ExplainStatement::Domains => write!(f, "DOMAINS;"),
+            ExplainStatement::Caches => write!(f, "CACHES;"),
         }
     }
 }
@@ -61,6 +65,7 @@ pub(crate) fn explain_statement(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], Ex
             tuple((tag_no_case("last"), whitespace1, tag_no_case("statement"))),
         ),
         value(ExplainStatement::Domains, tag_no_case("domains")),
+        value(ExplainStatement::Caches, tag_no_case("caches")),
     ))(i)?;
     let (i, _) = statement_terminator(i)?;
     Ok((i, stmt))
@@ -96,5 +101,13 @@ mod tests {
             test_parse!(explain_statement, b"explain domains;"),
             ExplainStatement::Domains
         );
+    }
+
+    #[test]
+    fn explain_caches() {
+        assert_eq!(
+            test_parse!(explain_statement, b"explain caches;"),
+            ExplainStatement::Caches
+        )
     }
 }

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1851,6 +1851,7 @@ where
             SqlQuery::Explain(nom_sql::ExplainStatement::Domains) => {
                 self.noria.explain_domains().await
             }
+            SqlQuery::Explain(nom_sql::ExplainStatement::Caches) => self.export_caches().await,
             SqlQuery::CreateCache(CreateCacheStatement {
                 name,
                 inner,
@@ -2509,6 +2510,37 @@ where
 
     pub fn does_require_authentication(&self) -> bool {
         self.settings.require_authentication
+    }
+
+    /// Gets a list of all `CREATE CACHE ...` statements
+    async fn export_caches(&mut self) -> ReadySetResult<noria_connector::QueryResult<'static>> {
+        let create_dummy_column = |n: &str| ColumnSchema {
+            column: nom_sql::Column {
+                name: n.into(),
+                table: None,
+            },
+            column_type: DfType::DEFAULT_TEXT,
+            base: None,
+        };
+
+        let results: Vec<Vec<DfValue>> = self
+            .noria
+            .list_create_cache_stmts()
+            .await?
+            .into_iter()
+            .map(|s| vec![DfValue::from(s)])
+            .collect();
+
+        let select_schema = SelectSchema {
+            use_bogo: false,
+            schema: Cow::Owned(vec![create_dummy_column("query text")]),
+            columns: Cow::Owned(vec!["query text".into()]),
+        };
+
+        Ok(noria_connector::QueryResult::from_owned(
+            select_schema,
+            vec![Results::new(results)],
+        ))
     }
 }
 

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -587,6 +587,17 @@ impl NoriaConnector {
         Ok(QueryResult::from_owned(schema, vec![Results::new(data)]))
     }
 
+    #[allow(unused)]
+    pub(crate) async fn list_create_cache_stmts(&mut self) -> ReadySetResult<Vec<String>> {
+        let noria = &mut self.inner.get_mut()?.noria;
+        Ok(noria
+            .verbose_views()
+            .await?
+            .into_iter()
+            .map(|stmt| stmt.display(self.parse_dialect).to_string())
+            .collect())
+    }
+
     pub(crate) fn server_supports_pagination(&self) -> bool {
         self.inner
             .inner

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -587,7 +587,6 @@ impl NoriaConnector {
         Ok(QueryResult::from_owned(schema, vec![Results::new(data)]))
     }
 
-    #[allow(unused)]
     pub(crate) async fn list_create_cache_stmts(&mut self) -> ReadySetResult<Vec<String>> {
         let noria = &mut self.inner.get_mut()?.noria;
         Ok(noria

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -8,7 +8,7 @@ use nom_sql::{
     BinaryOperator, Column, ColumnConstraint, CreateTableBody, DeleteStatement, Expr,
     InsertStatement, Literal, SelectStatement, SqlIdentifier, SqlQuery, TableKey, UpdateStatement,
 };
-use readyset_client::{Modification, Operation};
+use readyset_client::{ColumnSchema, Modification, Operation};
 use readyset_data::{DfType, DfValue, Dialect};
 use readyset_errors::{
     bad_request_err, invalid_query, invalid_query_err, invariant, invariant_eq, unsupported,
@@ -594,6 +594,17 @@ pub(crate) fn generate_query_name(
     schema_search_path: &[SqlIdentifier],
 ) -> String {
     format!("q_{:x}", hash(&(statement, schema_search_path)))
+}
+
+pub(crate) fn create_dummy_column(name: &str) -> ColumnSchema {
+    ColumnSchema {
+        column: nom_sql::Column {
+            name: name.into(),
+            table: None,
+        },
+        column_type: DfType::DEFAULT_TEXT,
+        base: None,
+    }
 }
 
 #[cfg(test)]

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use futures_util::future;
 use hyper::client::HttpConnector;
-use nom_sql::{Relation, SelectStatement};
+use nom_sql::{CreateCacheStatement, Relation};
 use parking_lot::RwLock;
 use petgraph::graph::NodeIndex;
 use readyset_errors::{
@@ -463,12 +463,12 @@ impl ReadySetHandle {
         self.simple_post_request("views").await
     }
 
-    /// Enumerate all known external views. Includes the SqlQuery that created the view
+    /// Enumerate all known external views. Includes the SqlQuery that created
+    /// the view and the fallback behavior.
     ///
-    /// `Self::poll_ready` must have returned `Async::Ready` before you call this method.
-    pub async fn verbose_views(
-        &mut self,
-    ) -> ReadySetResult<BTreeMap<Relation, (SelectStatement, bool)>> {
+    /// `Self::poll_ready` must have returned `Async::Ready` before you call
+    /// this method.
+    pub async fn verbose_views(&mut self) -> ReadySetResult<Vec<CreateCacheStatement>> {
         self.simple_post_request("verbose_views").await
     }
 


### PR DESCRIPTION
Just a straightforward implementation of a new op in the stateful
proptest for weak indexes. No new bugs revealed, but we now create weak
indexes during test runs.

