### PR TITLE
jepsen: Perform a single read after waiting for things to settle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "postgres-derive"
 version = "0.4.3"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.26",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -6288,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "postgres-derive"
 version = "0.4.3"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.26",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -6288,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/benchmarks/scripts/open_write_latency.sh
+++ b/benchmarks/scripts/open_write_latency.sh
@@ -24,7 +24,7 @@ done
 cargo build --release --bin benchmarks
 for num_indices in "${indices[@]}"; do
     echo "=== Benchmarking ${num_indices} indices ==="
-    heaptrack target/release/benchmarks \
+    target/release/benchmarks \
         --local \
         --database-type "${DATABASE_TYPE:-mysql}" \
         --graph \

--- a/benchmarks/src/spec.rs
+++ b/benchmarks/src/spec.rs
@@ -270,6 +270,7 @@ impl WorkloadSpec {
                     name: None,
                     inner: Ok(nom_sql::CacheInner::Statement(Box::new(stmt))),
                     always: false,
+                    concurrently: false,
                 };
 
                 let _ = conn

--- a/benchmarks/src/utils/query.rs
+++ b/benchmarks/src/utils/query.rs
@@ -213,6 +213,7 @@ impl ArbitraryQueryParameters {
             name: Some("q".into()),
             inner: Ok(nom_sql::CacheInner::Statement(Box::new(stmt))),
             always: false,
+            concurrently: false,
         };
 
         conn.query_drop(create_cache_query.display(conn.dialect()).to_string())

--- a/benchmarks/src/write_benchmark.rs
+++ b/benchmarks/src/write_benchmark.rs
@@ -155,6 +155,7 @@ async fn create_indices(
                 name: None,
                 inner: Ok(CacheInner::Statement(Box::new(query))),
                 always: false,
+                concurrently: false,
             };
             conn.query_drop(create_cache.display(conn.dialect()).to_string())
                 .await?;

