### PR TITLE
jepsen: Add a proof-of-concept Model for eventual consistency

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.logging :refer [error info warn]]
+   [jepsen.checker :as checker]
    [jepsen.cli :as cli]
    [jepsen.consul.db :as consul.db]
    [jepsen.control :as c]
@@ -15,6 +16,7 @@
    [jepsen.os.debian :as debian]
    [jepsen.os.ubuntu :as ubuntu]
    [jepsen.readyset.client :as rs]
+   [jepsen.readyset.model :as rs.model]
    [jepsen.readyset.nodes :as nodes]
    [jepsen.tests :as tests]
    [slingshot.slingshot :refer [try+]]))
@@ -251,6 +253,9 @@
     :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
             #_"refs/tags/beta-2023-07-26")
     :client (rs/new-client)
+    :checker (checker/linearizable
+              {:model (rs.model/eventually-consistent-table)
+               :algorithm :linear})
     :generator (->> (gen/mix [rs/r rs/w])
                     (gen/stagger 1)
                     (gen/nemesis nil)

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -104,7 +104,7 @@
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
 
-(defrecord Client [conn table-created?]
+(defrecord Client [conn table-created? tables]
   client/Client
   (open! [this test node]
     (assoc this :conn (test-datasource test)))
@@ -128,7 +128,9 @@
      (case (:f op)
        :read (assoc op
                     :type :ok
-                    :value (jdbc/execute! conn ["select x from t1"]))
+                    :value
+                    (map (some-fn :t1/x :x)
+                         (jdbc/execute! conn ["select x from t1"])))
        :write
        (do (jdbc/execute! conn ["insert into t1 (x) values (?)"
                                 (:value op)])

--- a/jepsen/src/jepsen/readyset/model.clj
+++ b/jepsen/src/jepsen/readyset/model.clj
@@ -1,0 +1,29 @@
+(ns jepsen.readyset.model
+  "A Knossos Model for ReadySet eventual consistency"
+  (:require
+   [knossos.model :as model])
+  (:import
+   (knossos.model Model)))
+
+(defrecord
+    ^{:doc "A model for an eventually-consistent table with a single column.
+    Supports :write ops to write new rows, and :read ops to read the list of
+    rows out of the table"}
+    EventuallyConsistentTable [rows past-results]
+  Model
+  (step [this op]
+    (case (:f op)
+      :write (-> this
+                 (update :rows conj (:value op))
+                 (#(update % :past-results conj (sort (:rows %)))))
+      :read (let [results (sort (:value op))]
+              (if (or (nil? (:value op))
+                      (contains? past-results results))
+                this
+                (model/inconsistent (str "can't read " results
+                                         "; valid results: " past-results)))))))
+
+(defn eventually-consistent-table []
+  (map->EventuallyConsistentTable
+   {:rows []
+    :past-results #{[]}}))


### PR DESCRIPTION
Add a proof of concept of a very simple Model for a single eventually
consistent table. This writes rows to the table, and validates that the
results returned from reads always look like *one of* the valid results
from one of the table's past sets of rows.

This is all pretty hardcoded at this point, but going forward my plan is
to generalize it a bit to support multiple tables and arbitrary queries.

As of this commit, this all (probably unsurprisingly) still passes.

