### PR TITLE
dataflow-state: Add KeyedState::values method

### DIFF
--- a/dataflow-state/src/keyed_state.rs
+++ b/dataflow-state/src/keyed_state.rs
@@ -609,6 +609,26 @@ impl KeyedState {
             }
         }
     }
+
+    pub(super) fn values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Rows> + 'a> {
+        match self {
+            KeyedState::AllRows(ref rows) => Box::new(iter::once(rows)),
+            KeyedState::SingleBTree(ref map) => Box::new(map.values()),
+            KeyedState::DoubleBTree(ref map) => Box::new(map.values()),
+            KeyedState::TriBTree(ref map) => Box::new(map.values()),
+            KeyedState::QuadBTree(ref map) => Box::new(map.values()),
+            KeyedState::QuinBTree(ref map) => Box::new(map.values()),
+            KeyedState::SexBTree(ref map) => Box::new(map.values()),
+            KeyedState::MultiBTree(ref map, _) => Box::new(map.values()),
+            KeyedState::SingleHash(ref map) => Box::new(map.values()),
+            KeyedState::DoubleHash(ref map) => Box::new(map.values()),
+            KeyedState::TriHash(ref map) => Box::new(map.values()),
+            KeyedState::QuadHash(ref map) => Box::new(map.values()),
+            KeyedState::QuinHash(ref map) => Box::new(map.values()),
+            KeyedState::SexHash(ref map) => Box::new(map.values()),
+            KeyedState::MultiHash(ref map, _) => Box::new(map.values()),
+        }
+    }
 }
 
 impl From<&Index> for KeyedState {

--- a/dataflow-state/src/single_state.rs
+++ b/dataflow-state/src/single_state.rs
@@ -1,4 +1,3 @@
-use std::iter;
 use std::ops::{Bound, RangeBounds};
 use std::rc::Rc;
 
@@ -388,23 +387,7 @@ impl SingleState {
     }
 
     pub(super) fn values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Rows> + 'a> {
-        match self.state {
-            KeyedState::AllRows(ref rows) => Box::new(iter::once(rows)),
-            KeyedState::SingleBTree(ref map) => Box::new(map.values()),
-            KeyedState::DoubleBTree(ref map) => Box::new(map.values()),
-            KeyedState::TriBTree(ref map) => Box::new(map.values()),
-            KeyedState::QuadBTree(ref map) => Box::new(map.values()),
-            KeyedState::QuinBTree(ref map) => Box::new(map.values()),
-            KeyedState::SexBTree(ref map) => Box::new(map.values()),
-            KeyedState::MultiBTree(ref map, _) => Box::new(map.values()),
-            KeyedState::SingleHash(ref map) => Box::new(map.values()),
-            KeyedState::DoubleHash(ref map) => Box::new(map.values()),
-            KeyedState::TriHash(ref map) => Box::new(map.values()),
-            KeyedState::QuadHash(ref map) => Box::new(map.values()),
-            KeyedState::QuinHash(ref map) => Box::new(map.values()),
-            KeyedState::SexHash(ref map) => Box::new(map.values()),
-            KeyedState::MultiHash(ref map, _) => Box::new(map.values()),
-        }
+        self.state.values()
     }
 
     /// Return a reference to this state's Index, which contains the list of columns it's keyed on


### PR DESCRIPTION
This basically moves the existing SingleState::values method into
KeyedState, and then calls that from SingleState::values to retain the
same functionality in the existing method.

This could probably be justifiable as a refactor, since it avoids
SingleState needing to know as much about the implementation of the
KeyedState it wraps, but it also will be useful for testing purposes in
the following commit since it lets tests see what rows are contained in
a bare KeyedState without it needing to be wrapped in a SingleState.

