### PR TITLE
dataflow-state: Rename variable in add_weak_key

### DIFF
--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -396,8 +396,8 @@ impl State for MemoryState {
     }
 
     fn add_weak_key(&mut self, index: Index) {
-        let state = KeyedState::from(&index);
-        self.weak_indices.insert(index.columns, state);
+        let weak_index = KeyedState::from(&index);
+        self.weak_indices.insert(index.columns, weak_index);
     }
 
     fn lookup_weak<'a>(&'a self, columns: &[usize], key: &PointKey) -> Option<RecordResult<'a>> {


### PR DESCRIPTION
The name `state` is about to become confusing, since we need to iterate
over `self.state` to add entries to the newly created weak index.

Refs: #179
