### PR TITLE
jepsen: Break out ReadySet automation into its own ns

### DIFF
--- a/jepsen/src/jepsen/readyset/automation.clj
+++ b/jepsen/src/jepsen/readyset/automation.clj
@@ -1,0 +1,100 @@
+(ns jepsen.readyset.automation
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen.control :as c]
+            [jepsen.control.net :as net]
+            [jepsen.control.util :as cu]
+            [jepsen.os.debian :as debian]
+            [jepsen.readyset.client :as rs]
+            [jepsen.readyset.nodes :as nodes]))
+
+(defn ensure-git-cloned
+  "Ensure that a git repository `repo` is cloned at ref `ref` in dir `dir`"
+  [repo ref dir]
+  (debian/install ["git"])
+
+  (when (and (cu/exists? dir)
+             (not (cu/exists? (str dir "/.git"))))
+    (c/exec :rm :-rf dir))
+  (letfn [(git [& args] (apply c/exec :git :-C dir args))]
+    (if (cu/exists? dir)
+      (git :fetch :origin)
+      (c/exec :git :clone repo dir))
+    (git :checkout ref)))
+
+(defn compile-and-install-readyset-binary!
+  [node ref bin & [{:keys [force?] :or {force? false}}]]
+  (if (and
+       (cu/file? (str "/usr/local/bin/" bin))
+       (not force?))
+    (info node bin "already exists, not re-installing")
+    (c/su
+     (debian/install ["clang"
+                      "libclang-dev"
+                      "libssl-dev"
+                      "liblz4-dev"
+                      "build-essential"
+                      "pkg-config"])
+     (c/exec* "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+     (ensure-git-cloned
+      "https://github.com/readysettech/readyset.git"
+      ref
+      "/opt/readyset")
+     (c/exec* "~/.cargo/bin/rustup install $(</opt/readyset/rust-toolchain)")
+     (info node "compiling" bin)
+     (c/cd "/opt/readyset"
+           (c/exec "~/.cargo/bin/cargo" "build" "--release" "--bin" bin)
+           (c/exec "mv"
+                   (str "target/release/" bin)
+                   "/usr/local/bin/")))))
+
+
+(defn authority-address
+  [test]
+  (str (name (nodes/node-with-role test :node-role/consul))
+       ":8500"))
+
+(defn upstream-db-url
+  "Returns the upstream DB URL for the given test"
+  [test]
+  (str "postgresql://"
+       rs/pguser ":" rs/pgpassword
+       "@" (nodes/node-with-role test :node-role/upstream)
+       "/" rs/pgdatabase))
+
+(defn start-readyset-adapter! [node test]
+  (c/su
+   (cu/start-daemon!
+    {:logfile "/var/log/readyset.log"
+     :pidfile "/var/run/readyset.pid"
+     :chdir "/"}
+    "/usr/local/bin/readyset"
+    :--log-level (:log-level test "info")
+    :--deployment "jepsen"
+    :-a "0.0.0.0:5432"
+    :--controller-address "0.0.0.0"
+    :--external-address (net/ip (name node))
+    :--authority-address (authority-address test)
+    :--upstream-db-url (upstream-db-url test)
+    :--disable-upstream-ssl-verification
+    :--embedded-readers
+    :--reader-replicas (str (nodes/num-adapters test)))))
+
+(defn start-readyset-server! [node test]
+  (c/su
+   (c/exec :mkdir :-p "/opt/readyset/data")
+   (cu/start-daemon!
+    {:logfile "/var/log/readyset-server.log"
+     :pidfile "/var/run/readyset-server.pid"
+     :chdir "/"}
+    "/usr/local/bin/readyset-server"
+    :--log-level (:log-level test "info")
+    :--deployment "jepsen"
+    :--db-dir "/opt/readyset/data"
+    :-a "0.0.0.0"
+    :--external-address (net/ip (name node))
+    :--authority-address (authority-address test)
+    :--upstream-db-url (upstream-db-url test)
+    :--allow-full-materialization
+    :--disable-upstream-ssl-verification
+    :--no-readers
+    :--reader-replicas (str (nodes/num-adapters test)))))


### PR DESCRIPTION
Break out the functions for installing and starting the readyset server
and adapter into a new jepsen.readyset.automation ns, in preparation for
adding additional functions to this ns to kill readyset.

