### PR TITLE
dataflow-state: Initialize new weak indexes with existing rows

### DIFF
--- a/readyset-mysql/tests/integration.rs
+++ b/readyset-mysql/tests/integration.rs
@@ -36,8 +36,9 @@ async fn setup_telemetry() -> (TelemetryReporter, mysql_async::Opts, Handle, Shu
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Reproduces known failure (REA-3207)"]
 async fn duplicate_join_key() {
+    // This used to trigger a bug involving weak indexes. See issue #179 for more info.
+
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
 


### PR DESCRIPTION
Since weak indexes are supposed to index every materialized row, we need
to make sure that we take existing materialized data into account when
we create a new weak index.

Fixes: #179
Release-Note-Core: Fixed an issue where ReadySet could crash or return
  incorrect data in certain situations when multiple rows shared the
  same value in a join column for a cached query.
