### PR TITLE
readyset-mysql: De-ignore duplicate_join_key test now that it passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ version = "0.0.1"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
+ "async-trait",
  "bincode",
  "clap 4.3.2",
  "criterion",
@@ -1235,6 +1236,7 @@ dependencies = [
  "partial-map",
  "pretty_assertions",
  "proptest",
+ "proptest-stateful",
  "rand 0.7.3",
  "readyset-alloc",
  "readyset-client",

--- a/dataflow-state/Cargo.toml
+++ b/dataflow-state/Cargo.toml
@@ -39,6 +39,8 @@ partial-map = { path = "../partial-map" }
 replication-offset = { path = "../replication-offset" }
 
 [dev-dependencies]
+proptest-stateful = { path = "../proptest-stateful" }
+async-trait = "0.1"
 pretty_assertions = "0.7.2"
 lazy_static = "1.0.0"
 criterion = { version = "0.3", features=['real_blackbox', 'async_tokio'] }

--- a/dataflow-state/src/keyed_state.rs
+++ b/dataflow-state/src/keyed_state.rs
@@ -609,6 +609,26 @@ impl KeyedState {
             }
         }
     }
+
+    pub(super) fn values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Rows> + 'a> {
+        match self {
+            KeyedState::AllRows(ref rows) => Box::new(iter::once(rows)),
+            KeyedState::SingleBTree(ref map) => Box::new(map.values()),
+            KeyedState::DoubleBTree(ref map) => Box::new(map.values()),
+            KeyedState::TriBTree(ref map) => Box::new(map.values()),
+            KeyedState::QuadBTree(ref map) => Box::new(map.values()),
+            KeyedState::QuinBTree(ref map) => Box::new(map.values()),
+            KeyedState::SexBTree(ref map) => Box::new(map.values()),
+            KeyedState::MultiBTree(ref map, _) => Box::new(map.values()),
+            KeyedState::SingleHash(ref map) => Box::new(map.values()),
+            KeyedState::DoubleHash(ref map) => Box::new(map.values()),
+            KeyedState::TriHash(ref map) => Box::new(map.values()),
+            KeyedState::QuadHash(ref map) => Box::new(map.values()),
+            KeyedState::QuinHash(ref map) => Box::new(map.values()),
+            KeyedState::SexHash(ref map) => Box::new(map.values()),
+            KeyedState::MultiHash(ref map, _) => Box::new(map.values()),
+        }
+    }
 }
 
 impl From<&Index> for KeyedState {

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -1014,7 +1014,6 @@ mod tests {
             #[allow(unused)]
             ReplayKey(Tag, TestRow),
             CreateStrictIndex(Vec<usize>, Tag),
-            #[allow(unused)]
             CreateWeakIndex(Vec<usize>),
         }
 
@@ -1022,7 +1021,6 @@ mod tests {
         struct IndexModelState {
             rows: Vec<TestRow>,
             strict_indexes: BTreeMap<Tag, Vec<usize>>,
-            #[allow(unused)]
             weak_indexes: Vec<Vec<usize>>,
         }
 
@@ -1083,9 +1081,9 @@ mod tests {
 
                 let insert_row_strat = gen_insert_row().boxed();
                 let create_strict_strat = gen_create_strict(self.next_tag()).boxed();
-                //let create_weak_strat = gen_create_weak().boxed();
+                let create_weak_strat = gen_create_weak().boxed();
 
-                let mut ops = vec![insert_row_strat, create_strict_strat];
+                let mut ops = vec![insert_row_strat, create_strict_strat, create_weak_strat];
 
                 if !self.rows.is_empty() {
                     let delete_row_strat = gen_delete_row(self.rows.clone()).boxed();
@@ -1117,6 +1115,9 @@ mod tests {
                     Operation::CreateStrictIndex(columns, tag) => {
                         self.strict_indexes.insert(*tag, columns.clone());
                     }
+                    Operation::CreateWeakIndex(columns) => {
+                        self.weak_indexes.push(columns.clone());
+                    }
                     _ => todo!(),
                 }
             }
@@ -1139,6 +1140,10 @@ mod tests {
                     Operation::CreateStrictIndex(columns, tag) => {
                         let index = Index::new(IndexType::HashMap, columns.clone());
                         ctxt.add_key(index, Some(vec![*tag]));
+                    }
+                    Operation::CreateWeakIndex(columns) => {
+                        let index = Index::new(IndexType::HashMap, columns.clone());
+                        ctxt.add_weak_key(index);
                     }
                     _ => todo!(),
                 }

--- a/dataflow-state/src/single_state.rs
+++ b/dataflow-state/src/single_state.rs
@@ -1,4 +1,3 @@
-use std::iter;
 use std::ops::{Bound, RangeBounds};
 use std::rc::Rc;
 
@@ -388,23 +387,7 @@ impl SingleState {
     }
 
     pub(super) fn values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Rows> + 'a> {
-        match self.state {
-            KeyedState::AllRows(ref rows) => Box::new(iter::once(rows)),
-            KeyedState::SingleBTree(ref map) => Box::new(map.values()),
-            KeyedState::DoubleBTree(ref map) => Box::new(map.values()),
-            KeyedState::TriBTree(ref map) => Box::new(map.values()),
-            KeyedState::QuadBTree(ref map) => Box::new(map.values()),
-            KeyedState::QuinBTree(ref map) => Box::new(map.values()),
-            KeyedState::SexBTree(ref map) => Box::new(map.values()),
-            KeyedState::MultiBTree(ref map, _) => Box::new(map.values()),
-            KeyedState::SingleHash(ref map) => Box::new(map.values()),
-            KeyedState::DoubleHash(ref map) => Box::new(map.values()),
-            KeyedState::TriHash(ref map) => Box::new(map.values()),
-            KeyedState::QuadHash(ref map) => Box::new(map.values()),
-            KeyedState::QuinHash(ref map) => Box::new(map.values()),
-            KeyedState::SexHash(ref map) => Box::new(map.values()),
-            KeyedState::MultiHash(ref map, _) => Box::new(map.values()),
-        }
+        self.state.values()
     }
 
     /// Return a reference to this state's Index, which contains the list of columns it's keyed on

--- a/readyset-mysql/tests/integration.rs
+++ b/readyset-mysql/tests/integration.rs
@@ -36,8 +36,9 @@ async fn setup_telemetry() -> (TelemetryReporter, mysql_async::Opts, Handle, Shu
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Reproduces known failure (REA-3207)"]
 async fn duplicate_join_key() {
+    // This used to trigger a bug involving weak indexes. See issue #179 for more info.
+
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
 


### PR DESCRIPTION
The previous commit fixed the bug that caused this (#179) so we can now
include this in our test runs.

Refs: #179
