### PR TITLE
jepsen: Allow configuring timing params

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -259,20 +259,24 @@
               {:model (rs.model/eventually-consistent-table)
                :algorithm :linear})
     :generator (->> (gen/mix [rs/r rs/w])
-                    (gen/stagger 1)
+                    (gen/stagger (/ (:rate opts)))
                     (gen/nemesis
                      (cycle
                       [(gen/sleep 5)
                        {:type :info, :f :start}
                        (gen/sleep 5)
                        {:type :info, :f :stop}]))
-                    (gen/time-limit 30))
+                    (gen/time-limit (:time-limit opts)))
     :pure-generators true}))
 
 (def opt-spec
   [[nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
     :default "info"]
-   [nil "--force-install" "Force install readyset binaries"]])
+   [nil "--force-install" "Force install readyset binaries"]
+   ["-r" "--rate HZ" "Approximate number of requests per second, per thread"
+    :default 10
+    :parse-fn read-string
+    :validate [#(and (number? %) (pos? %)) "Must be a positive number"]]])
 
 (defn -main
   [& args]


### PR DESCRIPTION
Add a new `--rate` parameter to configure the rate of requests that we
run against the ReadySet cluster, and use the built-in `time-limit`
param to configure the time limit of the test overall.