--- a/database-utils/src/lib.rs
+++ b/database-utils/src/lib.rs
@@ -76,10 +76,30 @@ pub struct UpstreamConfig {
     #[serde(default = "default_replicator_restart_timeout")]
     pub replicator_restart_timeout: Duration,
 
+    /// By default, ReadySet attempts to snapshot and replicate all tables in the database
+    /// specified in --upstream-db-url. However, if the queries you want to cache in ReadySet
+    /// access only a subset of tables in the database, you can use this option to limit the tables
+    /// ReadySet snapshots and replicates. Filtering out tables that will not be used in caches
+    /// will speed up the snapshotting process.
+    ///
+    /// This option accepts a comma-separated list of `<schema>.<table>` (specific table in a
+    /// schema) or `<schema>.*` (all tables in a schema) for Postgres and `<database>.<table>`
+    /// for MySQL. Only tables specified in the list will be eligible to be used by caches.
     #[clap(long, env = "REPLICATION_TABLES")]
     #[serde(default)]
     pub replication_tables: Option<RedactedString>,
 
+    /// By default, ReadySet attempts to snapshot and replicate all tables in the database
+    /// specified in --upstream-db-url. However, if you know the queries you want to cache in
+    /// ReadySet won't access a subset of tables in the database, you can use this option to
+    /// limit the tables ReadySet snapshots and replicates. Filtering out tables that will not be
+    /// used in caches will speed up the snapshotting process.
+    ///
+    /// This option accepts a comma-separated list of `<schema>.<table>` (specific table in a
+    /// schema) or `<schema>.*` (all tables in a schema) for Postgres and `<database>.<table>`
+    /// for MySQL.
+    ///
+    /// Tables specified in the list will not be eligible to be used by caches.
     #[clap(long, env = "REPLICATION_TABLES_IGNORE")]
     #[serde(default)]
     pub replication_tables_ignore: Option<RedactedString>,

--- a/database-utils/src/lib.rs
+++ b/database-utils/src/lib.rs
@@ -80,6 +80,10 @@ pub struct UpstreamConfig {
     #[serde(default)]
     pub replication_tables: Option<RedactedString>,
 
+    #[clap(long, env = "REPLICATION_TABLES_IGNORE")]
+    #[serde(default)]
+    pub replication_tables_ignore: Option<RedactedString>,
+
     /// Sets the time (in seconds) between reports of progress snapshotting the database. A value
     /// of 0 disables reporting.
     #[clap(long, default_value = "30", hide = true)]
@@ -140,6 +144,7 @@ impl Default for UpstreamConfig {
             replication_server_id: Default::default(),
             replicator_restart_timeout: Duration::from_secs(1),
             replication_tables: Default::default(),
+            replication_tables_ignore: Default::default(),
             snapshot_report_interval_secs: 30,
             ssl_root_cert: None,
             replication_pool_size: 50,

--- a/jepsen/.gitignore
+++ b/jepsen/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+/.prepl-port
+/.cpcache
+/store

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,0 +1,14 @@
+(defproject jepsen.readyset "0.1.0-SNAPSHOT"
+  :description "ReadySet Jepsen test"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [jepsen "0.3.3-SNAPSHOT"]
+
+                 [base64-clj "0.1.1"]
+                 [cheshire "5.9.0"]
+                 [clj-http "3.10.0"]
+                 [com.github.seancorfield/next.jdbc "1.3.883"]
+                 [org.postgresql/postgresql "42.6.0"]
+                 [slingshot "0.12.2"]]
+  :repl-options {:init-ns jepsen.readyset}
+  :main jepsen.readyset
+  :resource-paths ["resources"])

--- a/jepsen/resources/haproxy.cfg.tpl
+++ b/jepsen/resources/haproxy.cfg.tpl
@@ -1,0 +1,17 @@
+global
+    daemon
+    maxconn 256
+defaults
+    mode http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+frontend readyset_frontend
+    bind *:5432
+    mode tcp
+    option tcplog
+    default_backend readyset_backend
+backend readyset_backend
+    mode tcp
+    balance roundrobin
+    ${servers}

--- a/jepsen/src/jepsen/consul/client.clj
+++ b/jepsen/src/jepsen/consul/client.clj
@@ -1,0 +1,130 @@
+(ns jepsen.consul.client
+  "Taken from https://github.com/jepsen-io/jepsen/blob/main/consul/src/jepsen/consul/client.clj"
+  (:refer-clojure :exclude [get])
+  (:require [clojure.tools.logging :refer [warn]]
+            [jepsen.control.net :as net]
+            [base64-clj.core :as base64]
+            [cheshire.core :as json]
+            [clj-http.client :as http]
+            [dom-top.core :refer [with-retry]]
+            [slingshot.slingshot :refer [throw+]]))
+
+(defn maybe-int [value]
+  (if (= value "null")
+      nil
+      (Integer. value)))
+
+(defn parse-index [resp]
+  (-> resp
+      :headers
+      (clojure.core/get "X-Consul-Index")
+      Integer.))
+
+(defn parse-body
+  "Parse the base64 encoded value.
+   The response JSON looks like:
+    [
+     {
+       \"CreateIndex\": 100,
+       \"ModifyIndex\": 200,
+       \"Key\": \"foo\",
+       \"Flags\": 0,
+       \"Value\": \"YmFy\"
+     }
+    ]
+  "
+  [resp]
+  (let [body  (-> resp
+                  :body
+                  (json/parse-string #(keyword (.toLowerCase %)))
+                  first)
+        value (-> body :value base64/decode maybe-int)]
+    (assoc body :value value)))
+
+(defn parse [response]
+  (assoc (parse-body response)
+         :index (parse-index response)))
+
+(defn get
+  ([url]
+   (http/get url))
+  ([url key]
+   (http/get (str url key)))
+  ([url key consistency]
+   (http/get (str url key)
+             {:query-params {(keyword consistency) nil}})))
+
+(defn put!
+  ([url key value]
+   (http/put (str url key) {:body value}))
+  ([url key value consistency]
+   (http/put (str url key)
+             {:body value
+              :query-params {(keyword consistency) nil}})))
+
+(defn cas!
+  "Consul uses an index based CAS, not a value-based CAS, so we must first get
+  the existing index for this the current key and then use the index to issue a
+  CAS request."
+  ([url key value new-value]
+   (let [res (parse (get url key))
+         existing-value (str (:value res))
+         index (:index res)]
+     (if (= existing-value value)
+       (let [params {:body new-value :query-params {:cas index}}
+             body (:body (http/put (str url key) params))]
+         (= body "true"))
+       false)))
+
+  ([url key value new-value consistency]
+   (let [res (parse (get url key consistency))
+         existing-value (str (:value res))
+         index (:index res)]
+     (if (= existing-value value)
+       (let [params {:body new-value :query-params {:cas index
+                                                    :query-params {(keyword consistency) nil}}}
+             body (:body (http/put (str url key) params))]
+         (= body "true"))
+       false))))
+
+(defn txn
+  "TODO Model txn requests when we get to testing that part of Consul"
+  [])
+
+(defmacro with-errors
+  [op idempotent & body]
+  `(try ~@body
+        (catch Exception e#
+            (let [type# (if (~idempotent (:f ~op))
+                         :fail
+                         :info)]
+              (condp re-find (.getMessage e#)
+                #"404" (assoc ~op :type type# :error :key-not-found)
+                #"403" (assoc ~op :type type# :error :not-authorized)
+                #"500" (assoc ~op :type type# :error :server-unavailable)
+                (throw e#))))))
+
+(defn await-cluster-ready
+  "Blocks until cluster index matches count of nodes on test."
+  [node count]
+  (let [url (str "http://" (net/ip (name node)) ":8500/v1/catalog/nodes?index=" count)]
+     (with-retry [attempts 5]
+       (get url)
+
+       ;; We got an application-level response, let's proceed!
+       (catch clojure.lang.ExceptionInfo e
+         (if (and (= (.getMessage e) "clj-http: status 500")
+                  (< 0 attempts))
+           (retry (dec attempts))
+           (throw+ {:error :retry-attempts-exceeded :exception e})))
+
+       ;; Cluster not converged yet, let's keep waiting
+       (catch java.net.ConnectException e
+         (if (< 0 attempts)
+           (do
+             ;; TODO It would be nice to remove this log warning if we don't have connection issues anymore
+             (warn "Connection refused from node:" node ", retrying. Attempts remaining:" attempts)
+             (Thread/sleep 200)
+             (retry (dec attempts)))
+           (throw+ {:error :retry-attempts-exceeded :exception e})))))
+  true)

--- a/jepsen/src/jepsen/consul/db.clj
+++ b/jepsen/src/jepsen/consul/db.clj
@@ -1,0 +1,70 @@
+(ns jepsen.consul.db
+  "Adapted from https://github.com/jepsen-io/jepsen/blob/main/consul/src/jepsen/consul/db.clj"
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen.consul.client :as client]
+            [jepsen.core :as jepsen]
+            [jepsen.db :as db]
+            [jepsen.control :as c]
+            [jepsen.control.net :as net]
+            [jepsen.control.util :as cu]))
+
+(def dir "/opt")
+(def binary "consul")
+(def config-file "/opt/consul.json")
+(def pidfile "/var/run/consul.pid")
+(def logfile "/var/log/consul.log")
+(def data-dir "/var/lib/consul")
+
+(def retry-interval "5s")
+
+(defn start-consul!
+  [node]
+  (info node "starting consul")
+  (cu/start-daemon!
+   {:logfile logfile
+    :pidfile pidfile
+    :chdir   dir}
+   binary
+   :agent
+   :-server
+   :-log-level "debug"
+   :-client    "0.0.0.0"
+   :-bind      (net/ip (name node))
+   :-data-dir  data-dir
+   :-node      (name node)
+   :-retry-interval retry-interval
+   :-bootstrap
+   :>> logfile
+   (c/lit "2>&1")))
+
+(defn db
+  "Install and cleanup a specific version of consul"
+  [version]
+  (reify db/DB
+    (setup! [_ test node]
+      (info node "installing consul" version)
+      (c/su
+       (let [url (str "https://releases.hashicorp.com/consul/"
+                      version "/consul_" version "_linux_amd64.zip")]
+         (cu/install-archive! url (str dir "/" binary)))
+
+       (start-consul! node))
+
+      (info "Waiting for cluster to converge")
+      (client/await-cluster-ready node 1)
+
+      #_(jepsen/synchronize test))
+
+    (teardown! [_ _test node]
+      (c/su
+       (cu/stop-daemon! binary pidfile)
+       (info node "consul killed")
+
+       (c/exec :rm :-rf pidfile logfile data-dir (str dir "/" binary) config-file)
+       (c/su
+        (c/exec :rm :-rf binary)))
+      (info node "consul nuked"))
+
+    db/LogFiles
+    (log-files [_ _test _node]
+      [logfile])))

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -251,7 +251,7 @@
     :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
             #_"refs/tags/beta-2023-07-26")
     :client (rs/new-client)
-    :generator (->> rs/r
+    :generator (->> (gen/mix [rs/r rs/w])
                     (gen/stagger 1)
                     (gen/nemesis nil)
                     (gen/time-limit 15))

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.logging :refer [error info warn]]
+   [jepsen.checker :as checker]
    [jepsen.cli :as cli]
    [jepsen.consul.db :as consul.db]
    [jepsen.control :as c]
@@ -15,6 +16,7 @@
    [jepsen.os.debian :as debian]
    [jepsen.os.ubuntu :as ubuntu]
    [jepsen.readyset.client :as rs]
+   [jepsen.readyset.model :as rs.model]
    [jepsen.readyset.nodes :as nodes]
    [jepsen.tests :as tests]
    [slingshot.slingshot :refer [try+]]))
@@ -251,6 +253,9 @@
     :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
             #_"refs/tags/beta-2023-07-26")
     :client (rs/new-client)
+    :checker (checker/linearizable
+              {:model (rs.model/eventually-consistent-table)
+               :algorithm :linear})
     :generator (->> (gen/mix [rs/r rs/w])
                     (gen/stagger 1)
                     (gen/nemesis nil)

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -1,0 +1,331 @@
+(ns jepsen.readyset
+  (:gen-class)
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.tools.logging :refer [error info warn]]
+   [jepsen.cli :as cli]
+   [jepsen.consul.db :as consul.db]
+   [jepsen.control :as c]
+   [jepsen.control.net :as net]
+   [jepsen.control.util :as cu]
+   [jepsen.core :as jepsen]
+   [jepsen.db :as db]
+   [jepsen.os.debian :as debian]
+   [jepsen.os.ubuntu :as ubuntu]
+   [jepsen.readyset.client :as rs]
+   [jepsen.tests :as tests]
+   [slingshot.slingshot :refer [try+]]))
+
+(def pguser "postgres")
+(def pgpassword "password")
+(def pgdatabase "jepsen")
+
+(defn- node->role
+  [test]
+  (zipmap
+   (:nodes test)
+   (concat [:node-role/load-balancer
+            :node-role/consul
+            :node-role/readyset-server
+            :node-role/upstream]
+           (repeat :node-role/readyset-adapter))))
+
+(defn role->node
+  [test]
+  (into {} (map (comp vec reverse)) (node->role test)))
+
+(defn- node-role
+  "Given a test and a node in that test, returns what will be running on that
+  node for the test, represented as a keyword in
+  `#{:node-role/consul
+     :node-role/readyset-adapter
+     :node-role/load-balancer
+     :node-role/readyset-server
+     :node-role/upstream}`.
+
+  Note that we must always have at least 5 nodes to run a test.
+
+  Roles will be assigned to nodes in the following order:
+
+    1. `:node-role/load-balancer`
+    2. `:node-role/consul`
+    3. `:node-role/readyset-server`
+    4. `:node-role/upstream`
+    5. ... and all remaining nodes will have `:node-role/readyset-adapter`"
+  [test node]
+  (assert
+   (>= (count (:nodes test)) 5)
+   "Must have at least 5 nodes to run a high-availability ReadySet cluster")
+  (get (node->role test) node))
+
+(defn- node-with-role
+  "Returns the node with the given role in the given test"
+  [test role]
+  (get (role->node test) role))
+
+(defn- adapter-nodes
+  "Returns a sequence of adapter nodes in the given test"
+  [test]
+  (->> test :nodes (drop 4)))
+
+(defn- num-adapters
+  "Returns the number of adapter instances that will be running in the given
+  test"
+  [test]
+  (- (count (:nodes test)) 4))
+
+(defn- upstream-db-url
+  "Returns the upstream DB URL for the given test"
+  [test]
+  (str "postgresql://"
+       pguser ":" pgpassword
+       "@" (node-with-role test :node-role/upstream)
+       "/" pgdatabase))
+
+(defn- readyset-datasource
+  "Build a JDBC DataSource for connecting to the ReadySet cluster in the given
+  test"
+  [test]
+  (rs/make-datasource
+   {:dbtype "postgres"
+    :dbname pgdatabase
+    :user pguser
+    :password pgpassword
+    :host (name (node-with-role test :node-role/load-balancer))
+    :port 5432}))
+
+(defn- ensure-git-cloned
+  "Ensure that a git repository `repo` is cloned at ref `ref` in dir `dir`"
+  [repo ref dir]
+  (debian/install ["git"])
+
+  (when (and (cu/exists? dir)
+             (not (cu/exists? (str dir "/.git"))))
+    (c/exec :rm :-rf dir))
+  (letfn [(git [& args] (apply c/exec :git :-C dir args))]
+    (if (cu/exists? dir)
+      (git :fetch :origin)
+      (c/exec :git :clone repo dir))
+    (git :checkout ref)))
+
+(defn- compile-and-install-readyset-binary
+  [node ref bin & [{:keys [force?] :or {force? false}}]]
+  (if (and
+       (cu/file? (str "/usr/local/bin/" bin))
+       (not force?))
+    (info node bin "already exists, not re-installing")
+    (c/su
+     (debian/install ["clang"
+                      "libclang-dev"
+                      "libssl-dev"
+                      "liblz4-dev"
+                      "build-essential"
+                      "pkg-config"])
+     (c/exec* "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+     (ensure-git-cloned
+      "https://github.com/readysettech/readyset.git"
+      ref
+      "/opt/readyset")
+     (c/exec* "~/.cargo/bin/rustup install $(</opt/readyset/rust-toolchain)")
+     (info node "compiling" bin)
+     (c/cd "/opt/readyset"
+           (c/exec "~/.cargo/bin/cargo" "build" "--release" "--bin" bin)
+           (c/exec "mv"
+                   (str "target/release/" bin)
+                   "/usr/local/bin/")))))
+
+(defn- authority-address
+  [test]
+  (str (name (node-with-role test :node-role/consul))
+       ":8500"))
+
+(defn- append-to-file [s file]
+  (c/exec "echo" s (c/lit ">>") file))
+
+(defn db
+  "ReadySet DB at a given git ref"
+  [ref]
+  (let [consul (consul.db/db "1.16.1")]
+    (reify db/DB
+      (setup! [_ test node]
+        (if-let [role (node-role test node)]
+          (do
+            (info node "role is" role)
+            (case role
+              :node-role/load-balancer
+              (do
+                (debian/install ["haproxy"])
+                (let [haproxy-servers
+                      (->> test
+                           adapter-nodes
+                           (map #(str "server " (name %) " " (name %) ":5432 check"))
+                           (str/join "\n"))
+                      haproxy-cfg (-> (io/resource "haproxy.cfg.tpl")
+                                      (slurp)
+                                      (str/replace "${servers}" haproxy-servers))]
+                  (c/su
+                   (cu/write-file! haproxy-cfg "/etc/haproxy/haproxy.cfg")
+                   (c/exec "systemctl" "restart" "haproxy")))
+                (jepsen/synchronize test (* 60 30)))
+
+              :node-role/consul
+              (do
+                (db/setup! consul test node)
+                (jepsen/synchronize test (* 60 30)))
+
+              :node-role/upstream
+              (do
+                (debian/install ["postgresql"])
+                (info node "setting up postgresql database " pgdatabase)
+                (c/sudo
+                 "postgres"
+
+                 (try+
+                  (c/exec "psql" :-c (str "create database " pgdatabase))
+                  (catch #(re-find #"database \".*?\" already exists"
+                                   (:err %)) _))
+                 (c/exec "psql" :-c (str "alter user " pguser
+                                         " password '" pgpassword "'"))
+
+                 (append-to-file
+                  "listen_addresses = '*'\nwal_level = logical"
+                  "/etc/postgresql/14/main/postgresql.conf")
+                 (append-to-file
+                  "host all all 0.0.0.0/0 scram-sha-256"
+                  "/etc/postgresql/14/main/pg_hba.conf"))
+                (c/su (c/exec "systemctl" "restart" "postgresql"))
+                (jepsen/synchronize test (* 60 30)))
+
+              :node-role/readyset-adapter
+              (do
+                (compile-and-install-readyset-binary
+                 node
+                 ref
+                 "readyset"
+                 {:force? (:force-install test)})
+
+                ;; Don't try to start readyset processes until Consul is up
+                (jepsen/synchronize test (* 60 30))
+                (c/su
+                 (cu/start-daemon!
+                  {:logfile "/var/log/readyset.log"
+                   :pidfile "/var/run/readyset.pid"
+                   :chdir "/"}
+                  "/usr/local/bin/readyset"
+                  :--log-level (:log-level test "info")
+                  :--deployment "jepsen"
+                  :-a "0.0.0.0:5432"
+                  :--external-address (net/ip (name node))
+                  :--authority-address (authority-address test)
+                  :--upstream-db-url (upstream-db-url test)
+                  :--disable-upstream-ssl-verification
+                  :--embedded-readers
+                  :--reader-replicas (str (num-adapters test)))))
+
+              :node-role/readyset-server
+              (do
+                (compile-and-install-readyset-binary
+                 node
+                 ref
+                 "readyset-server"
+                 {:force? (:force-install test)})
+
+                ;; Don't try to start readyset processes until Consul is up
+                (jepsen/synchronize test (* 60 30))
+                (c/su
+                 (c/exec :mkdir "/opt/readyset/data")
+                 (cu/start-daemon!
+                  {:logfile "/var/log/readyset-server.log"
+                   :pidfile "/var/run/readyset-server.pid"
+                   :chdir "/"}
+                  "/usr/local/bin/readyset-server"
+                  :--log-level (:log-level test "info")
+                  :--deployment "jepsen"
+                  :--db-dir "/opt/readyset/data"
+                  :-a "0.0.0.0"
+                  :--external-address (net/ip (name node))
+                  :--authority-address (authority-address test)
+                  :--upstream-db-url (upstream-db-url test)
+                  :--disable-upstream-ssl-verification
+                  :--no-readers
+                  :--reader-replicas (str (num-adapters test))))
+
+                (let [ds (readyset-datasource test)]
+                  (rs/wait-for-snapshot-completed ds))
+                (info "ReadySet is running"))))
+
+          (error node "unknown role")))
+
+      (teardown! [_ test node]
+        (if-let [role (node-role test node)]
+          (do
+            (info node "tearing down for role" role)
+            (case role
+              :node-role/load-balancer nil
+              :node-role/consul (db/teardown! consul test node)
+
+              :node-role/upstream
+              (try+
+               (info node "dropping database" pgdatabase)
+               (c/sudo "postgres" (c/exec "psql"
+                                          :-c (str "drop database " pgdatabase)))
+               (catch #(re-find #"psql: command not found" (:err %)) _)
+               (catch #(re-find #"database \".*?\" does not exist" (:err %)) _)
+               (catch
+                   #(re-find #"database \".*?\" is used by an active logical"
+                             (:err %))
+                   e
+                 (warn node "Could not drop database:" e)))
+
+              :node-role/readyset-adapter
+              (c/su
+               (cu/stop-daemon! "/var/run/readyset.pid")
+               (info node "ReadySet Adapter killed")
+               (c/exec :rm :-rf
+                       "/var/run/readyset.pid"
+                       "/var/log/readyset.log"))
+
+              :node-role/readyset-server
+              (c/su
+               (cu/stop-daemon! "/var/run/readyset-server.pid")
+               (info node "ReadySet Server killed")
+               (c/exec :rm :-rf
+                       "/var/run/readyset-server.pid"
+                       "/var/log/readyset-server.log"
+                       "/opt/readyset/data"))))
+          (error node "unknown role")))
+
+      db/LogFiles
+      (log-files [_ test node]
+        (if-let [role (node-role test node)]
+          (case role
+            :node-role/load-balancer nil
+            :node-role/consul (db/log-files consul test node)
+            :node-role/upstream nil
+            :node-role/readyset-adapter ["/var/log/readyset.log"]
+            :node-role/readyset-server ["/var/log/readyset-server.log"])
+          (error node "unknown role"))))))
+
+(defn readyset-test
+  [opts]
+  (merge
+   tests/noop-test
+   opts
+   {:name "ReadySet"
+    :os ubuntu/os
+    :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
+            #_"refs/tags/beta-2023-07-26")
+    :pure-generators true}))
+
+(def opt-spec
+  [[nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
+    :default "info"]
+   [nil "--force-install" "Force install readyset binaries"]])
+
+(defn -main
+  [& args]
+  (cli/run! (merge (cli/single-test-cmd {:test-fn readyset-test
+                                         :opt-spec opt-spec})
+                   (cli/serve-cmd))
+            args))

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -259,20 +259,24 @@
               {:model (rs.model/eventually-consistent-table)
                :algorithm :linear})
     :generator (->> (gen/mix [rs/r rs/w])
-                    (gen/stagger 1)
+                    (gen/stagger (/ (:rate opts)))
                     (gen/nemesis
                      (cycle
                       [(gen/sleep 5)
                        {:type :info, :f :start}
                        (gen/sleep 5)
                        {:type :info, :f :stop}]))
-                    (gen/time-limit 30))
+                    (gen/time-limit (:time-limit opts)))
     :pure-generators true}))
 
 (def opt-spec
   [[nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
     :default "info"]
-   [nil "--force-install" "Force install readyset binaries"]])
+   [nil "--force-install" "Force install readyset binaries"]
+   ["-r" "--rate HZ" "Approximate number of requests per second, per thread"
+    :default 10
+    :parse-fn read-string
+    :validate [#(and (number? %) (pos? %)) "Must be a positive number"]]])
 
 (defn -main
   [& args]

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -103,6 +103,7 @@
 
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn final-r [_ _] {:type :invoke, :f :final-read, :value nil})
 
 (defrecord Client [conn table-created? tables]
   client/Client
@@ -126,11 +127,13 @@
   (invoke! [_ test op]
     (try+
      (case (:f op)
-       :read (assoc op
-                    :type :ok
-                    :value
-                    (map (some-fn :t1/x :x)
-                         (jdbc/execute! conn ["select x from t1"])))
+       (:read :final-read)
+       (assoc op
+              :type :ok
+              :value
+              (map (some-fn :t1/x :x)
+                   (jdbc/execute! conn ["select x from t1"])))
+
        :write
        (do (jdbc/execute! conn ["insert into t1 (x) values (?)"
                                 (:value op)])

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -104,7 +104,7 @@
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
 
-(defrecord Client [conn table-created?]
+(defrecord Client [conn table-created? tables]
   client/Client
   (open! [this test node]
     (assoc this :conn (test-datasource test)))
@@ -128,7 +128,9 @@
      (case (:f op)
        :read (assoc op
                     :type :ok
-                    :value (jdbc/execute! conn ["select x from t1"]))
+                    :value
+                    (map (some-fn :t1/x :x)
+                         (jdbc/execute! conn ["select x from t1"])))
        :write
        (do (jdbc/execute! conn ["insert into t1 (x) values (?)"
                                 (:value op)])

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -1,0 +1,82 @@
+(ns jepsen.readyset.client
+  "Utilities for interacting with a ReadySet cluster"
+  (:require
+   [clojure.tools.logging :refer [info warn]]
+   [dom-top.core :refer [with-retry]]
+   [next.jdbc :as jdbc]
+   [slingshot.slingshot :refer [throw+]]
+   [clojure.set :as set])
+  (:import
+   (org.postgresql.util PSQLException)))
+
+(defn make-datasource
+  "Make a new JDBC DataSource for connecting to ReadySet, using the options
+  accepted by `jdbc/get-datasource`"
+  [db-info]
+  (jdbc/get-datasource
+   (assoc db-info
+          ;; Use simple queries where possible, so that we can run readyset
+          ;; commands (to work around REA-2960
+          :preferQueryMode "simple"
+          ;; Avoid sending `SET extra_float_digits = 3` on connection
+          ;; (see https://github.com/pgjdbc/pgjdbc/issues/168)
+          :assumeMinServerVersion "9.0")))
+
+(defn wait-for-connection
+  "Wait for a connection to the given ReadySet datasource (as creaated by
+  `make-datasource`) to succeed"
+  [ds]
+  (info "Waiting for ReadySet to be connectable")
+  (with-retry [attempts 5]
+    (jdbc/execute! ds ["show readyset version"])
+    (catch PSQLException e
+      (if (pos? attempts)
+        (do
+          (warn "Error connecting to readyset adapter:" (ex-message e))
+          (Thread/sleep 1000)
+          (retry (dec attempts)))
+        (throw+ {:error :retry-attempts-exceeded
+                 :exception e})))))
+
+(defn readyset-status
+  "Return the status of the ReadySet cluster for the given data source,
+  represented as a map giving the results of the `SHOW READYSET STATUS` command"
+  [ds]
+  (let [res (jdbc/execute! ds ["show readyset status"])]
+    (set/rename-keys
+     (into {} (map (juxt :name :value)) res)
+     {"Snapshot Status" :snapshot-status
+      "Maximum Replication Offset" :maximum-replication-offset
+      "Minimum Replication Offset" :minimum-replication-offset
+      "Last Started Controller" :last-started-controller
+      "Last Completed Snapshot" :last-completed-snapshot
+      "Last Started Replication" :last-started-replication})))
+
+(defn wait-for-snapshot-completed
+  "Wait for the ReadySet cluster at the given datasource to report that
+  snapshotting has completed"
+  [ds]
+  (wait-for-connection ds)
+  (info "Waiting for snapshot status = Completed")
+  (with-retry [attempts 5]
+    (let [{:keys [snapshot-status]} (readyset-status ds)]
+      (when-not (= snapshot-status "Completed")
+        (if (pos? attempts)
+          (do
+            (Thread/sleep 200)
+            (retry (dec attempts)))
+          (throw+ {:error :retry-attempts-exceeded}))))))
+
+(comment
+  (def --ds
+    (make-datasource {:dbtype "postgres"
+                      :dbname "jepsen"
+                      :user "postgres"
+                      :password "password"
+                      :host "aspen-jepsen-n1"
+                      :port 5432}))
+
+  (wait-for-connection --ds)
+
+  (readyset-status --ds)
+  )

--- a/jepsen/src/jepsen/readyset/model.clj
+++ b/jepsen/src/jepsen/readyset/model.clj
@@ -1,0 +1,29 @@
+(ns jepsen.readyset.model
+  "A Knossos Model for ReadySet eventual consistency"
+  (:require
+   [knossos.model :as model])
+  (:import
+   (knossos.model Model)))
+
+(defrecord
+    ^{:doc "A model for an eventually-consistent table with a single column.
+    Supports :write ops to write new rows, and :read ops to read the list of
+    rows out of the table"}
+    EventuallyConsistentTable [rows past-results]
+  Model
+  (step [this op]
+    (case (:f op)
+      :write (-> this
+                 (update :rows conj (:value op))
+                 (#(update % :past-results conj (sort (:rows %)))))
+      :read (let [results (sort (:value op))]
+              (if (or (nil? (:value op))
+                      (contains? past-results results))
+                this
+                (model/inconsistent (str "can't read " results
+                                         "; valid results: " past-results)))))))
+
+(defn eventually-consistent-table []
+  (map->EventuallyConsistentTable
+   {:rows []
+    :past-results #{[]}}))

--- a/jepsen/src/jepsen/readyset/nodes.clj
+++ b/jepsen/src/jepsen/readyset/nodes.clj
@@ -1,0 +1,55 @@
+(ns jepsen.readyset.nodes)
+
+(defn node->role
+  [test]
+  (zipmap
+   (:nodes test)
+   (concat [:node-role/load-balancer
+            :node-role/consul
+            :node-role/readyset-server
+            :node-role/upstream]
+           (repeat :node-role/readyset-adapter))))
+
+(defn role->node
+  [test]
+  (into {} (map (comp vec reverse)) (node->role test)))
+
+(defn node-role
+  "Given a test and a node in that test, returns what will be running on that
+  node for the test, represented as a keyword in
+  `#{:node-role/consul
+     :node-role/readyset-adapter
+     :node-role/load-balancer
+     :node-role/readyset-server
+     :node-role/upstream}`.
+
+  Note that we must always have at least 5 nodes to run a test.
+
+  Roles will be assigned to nodes in the following order:
+
+    1. `:node-role/load-balancer`
+    2. `:node-role/consul`
+    3. `:node-role/readyset-server`
+    4. `:node-role/upstream`
+    5. ... and all remaining nodes will have `:node-role/readyset-adapter`"
+  [test node]
+  (assert
+   (>= (count (:nodes test)) 5)
+   "Must have at least 5 nodes to run a high-availability ReadySet cluster")
+  (get (node->role test) node))
+
+(defn node-with-role
+  "Returns the node with the given role in the given test"
+  [test role]
+  (get (role->node test) role))
+
+(defn adapter-nodes
+  "Returns a sequence of adapter nodes in the given test"
+  [test]
+  (->> test :nodes (drop 4)))
+
+(defn num-adapters
+  "Returns the number of adapter instances that will be running in the given
+  test"
+  [test]
+  (- (count (:nodes test)) 4))

--- a/jepsen/test/readyset/jepsen_test.clj
+++ b/jepsen/test/readyset/jepsen_test.clj
@@ -1,0 +1,7 @@
+(ns readyset.jepsen-test
+  (:require [clojure.test :refer :all]
+            [readyset.jepsen :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))

--- a/psql-srv/src/codec/encoder.rs
+++ b/psql-srv/src/codec/encoder.rs
@@ -215,7 +215,7 @@ fn encode(message: BackendMessage, dst: &mut BytesMut) -> Result<(), Error> {
             set_i16(i16::try_from(n_values)?, dst, start_ofs + 5)?;
         }
 
-        PassThroughDataRow(row) => {
+        PassThroughSimpleRow(row) => {
             put_u8(ID_DATA_ROW, dst);
             // Put the length of this row in bytes. The length is equal to the length of the data,
             // plus 4 bytes for the length field itself and two bytes for the number of values in
@@ -894,7 +894,7 @@ mod tests {
         data.extend_from_slice(b"fake data for testing");
         codec
             .encode(
-                PassThroughDataRow(
+                PassThroughSimpleRow(
                     SimpleQueryRow::new(
                         vec![OwnedField::new("name".into(), 1, 2, 3, 4, 5, 6)].into(),
                         DataRowBody::new(data.into(), 1),

--- a/psql-srv/src/codec/encoder.rs
+++ b/psql-srv/src/codec/encoder.rs
@@ -358,7 +358,7 @@ fn encode(message: BackendMessage, dst: &mut BytesMut) -> Result<(), Error> {
             put_i16(i16::try_from(field_descriptions.len())?, dst);
             for d in field_descriptions {
                 put_str(&d.field_name, dst);
-                put_i32(d.table_id, dst);
+                put_u32(d.table_id, dst);
                 put_i16(d.col_id, dst);
                 put_type(d.data_type, dst)?;
                 put_i16(d.data_type_size, dst);

--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -123,6 +123,12 @@ pub struct Column {
     /// The name of the column
     pub name: SqlIdentifier,
 
+    /// The OID of the column's table, if known
+    pub table_oid: Option<u32>,
+
+    /// The attribute number of the column, if known
+    pub attnum: Option<i16>,
+
     /// The type of the column
     pub col_type: Type,
 }

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use nom_sql::SqlIdentifier;
 use postgres::error::ErrorPosition;
 pub use postgres::error::SqlState;
-use postgres::SimpleQueryRow;
+use postgres::{Row, SimpleQueryRow};
 use postgres_types::Type;
 use tokio_postgres::OwnedField;
 
@@ -83,6 +83,8 @@ pub enum BackendMessage {
     },
     PassThroughRowDescription(Vec<OwnedField>),
     PassThroughSimpleRow(SimpleQueryRow),
+    #[allow(unused)]
+    PassThroughDataRow(Row),
     SSLResponse {
         byte: u8,
     },

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -26,7 +26,7 @@ const SSL_RESPONSE_WILLING: u8 = b'S';
 /// * `R` - Represents a row of data values. `BackendMessage` implementations are provided wherein a
 ///   value of type `R` will, upon iteration, emit values that are convertible into type
 ///   `PsqlValue`, which can be serialized along with the rest of the `BackendMessage`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)] // TODO: benchmark if this matters
 pub enum BackendMessage {
     AuthenticationCleartextPassword,

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -82,7 +82,7 @@ pub enum BackendMessage {
         field_descriptions: Vec<FieldDescription>,
     },
     PassThroughRowDescription(Vec<OwnedField>),
-    PassThroughDataRow(SimpleQueryRow),
+    PassThroughSimpleRow(SimpleQueryRow),
     SSLResponse {
         byte: u8,
     },

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -128,7 +128,7 @@ pub enum ErrorSeverity {
 #[derive(Debug, PartialEq, Eq)]
 pub struct FieldDescription {
     pub field_name: SqlIdentifier,
-    pub table_id: i32,
+    pub table_id: u32,
     pub col_id: i16,
     pub data_type: Type,
     pub data_type_size: i16,

--- a/psql-srv/src/message/mod.rs
+++ b/psql-srv/src/message/mod.rs
@@ -9,3 +9,12 @@ pub enum TransferFormat {
     Binary,
     Text,
 }
+
+impl From<TransferFormat> for i16 {
+    fn from(value: TransferFormat) -> Self {
+        match value {
+            TransferFormat::Text => 0,
+            TransferFormat::Binary => 1,
+        }
+    }
+}

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -41,7 +41,7 @@ const TYPLEN_32: i16 = 32;
 const TYPLEN_VARLENA: i16 = -1;
 const TYPLEN_CSTRING: i16 = -2; // Null-terminated C string
 const UNKNOWN_COLUMN: i16 = 0;
-const UNKNOWN_TABLE: i32 = 0;
+const UNKNOWN_TABLE: u32 = 0;
 
 /// State machine for an ongoing SASL authentication flow
 ///
@@ -907,8 +907,8 @@ async fn make_field_description<B: PsqlBackend>(
 
     Ok(FieldDescription {
         field_name: col.name.clone(),
-        table_id: UNKNOWN_TABLE,
-        col_id: UNKNOWN_COLUMN,
+        table_id: col.table_oid.unwrap_or(UNKNOWN_TABLE),
+        col_id: col.attnum.unwrap_or(UNKNOWN_COLUMN),
         data_type: col.col_type.clone(),
         data_type_size,
         type_modifier: ATTTYPMOD_NONE,
@@ -1007,10 +1007,14 @@ mod tests {
                     schema: vec![
                         Column {
                             name: "col1".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::INT4,
                         },
                         Column {
                             name: "col2".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1039,10 +1043,14 @@ mod tests {
                     row_schema: vec![
                         Column {
                             name: "col1".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::INT4,
                         },
                         Column {
                             name: "col2".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1064,10 +1072,14 @@ mod tests {
                     schema: vec![
                         Column {
                             name: "col1".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::INT4,
                         },
                         Column {
                             name: "col2".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1548,10 +1560,14 @@ mod tests {
                 row_schema: vec![
                     Column {
                         name: "col1".into(),
+                        table_oid: None,
+                        attnum: None,
                         col_type: Type::INT4
                     },
                     Column {
                         name: "col2".into(),
+                        table_oid: None,
+                        attnum: None,
                         col_type: Type::FLOAT8
                     },
                 ],

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -636,7 +636,7 @@ impl Protocol {
                                         processing_select = true;
                                     }
                                     // Create a message for each row
-                                    messages.push(BackendMessage::PassThroughDataRow(row))
+                                    messages.push(BackendMessage::PassThroughSimpleRow(row))
                                 }
                                 SimpleQueryMessage::CommandComplete(CommandCompleteContents {
                                     fields,

--- a/psql-srv/src/response.rs
+++ b/psql-srv/src/response.rs
@@ -11,7 +11,7 @@ use crate::value::PsqlValue;
 /// An encapsulation of a complete response produced by a Postgresql backend in response to a
 /// request. The response will be sent to the frontend as a sequence of zero or more
 /// `BackendMessage`s.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[warn(variant_size_differences)]
 pub enum Response<S> {
     Empty,

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -60,6 +60,8 @@ impl PsqlBackend for ErrorBackend {
                 param_schema: vec![],
                 row_schema: vec![Column {
                     name: "x".into(),
+                    table_oid: None,
+                    attnum: None,
                     col_type: Type::BOOL,
                 }],
             })
@@ -76,6 +78,8 @@ impl PsqlBackend for ErrorBackend {
             ErrorPosition::Serialize => Ok(QueryResponse::Select {
                 schema: vec![Column {
                     name: "x".into(),
+                    table_oid: None,
+                    attnum: None,
                     col_type: Type::BOOL,
                 }],
                 resultset: stream::iter(vec![Err(Error::InternalError("factory".to_owned()))]),

--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -1,7 +1,7 @@
 name: readyset-mysql
 services:
   cache:
-    image: public.ecr.aws/readyset/readyset:beta-2023-07-26
+    image: public.ecr.aws/readyset/readyset:beta-latest
     platform: linux/amd64
     expose:
       - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -1,7 +1,7 @@
 name: readyset-postgres
 services:
   cache:
-    image: public.ecr.aws/readyset/readyset:beta-2023-07-26
+    image: public.ecr.aws/readyset/readyset:beta-latest
     platform: linux/amd64
     expose:
       - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -1,7 +1,7 @@
 name: readyset
 services:
   cache:
-    image: "public.ecr.aws/readyset/readyset:beta-2023-07-26"
+    image: "public.ecr.aws/readyset/readyset:beta-latest"
     platform: linux/amd64
     expose:
       - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -614,7 +614,6 @@ pub enum MigrationMode {
 
 #[derive(Debug, Clone)]
 pub struct SelectSchema<'a> {
-    pub use_bogo: bool,
     pub schema: Cow<'a, [ColumnSchema]>,
     pub columns: Cow<'a, [SqlIdentifier]>,
 }
@@ -622,7 +621,6 @@ pub struct SelectSchema<'a> {
 impl<'a> SelectSchema<'a> {
     pub fn into_owned(self) -> SelectSchema<'static> {
         SelectSchema {
-            use_bogo: self.use_bogo,
             schema: Cow::Owned(self.schema.into_owned()),
             columns: Cow::Owned(self.columns.into_owned()),
         }
@@ -1723,7 +1721,6 @@ where
             queries.retain(|q| &q.id.to_string() == q_id);
         }
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 create_dummy_column("query id"),
                 create_dummy_column("proxied query"),
@@ -1795,7 +1792,6 @@ where
         }
 
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 create_dummy_column("query id"),
                 create_dummy_column("cache name"),
@@ -2514,7 +2510,6 @@ where
             .collect();
 
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![create_dummy_column("query text")]),
             columns: Cow::Owned(vec!["query text".into()]),
         };

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1903,6 +1903,9 @@ where
             SqlQuery::Show(ShowStatement::ReadySetStatus) => {
                 self.noria.readyset_status(&self.authority).await
             }
+            SqlQuery::Show(ShowStatement::ReadySetMigrationStatus(id)) => {
+                self.noria.migration_status(*id).await
+            }
             SqlQuery::Show(ShowStatement::ReadySetVersion) => readyset_version(),
             SqlQuery::Show(ShowStatement::ReadySetTables) => self.noria.table_statuses().await,
             SqlQuery::Show(ShowStatement::ProxiedQueries(q_id)) => {

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1839,7 +1839,13 @@ where
                 name,
                 inner,
                 always,
+                concurrently,
             }) => {
+                if *concurrently {
+                    return Some(Err(unsupported_err!(
+                        "CREATE CACHE CONCURRENTLY not yet implemented"
+                    )));
+                }
                 let (stmt, search_path) = match inner {
                     Ok(CacheInner::Statement(st)) => (*st.clone(), None),
                     Ok(CacheInner::Id(id)) => {

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -538,7 +538,6 @@ impl NoriaConnector {
     pub(crate) async fn explain_domains(&mut self) -> ReadySetResult<QueryResult<'static>> {
         let domains = self.inner.get_mut()?.noria.domains().await?;
         let schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 ColumnSchema {
                     column: nom_sql::Column {
@@ -1010,7 +1009,6 @@ impl NoriaConnector {
         )?;
 
         let schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(
                 ["table", "status"]
                     .iter()
@@ -1775,8 +1773,6 @@ async fn do_read<'a>(
 
     Ok(QueryResult::from_iter(
         SelectSchema {
-            // TODO(vlad): looks like poor `use_bogo` is unused except in js? Should just remove it.
-            use_bogo: false,
             schema: Cow::Borrowed(
                 reader_handle
                     .schema()

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -984,6 +984,25 @@ impl NoriaConnector {
         ))
     }
 
+    /// Query the status of a pending migration identified by the given `migration_id`. Once the
+    /// function returns a result (completed or an error), calling again with the same id will lead
+    /// to undefined behavior.
+    pub(crate) async fn migration_status(
+        &mut self,
+        id: u64,
+    ) -> ReadySetResult<QueryResult<'static>> {
+        let status = noria_await!(
+            self.inner.get_mut()?,
+            self.inner.get_mut()?.noria.migration_status(id)
+        )?
+        .to_string();
+        Ok(QueryResult::Meta(vec![(
+            "Migration Status".to_string(),
+            status,
+        )
+            .into()]))
+    }
+
     pub(crate) async fn table_statuses(&mut self) -> ReadySetResult<QueryResult<'static>> {
         let statuses = noria_await!(
             self.inner.get_mut()?,

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -940,9 +940,12 @@ impl NoriaConnector {
         Ok(QueryResult::Empty)
     }
 
+    /// Returns status provided by the Controller and persisted in the Authority. Also appends
+    /// additional_meta provided by the caller to the status.
     pub(crate) async fn readyset_status(
         &mut self,
         authority: &Authority,
+        mut additional_meta: Vec<(String, String)>,
     ) -> ReadySetResult<QueryResult<'static>> {
         let mut status =
             match noria_await!(self.inner.get_mut()?, self.inner.get_mut()?.noria.status()) {
@@ -977,7 +980,8 @@ impl NoriaConnector {
             ));
         }
 
-        // Converts from ReadySetStatus -> Vec<(String, String)> -> QueryResult
+        status.append(&mut additional_meta);
+
         Ok(QueryResult::MetaVariables(
             status.into_iter().map(MetaVariable::from).collect(),
         ))

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -174,6 +174,7 @@ impl MigrationHandler {
                         &query.query().statement,
                         Some(query.query().schema_search_path.clone()),
                         false,
+                        false,
                     )
                     .await;
                 // Inform the query status cache of completed migrations
@@ -296,8 +297,10 @@ impl MigrationHandler {
                 &inlined_query,
                 Some(view_request.schema_search_path.clone()),
                 false,
+                false,
             )
-            .await
+            .await?;
+        Ok(())
     }
 
     async fn perform_dry_run_migration(&mut self, view_request: &ViewCreateRequest) {

--- a/readyset-adapter/src/upstream_database.rs
+++ b/readyset-adapter/src/upstream_database.rs
@@ -92,6 +92,9 @@ pub trait UpstreamDatabase: Sized + Send {
     /// Resets the connection with the upstream database
     async fn reset(&mut self) -> Result<(), Self::Error>;
 
+    /// Test the connection with the upstream database
+    async fn is_connected(&mut self) -> bool;
+
     /// Returns the SQL dialect for which to format queries.
     fn sql_dialect() -> nom_sql::Dialect;
 

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -701,6 +701,14 @@ impl ReadySetHandle {
         }
     }
 
+    /// Query the status of a pending migration identified by the given `migration_id`.
+    pub fn migration_status(
+        &mut self,
+        migration_id: u64,
+    ) -> impl Future<Output = ReadySetResult<MigrationStatus>> + '_ {
+        self.rpc::<_, MigrationStatus>("migration_status", migration_id, self.migration_timeout)
+    }
+
     /// Asynchronous version of extend_recipe(). The Controller should immediately return an ID that
     /// can be used to query the migration status.
     pub fn extend_recipe_async(

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -197,6 +197,7 @@ impl ChangeList {
                                 name,
                                 inner,
                                 always,
+                                ..
                             }) => {
                                 let statement = match inner {
                                     Ok(CacheInner::Statement(stmt)) => stmt,

--- a/readyset-client/src/recipe/mod.rs
+++ b/readyset-client/src/recipe/mod.rs
@@ -18,8 +18,23 @@ pub struct ExtendRecipeSpec<'a> {
     pub replication_offset: Option<Cow<'a, ReplicationOffset>>,
     /// Parameter that indicates if the leader is required to be ready before handling
     /// this RecipeSpec.
+    ///
     /// Defaults to true.
     pub require_leader_ready: bool,
+    /// Optional parameter to request a non-blocking migration. If set, the controller will return
+    /// immediately with an id that can be used to query the status of the migration.
+    ///
+    /// Defaults to false.
+    pub concurrently: bool,
+}
+
+impl<'a> ExtendRecipeSpec<'a> {
+    /// Sets the `concurrently` flag, requesting that the controller returns immediately with an id
+    /// that can be used to query the status of the migration.
+    pub fn concurrently(mut self) -> Self {
+        self.concurrently = true;
+        self
+    }
 }
 
 impl<'a> From<ChangeList> for ExtendRecipeSpec<'a> {
@@ -28,6 +43,7 @@ impl<'a> From<ChangeList> for ExtendRecipeSpec<'a> {
             changes,
             replication_offset: None,
             require_leader_ready: true,
+            concurrently: false,
         }
     }
 }

--- a/readyset-client/src/recipe/mod.rs
+++ b/readyset-client/src/recipe/mod.rs
@@ -3,7 +3,9 @@
 pub mod changelist;
 
 use std::borrow::Cow;
+use std::fmt::Display;
 
+use readyset_errors::ReadySetError;
 use serde::{Deserialize, Serialize};
 
 pub use crate::recipe::changelist::ChangeList;
@@ -59,12 +61,24 @@ pub enum ExtendRecipeResult {
 }
 
 /// The status of an actively running migration
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MigrationStatus {
     /// The migration has completed
     Done,
+    /// The migration has completed with an error
+    Failed(ReadySetError),
     /// The migration has not yet completed
     Pending,
+}
+
+impl Display for MigrationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MigrationStatus::Done => f.write_str("Completed"),
+            MigrationStatus::Failed(e) => write!(f, "Failed with error {e}"),
+            MigrationStatus::Pending => f.write_str("Pending"),
+        }
+    }
 }
 
 impl MigrationStatus {

--- a/readyset-client/src/view.rs
+++ b/readyset-client/src/view.rs
@@ -148,6 +148,10 @@ pub struct ColumnBase {
     pub table: Relation,
     /// A list of constraints on the column
     pub constraints: Vec<ColumnConstraint>,
+    /// If known, the PostgreSQL OID for the column's base table
+    pub table_oid: Option<u32>,
+    /// If known, the PostgreSQL `attnum` for the column
+    pub attnum: Option<i16>,
 }
 
 /// Combines the specification for a columns with its base name
@@ -174,6 +178,8 @@ impl ColumnSchema {
                 column: spec.column.name.clone(),
                 table,
                 constraints: spec.constraints,
+                table_oid: None,
+                attnum: None,
             }),
             column: spec.column,
             column_type: DfType::from_sql_type(
@@ -2083,6 +2089,8 @@ mod tests {
                             table: "t".into(),
                             column: "x".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                     ColumnSchema {
@@ -2095,6 +2103,8 @@ mod tests {
                             table: "t".into(),
                             column: "y".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                 ],
@@ -2109,6 +2119,8 @@ mod tests {
                             table: "t".into(),
                             column: "x".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                     ColumnSchema {
@@ -2121,6 +2133,8 @@ mod tests {
                             table: "t".into(),
                             column: "y".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                 ],

--- a/readyset-clustertest/src/lib.rs
+++ b/readyset-clustertest/src/lib.rs
@@ -1330,7 +1330,7 @@ impl DeploymentHandle {
 
         self.adapters.push(AdapterHandle {
             metrics_port,
-            conn_str: format!("mysql://127.0.0.1:{}", port),
+            conn_str: format!("{}://127.0.0.1:{}/{}", database_type, port, &self.name),
             process,
         });
 

--- a/readyset-clustertest/src/readyset.rs
+++ b/readyset-clustertest/src/readyset.rs
@@ -495,16 +495,17 @@ async fn server_auto_restarts() {
 async fn assert_deployment_health(mut dh: DeploymentHandle) {
     let mut adapter = dh.first_adapter().await;
     adapter
-        .query_drop(
-            r"CREATE TABLE t1 (
-        uid INT NOT NULL,
-        value INT NOT NULL
-    );",
-        )
+        .query_drop(format!(
+            r"CREATE TABLE {}.t1 (
+                uid INT NOT NULL,
+                value INT NOT NULL
+            );",
+            dh.name()
+        ))
         .await
         .unwrap();
     adapter
-        .query_drop(r"INSERT INTO t1 VALUES (1, 4);")
+        .query_drop(format!(r"INSERT INTO {}.t1 VALUES (1, 4);", dh.name()))
         .await
         .unwrap();
 

--- a/readyset-mysql/src/query_handler.rs
+++ b/readyset-mysql/src/query_handler.rs
@@ -850,7 +850,6 @@ impl QueryHandler for MySqlQueryHandler {
                     format!("@@{}", MAX_ALLOWED_PACKET_VARIABLE_NAME).into();
                 Ok(QueryResult::from_owned(
                     SelectSchema {
-                        use_bogo: false,
                         schema: Cow::Owned(vec![ColumnSchema {
                             column: Column {
                                 name: field_name.clone(),
@@ -865,7 +864,6 @@ impl QueryHandler for MySqlQueryHandler {
                 ))
             }
             _ => Ok(QueryResult::empty(SelectSchema {
-                use_bogo: false,
                 schema: Cow::Owned(vec![]),
                 columns: Cow::Owned(vec![]),
             })),

--- a/readyset-mysql/src/upstream.rs
+++ b/readyset-mysql/src/upstream.rs
@@ -285,6 +285,10 @@ impl UpstreamDatabase for MySqlUpstream {
         Ok(())
     }
 
+    async fn is_connected(&mut self) -> bool {
+        self.conn.ping().await.is_ok()
+    }
+
     /// Prepares the given query using the mysql connection. Note, queries are prepared on a
     /// per connection basis. They are not universal.
     async fn prepare<'a, 'b, S>(

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -153,6 +153,8 @@ impl PsqlBackend for Backend {
                         .map(|col| psql_srv::Column {
                             name: col.name().into(),
                             col_type: col.type_().clone(),
+                            table_oid: None,
+                            attnum: None,
                         })
                         .collect()
                 })
@@ -181,6 +183,8 @@ impl PsqlBackend for Backend {
                 .map(|c| psql_srv::Column {
                     name: c.name().into(),
                     col_type: c.type_().clone(),
+                    table_oid: None,
+                    attnum: None,
                 })
                 .collect(),
         };
@@ -223,6 +227,8 @@ impl PsqlBackend for Backend {
                     .map(|col| psql_srv::Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
+                        table_oid: None,
+                        attnum: None,
                     })
                     .collect()
             })

--- a/readyset-psql/src/query_handler.rs
+++ b/readyset-psql/src/query_handler.rs
@@ -347,7 +347,6 @@ impl QueryHandler for PostgreSqlQueryHandler {
 
     fn default_response(_: &SqlQuery) -> ReadySetResult<QueryResult<'static>> {
         Ok(noria_connector::QueryResult::empty(SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![]),
             columns: Cow::Owned(vec![]),
         }))

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -94,7 +94,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 let columns = vars.iter().map(|v| v.name.clone()).collect::<Vec<_>>();
 
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(
                         vars.iter()
                             .map(|v| ColumnSchema {
@@ -124,7 +123,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
             }
             Noria(NoriaResult::MetaVariables(vars)) => {
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(vec![
                         ColumnSchema {
                             column: nom_sql::Column {
@@ -163,7 +161,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 let (col1_header, col2_header): (SqlIdentifier, SqlIdentifier) =
                     (vars[0].name.clone(), vars[0].value.clone().into());
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(vec![
                         ColumnSchema {
                             column: nom_sql::Column {

--- a/readyset-psql/src/resultset.rs
+++ b/readyset-psql/src/resultset.rs
@@ -148,7 +148,6 @@ mod tests {
     async fn create_resultset() {
         let results = vec![];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,
@@ -168,7 +167,6 @@ mod tests {
     async fn stream_resultset() {
         let results = vec![Results::new(vec![vec![DfValue::Int(10)]])];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,
@@ -191,7 +189,6 @@ mod tests {
             Results::new(vec![vec![DfValue::Int(11)], vec![DfValue::Int(12)]]),
         ];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,

--- a/readyset-psql/src/schema.rs
+++ b/readyset-psql/src/schema.rs
@@ -15,15 +15,7 @@ pub struct SelectSchema<'a>(pub cl::SelectSchema<'a>);
 impl<'a> TryFrom<SelectSchema<'a>> for Vec<ps::Column> {
     type Error = Error;
     fn try_from(s: SelectSchema) -> Result<Self, Self::Error> {
-        s.0.schema
-            .iter()
-            .map(|c| {
-                Ok(ps::Column {
-                    name: c.column.name.clone(),
-                    col_type: type_to_pgsql(&c.column_type)?,
-                })
-            })
-            .collect()
+        NoriaSchema(&s.0.schema).try_into()
     }
 }
 
@@ -50,6 +42,8 @@ impl<'a> TryFrom<NoriaSchema<'a>> for Vec<ps::Column> {
                 Ok(ps::Column {
                     name: c.column.name.clone(),
                     col_type: type_to_pgsql(&c.column_type)?,
+                    table_oid: c.base.as_ref().and_then(|b| b.table_oid),
+                    attnum: c.base.as_ref().and_then(|b| b.attnum),
                 })
             })
             .collect()

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -258,10 +258,8 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                     Ok(Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
-                        // TODO: Load the following two fields from upstream, once tokio-postgres
-                        // provides them
-                        table_oid: None,
-                        attnum: None,
+                        table_oid: col.table_oid(),
+                        attnum: col.column_id(),
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -258,6 +258,10 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                     Ok(Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
+                        // TODO: Load the following two fields from upstream, once tokio-postgres
+                        // provides them
+                        table_oid: None,
+                        attnum: None,
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -307,6 +307,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                 .generic_query_raw(
                     statement,
                     &convert_params_for_upstream(params, statement.params())?,
+                    Some(1), // Hardcode to binary for now
                 )
                 .await?,
         );

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -229,6 +229,11 @@ impl UpstreamDatabase for PostgreSqlUpstream {
         drop(old_self);
         Ok(())
     }
+
+    async fn is_connected(&mut self) -> bool {
+        !self.client.is_closed()
+    }
+
     // Returns the upstream server's version, with ReadySet's info appended, to indicate to clients
     // that they're going via ReadySet
     fn version(&self) -> String {

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -680,7 +680,6 @@ async fn deletion_propagation_after_alter() {
     shutdown_tx.shutdown().await;
 }
 
-#[ignore = "ENG-3041 Test reproduces write drop due to known bug"]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn write_propagation_after_alter_and_drop() {

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -1696,4 +1696,61 @@ mod multiple_create_and_drop {
 
         shutdown_tx.shutdown().await;
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn create_cache_concurrently() {
+        use tokio_postgres::{SimpleQueryMessage, SimpleQueryRow};
+        fn extract_single_value(mut rows: Vec<SimpleQueryMessage>) -> SimpleQueryRow {
+            match rows.swap_remove(0) {
+                SimpleQueryMessage::Row(r) => r,
+                _ => panic!(),
+            }
+        }
+
+        readyset_tracing::init_test_logging();
+        let (opts, _handle, shutdown_tx) = setup().await;
+        let conn = connect(opts).await;
+
+        conn.simple_query("CREATE TABLE t (a int)").await.unwrap();
+        let valid_cache = extract_single_value(
+            conn.simple_query("CREATE CACHE CONCURRENTLY FROM SELECT a FROM t")
+                .await
+                .unwrap(),
+        );
+
+        let invalid_cache = extract_single_value(
+            conn.simple_query("CREATE CACHE CONCURRENTLY FROM SELECT b FROM t")
+                .await
+                .unwrap(),
+        );
+
+        eventually!(
+            run_test: {
+                extract_single_value(
+                    conn.simple_query(&format!(
+                        "SHOW READYSET MIGRATION STATUS {}",
+                        valid_cache.get(0).unwrap()
+                    ))
+                    .await
+                    .unwrap()
+                )
+            },
+            then_assert: |completed| assert_eq!(completed.get(0).unwrap(), "Completed")
+        );
+        eventually!(
+            run_test: {
+                extract_single_value(
+                    conn.simple_query(&format!(
+                        "SHOW READYSET MIGRATION STATUS {}",
+                        invalid_cache.get(0).unwrap()
+                    ))
+                    .await
+                    .unwrap(),
+                )
+            },
+            then_assert: |failed| assert_eq!(&failed.get(0).unwrap()[..6], "Failed")
+        );
+
+        shutdown_tx.shutdown().await;
+    }
 }

--- a/readyset-server/src/controller/schema.rs
+++ b/readyset-server/src/controller/schema.rs
@@ -5,7 +5,7 @@ use readyset_data::DfType;
 use tracing::trace;
 
 use super::keys::provenance_of;
-use super::sql::{Recipe, Schema};
+use super::sql::{BaseSchema, Recipe, Schema};
 
 type Path<'a> = &'a [(
     petgraph::graph::NodeIndex,
@@ -57,18 +57,20 @@ fn get_base_for_column(
 
         let source_node = &graph[*ni];
         if source_node.is_base() {
-            if let Some(Schema::Table(schema)) = recipe.schema_for(source_node.name()) {
+            if let Some(Schema::Table(BaseSchema { statement, .. })) =
+                recipe.schema_for(source_node.name())
+            {
                 let col_index = cols.first().unwrap().unwrap();
                 #[allow(clippy::unwrap_used)] // occurs after implied table rewrite
                 return Ok(Some(ColumnBase {
-                    column: schema.fields[col_index].column.name.clone(),
-                    table: schema.fields[col_index]
+                    column: statement.fields[col_index].column.name.clone(),
+                    table: statement.fields[col_index]
                         .column
                         .table
                         .as_ref()
                         .unwrap()
                         .clone(),
-                    constraints: schema.fields[col_index].constraints.clone(),
+                    constraints: statement.fields[col_index].constraints.clone(),
                 }));
             }
         }

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -1,8 +1,8 @@
 use std::str;
 
 use nom_sql::{
-    CacheInner, CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
-    Relation, SqlIdentifier, SqlQuery,
+    CacheInner, CreateCacheStatement, CreateTableStatement, CreateViewStatement, Relation,
+    SqlIdentifier, SqlQuery,
 };
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::ChangeList;
@@ -14,6 +14,7 @@ use tracing::warn;
 use vec1::Vec1;
 
 use super::registry::{MatchedCache, RecipeExpr};
+use super::BaseSchema;
 use crate::controller::sql::SqlIncorporator;
 use crate::controller::Migration;
 
@@ -36,7 +37,7 @@ impl PartialEq for Recipe {
 
 #[derive(Debug)]
 pub(crate) enum Schema<'a> {
-    Table(&'a CreateTableBody),
+    Table(&'a BaseSchema),
     View(&'a [SqlIdentifier]),
 }
 
@@ -44,7 +45,7 @@ impl Recipe {
     /// Get the id associated with an alias
     pub(crate) fn expression_by_alias(&self, alias: &Relation) -> Option<SqlQuery> {
         let expr = self.inc.registry.get(alias).map(|e| match e {
-            RecipeExpr::Table { name, body } => SqlQuery::CreateTable(CreateTableStatement {
+            RecipeExpr::Table { name, body, .. } => SqlQuery::CreateTable(CreateTableStatement {
                 if_not_exists: false,
                 table: name.clone(),
                 body: Ok(body.clone()),

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -65,6 +65,7 @@ impl Recipe {
                 name: Some(name.clone()),
                 inner: Ok(CacheInner::Statement(Box::new(statement.clone()))),
                 always: *always,
+                concurrently: false, // concurrently not relevant after migrating
             }),
         });
         if expr.is_none() {

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -634,7 +634,7 @@ impl DfState {
             .schema_for(base)
             .map(|s| -> ReadySetResult<_> {
                 match s {
-                    Schema::Table(s) => Ok(s.clone()),
+                    Schema::Table(s) => Ok(s.statement.clone()),
                     _ => internal!(
                         "non-base schema {:?} returned for table {}",
                         s,

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -3804,7 +3804,8 @@ async fn finkelstein1982_queries() {
                     let stmt = inc
                         .rewrite(stmt, &[], Dialect::DEFAULT_MYSQL, None)
                         .unwrap();
-                    inc.add_table(stmt.table, stmt.body.unwrap(), mig).unwrap();
+                    inc.add_table(stmt.table, stmt.body.unwrap(), None, mig)
+                        .unwrap();
                 }
                 SqlQuery::Select(stmt) => {
                     inc.add_query(None, stmt, false, &[], mig).unwrap();

--- a/readyset-sql-passes/src/anonymize.rs
+++ b/readyset-sql-passes/src/anonymize.rs
@@ -199,6 +199,7 @@ impl<'ast> VisitorMut<'ast> for AnonymizeVisitor<'_> {
             | nom_sql::ShowStatement::CachedQueries(..)
             | nom_sql::ShowStatement::ProxiedQueries(..)
             | nom_sql::ShowStatement::ReadySetStatus
+            | nom_sql::ShowStatement::ReadySetMigrationStatus(..)
             | nom_sql::ShowStatement::ReadySetVersion
             | nom_sql::ShowStatement::ReadySetTables => {}
         }

--- a/readyset-sql-passes/src/lib.rs
+++ b/readyset-sql-passes/src/lib.rs
@@ -66,7 +66,7 @@ pub struct RewriteContext<'a> {
     /// Map from names of *tables* in the database, to the body of the `CREATE TABLE` statement
     /// that was used to create that table. Each key in this map should also exist in
     /// [`view_schemas`].
-    pub base_schemas: &'a HashMap<Relation, CreateTableBody>,
+    pub base_schemas: HashMap<&'a Relation, &'a CreateTableBody>,
 
     /// List of views that are known to exist but have not yet been compiled (so we can't know
     /// their fields yet)
@@ -171,7 +171,7 @@ impl Rewrite for SelectStatement {
             .normalize_topk_with_aggregate()?
             .detect_problematic_self_joins()?
             .remove_numeric_field_references()?
-            .order_limit_removal(context.base_schemas)
+            .order_limit_removal(&context.base_schemas)
     }
 }
 

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -287,6 +287,7 @@ impl NoriaAdapter {
         let table_filter = TableFilter::try_new(
             nom_sql::Dialect::MySQL,
             config.replication_tables.take(),
+            config.replication_tables_ignore.take(),
             mysql_options.db_name(),
         )?;
 
@@ -497,6 +498,7 @@ impl NoriaAdapter {
         let table_filter = TableFilter::try_new(
             nom_sql::Dialect::PostgreSQL,
             config.replication_tables.take(),
+            config.replication_tables_ignore.take(),
             None,
         )?;
 


### PR DESCRIPTION
After running the main test, sleep for 15 seconds to wait for dataflow
to converge, then perform a single "final read" op, which must be
consistent with the contents of the table (not just eventually
consistent).

Fixes: REA-3368
