### PR TITLE
jepsen: Mix writes and reads

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -251,7 +251,7 @@
     :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
             #_"refs/tags/beta-2023-07-26")
     :client (rs/new-client)
-    :generator (->> rs/r
+    :generator (->> (gen/mix [rs/r rs/w])
                     (gen/stagger 1)
                     (gen/nemesis nil)
                     (gen/time-limit 15))


### PR DESCRIPTION
Add support for *writing* rows to the table in addition to just reading
them, implemented by just writing a value to a single column for now.
This is primarily just a proof of concept, but works fine as of this commit

