### PR TITLE
jepsen: clj-kondo lint

### DIFF
--- a/jepsen/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/jepsen/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,0 +1,5 @@
+{:hooks
+ {:analyze-call
+  {next.jdbc/with-transaction
+   hooks.com.github.seancorfield.next-jdbc/with-transaction}}
+ :lint-as {next.jdbc/on-connection clojure.core/with-open}}

--- a/jepsen/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
+++ b/jepsen/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj_kondo
@@ -1,0 +1,18 @@
+(ns hooks.com.github.seancorfield.next-jdbc
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-transaction
+  "Expands (with-transaction [tx expr opts] body)
+  to (let [tx expr] opts body) per clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/jepsen/.clj-kondo/config.edn
+++ b/jepsen/.clj-kondo/config.edn
@@ -1,0 +1,4 @@
+{:lint-as {dom-top.core/with-retry clojure.core/let}
+ :linters
+ {:unresolved-symbol
+  {:exclude [e retry]}}}

--- a/jepsen/.gitignore
+++ b/jepsen/.gitignore
@@ -1,0 +1,9 @@
+/target
+/classes
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+/.prepl-port
+/.cpcache
+/store

--- a/jepsen/.gitignore
+++ b/jepsen/.gitignore
@@ -7,3 +7,4 @@
 /.prepl-port
 /.cpcache
 /store
+/.clj-kondo/.cache

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -9,6 +9,7 @@
                  [com.github.seancorfield/next.jdbc "1.3.883"]
                  [org.postgresql/postgresql "42.6.0"]
                  [slingshot "0.12.2"]]
+  :plugins [[com.github.clj-kondo/lein-clj-kondo "0.2.5"]]
   :repl-options {:init-ns jepsen.readyset}
   :main jepsen.readyset
   :resource-paths ["resources"])

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,0 +1,14 @@
+(defproject jepsen.readyset "0.1.0-SNAPSHOT"
+  :description "ReadySet Jepsen test"
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [jepsen "0.3.3-SNAPSHOT"]
+
+                 [base64-clj "0.1.1"]
+                 [cheshire "5.9.0"]
+                 [clj-http "3.10.0"]
+                 [com.github.seancorfield/next.jdbc "1.3.883"]
+                 [org.postgresql/postgresql "42.6.0"]
+                 [slingshot "0.12.2"]]
+  :repl-options {:init-ns jepsen.readyset}
+  :main jepsen.readyset
+  :resource-paths ["resources"])

--- a/jepsen/resources/haproxy.cfg.tpl
+++ b/jepsen/resources/haproxy.cfg.tpl
@@ -1,0 +1,17 @@
+global
+    daemon
+    maxconn 256
+defaults
+    mode http
+    timeout connect 5000ms
+    timeout client 50000ms
+    timeout server 50000ms
+frontend readyset_frontend
+    bind *:5432
+    mode tcp
+    option tcplog
+    default_backend readyset_backend
+backend readyset_backend
+    mode tcp
+    balance roundrobin
+    ${servers}

--- a/jepsen/src/jepsen/consul/client.clj
+++ b/jepsen/src/jepsen/consul/client.clj
@@ -1,0 +1,130 @@
+(ns jepsen.consul.client
+  "Taken from https://github.com/jepsen-io/jepsen/blob/main/consul/src/jepsen/consul/client.clj"
+  (:refer-clojure :exclude [get])
+  (:require [clojure.tools.logging :refer [warn]]
+            [jepsen.control.net :as net]
+            [base64-clj.core :as base64]
+            [cheshire.core :as json]
+            [clj-http.client :as http]
+            [dom-top.core :refer [with-retry]]
+            [slingshot.slingshot :refer [throw+]]))
+
+(defn maybe-int [value]
+  (if (= value "null")
+      nil
+      (Integer. value)))
+
+(defn parse-index [resp]
+  (-> resp
+      :headers
+      (clojure.core/get "X-Consul-Index")
+      Integer.))
+
+(defn parse-body
+  "Parse the base64 encoded value.
+   The response JSON looks like:
+    [
+     {
+       \"CreateIndex\": 100,
+       \"ModifyIndex\": 200,
+       \"Key\": \"foo\",
+       \"Flags\": 0,
+       \"Value\": \"YmFy\"
+     }
+    ]
+  "
+  [resp]
+  (let [body  (-> resp
+                  :body
+                  (json/parse-string #(keyword (.toLowerCase %)))
+                  first)
+        value (-> body :value base64/decode maybe-int)]
+    (assoc body :value value)))
+
+(defn parse [response]
+  (assoc (parse-body response)
+         :index (parse-index response)))
+
+(defn get
+  ([url]
+   (http/get url))
+  ([url key]
+   (http/get (str url key)))
+  ([url key consistency]
+   (http/get (str url key)
+             {:query-params {(keyword consistency) nil}})))
+
+(defn put!
+  ([url key value]
+   (http/put (str url key) {:body value}))
+  ([url key value consistency]
+   (http/put (str url key)
+             {:body value
+              :query-params {(keyword consistency) nil}})))
+
+(defn cas!
+  "Consul uses an index based CAS, not a value-based CAS, so we must first get
+  the existing index for this the current key and then use the index to issue a
+  CAS request."
+  ([url key value new-value]
+   (let [res (parse (get url key))
+         existing-value (str (:value res))
+         index (:index res)]
+     (if (= existing-value value)
+       (let [params {:body new-value :query-params {:cas index}}
+             body (:body (http/put (str url key) params))]
+         (= body "true"))
+       false)))
+
+  ([url key value new-value consistency]
+   (let [res (parse (get url key consistency))
+         existing-value (str (:value res))
+         index (:index res)]
+     (if (= existing-value value)
+       (let [params {:body new-value :query-params {:cas index
+                                                    :query-params {(keyword consistency) nil}}}
+             body (:body (http/put (str url key) params))]
+         (= body "true"))
+       false))))
+
+(defn txn
+  "TODO Model txn requests when we get to testing that part of Consul"
+  [])
+
+(defmacro with-errors
+  [op idempotent & body]
+  `(try ~@body
+        (catch Exception e#
+            (let [type# (if (~idempotent (:f ~op))
+                         :fail
+                         :info)]
+              (condp re-find (.getMessage e#)
+                #"404" (assoc ~op :type type# :error :key-not-found)
+                #"403" (assoc ~op :type type# :error :not-authorized)
+                #"500" (assoc ~op :type type# :error :server-unavailable)
+                (throw e#))))))
+
+(defn await-cluster-ready
+  "Blocks until cluster index matches count of nodes on test."
+  [node count]
+  (let [url (str "http://" (net/ip (name node)) ":8500/v1/catalog/nodes?index=" count)]
+     (with-retry [attempts 5]
+       (get url)
+
+       ;; We got an application-level response, let's proceed!
+       (catch clojure.lang.ExceptionInfo e
+         (if (and (= (.getMessage e) "clj-http: status 500")
+                  (< 0 attempts))
+           (retry (dec attempts))
+           (throw+ {:error :retry-attempts-exceeded :exception e})))
+
+       ;; Cluster not converged yet, let's keep waiting
+       (catch java.net.ConnectException e
+         (if (< 0 attempts)
+           (do
+             ;; TODO It would be nice to remove this log warning if we don't have connection issues anymore
+             (warn "Connection refused from node:" node ", retrying. Attempts remaining:" attempts)
+             (Thread/sleep 200)
+             (retry (dec attempts)))
+           (throw+ {:error :retry-attempts-exceeded :exception e})))))
+  true)

--- a/jepsen/src/jepsen/consul/db.clj
+++ b/jepsen/src/jepsen/consul/db.clj
@@ -1,0 +1,70 @@
+(ns jepsen.consul.db
+  "Adapted from https://github.com/jepsen-io/jepsen/blob/main/consul/src/jepsen/consul/db.clj"
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen.consul.client :as client]
+            [jepsen.core :as jepsen]
+            [jepsen.db :as db]
+            [jepsen.control :as c]
+            [jepsen.control.net :as net]
+            [jepsen.control.util :as cu]))
+
+(def dir "/opt")
+(def binary "consul")
+(def config-file "/opt/consul.json")
+(def pidfile "/var/run/consul.pid")
+(def logfile "/var/log/consul.log")
+(def data-dir "/var/lib/consul")
+
+(def retry-interval "5s")
+
+(defn start-consul!
+  [node]
+  (info node "starting consul")
+  (cu/start-daemon!
+   {:logfile logfile
+    :pidfile pidfile
+    :chdir   dir}
+   binary
+   :agent
+   :-server
+   :-log-level "debug"
+   :-client    "0.0.0.0"
+   :-bind      (net/ip (name node))
+   :-data-dir  data-dir
+   :-node      (name node)
+   :-retry-interval retry-interval
+   :-bootstrap
+   :>> logfile
+   (c/lit "2>&1")))
+
+(defn db
+  "Install and cleanup a specific version of consul"
+  [version]
+  (reify db/DB
+    (setup! [_ test node]
+      (info node "installing consul" version)
+      (c/su
+       (let [url (str "https://releases.hashicorp.com/consul/"
+                      version "/consul_" version "_linux_amd64.zip")]
+         (cu/install-archive! url (str dir "/" binary)))
+
+       (start-consul! node))
+
+      (info "Waiting for cluster to converge")
+      (client/await-cluster-ready node 1)
+
+      #_(jepsen/synchronize test))
+
+    (teardown! [_ _test node]
+      (c/su
+       (cu/stop-daemon! binary pidfile)
+       (info node "consul killed")
+
+       (c/exec :rm :-rf pidfile logfile data-dir (str dir "/" binary) config-file)
+       (c/su
+        (c/exec :rm :-rf binary)))
+      (info node "consul nuked"))
+
+    db/LogFiles
+    (log-files [_ _test _node]
+      [logfile])))

--- a/jepsen/src/jepsen/consul/db.clj
+++ b/jepsen/src/jepsen/consul/db.clj
@@ -2,7 +2,6 @@
   "Adapted from https://github.com/jepsen-io/jepsen/blob/main/consul/src/jepsen/consul/db.clj"
   (:require [clojure.tools.logging :refer [info]]
             [jepsen.consul.client :as client]
-            [jepsen.core :as jepsen]
             [jepsen.db :as db]
             [jepsen.control :as c]
             [jepsen.control.net :as net]
@@ -41,7 +40,7 @@
   "Install and cleanup a specific version of consul"
   [version]
   (reify db/DB
-    (setup! [_ test node]
+    (setup! [_ _test node]
       (info node "installing consul" version)
       (c/su
        (let [url (str "https://releases.hashicorp.com/consul/"

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -251,7 +251,7 @@
     :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
             #_"refs/tags/beta-2023-07-26")
     :client (rs/new-client)
-    :generator (->> rs/r
+    :generator (->> (gen/mix [rs/r rs/w])
                     (gen/stagger 1)
                     (gen/nemesis nil)
                     (gen/time-limit 15))

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.tools.logging :refer [error info warn]]
+   [jepsen.checker :as checker]
    [jepsen.cli :as cli]
    [jepsen.consul.db :as consul.db]
    [jepsen.control :as c]
@@ -15,6 +16,7 @@
    [jepsen.os.debian :as debian]
    [jepsen.os.ubuntu :as ubuntu]
    [jepsen.readyset.client :as rs]
+   [jepsen.readyset.model :as rs.model]
    [jepsen.readyset.nodes :as nodes]
    [jepsen.tests :as tests]
    [slingshot.slingshot :refer [try+]]))
@@ -251,6 +253,9 @@
     :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
             #_"refs/tags/beta-2023-07-26")
     :client (rs/new-client)
+    :checker (checker/linearizable
+              {:model (rs.model/eventually-consistent-table)
+               :algorithm :linear})
     :generator (->> (gen/mix [rs/r rs/w])
                     (gen/stagger 1)
                     (gen/nemesis nil)

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -1,0 +1,331 @@
+(ns jepsen.readyset
+  (:gen-class)
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.tools.logging :refer [error info warn]]
+   [jepsen.cli :as cli]
+   [jepsen.consul.db :as consul.db]
+   [jepsen.control :as c]
+   [jepsen.control.net :as net]
+   [jepsen.control.util :as cu]
+   [jepsen.core :as jepsen]
+   [jepsen.db :as db]
+   [jepsen.os.debian :as debian]
+   [jepsen.os.ubuntu :as ubuntu]
+   [jepsen.readyset.client :as rs]
+   [jepsen.tests :as tests]
+   [slingshot.slingshot :refer [try+]]))
+
+(def pguser "postgres")
+(def pgpassword "password")
+(def pgdatabase "jepsen")
+
+(defn- node->role
+  [test]
+  (zipmap
+   (:nodes test)
+   (concat [:node-role/load-balancer
+            :node-role/consul
+            :node-role/readyset-server
+            :node-role/upstream]
+           (repeat :node-role/readyset-adapter))))
+
+(defn role->node
+  [test]
+  (into {} (map (comp vec reverse)) (node->role test)))
+
+(defn- node-role
+  "Given a test and a node in that test, returns what will be running on that
+  node for the test, represented as a keyword in
+  `#{:node-role/consul
+     :node-role/readyset-adapter
+     :node-role/load-balancer
+     :node-role/readyset-server
+     :node-role/upstream}`.
+
+  Note that we must always have at least 5 nodes to run a test.
+
+  Roles will be assigned to nodes in the following order:
+
+    1. `:node-role/load-balancer`
+    2. `:node-role/consul`
+    3. `:node-role/readyset-server`
+    4. `:node-role/upstream`
+    5. ... and all remaining nodes will have `:node-role/readyset-adapter`"
+  [test node]
+  (assert
+   (>= (count (:nodes test)) 5)
+   "Must have at least 5 nodes to run a high-availability ReadySet cluster")
+  (get (node->role test) node))
+
+(defn- node-with-role
+  "Returns the node with the given role in the given test"
+  [test role]
+  (get (role->node test) role))
+
+(defn- adapter-nodes
+  "Returns a sequence of adapter nodes in the given test"
+  [test]
+  (->> test :nodes (drop 4)))
+
+(defn- num-adapters
+  "Returns the number of adapter instances that will be running in the given
+  test"
+  [test]
+  (- (count (:nodes test)) 4))
+
+(defn- upstream-db-url
+  "Returns the upstream DB URL for the given test"
+  [test]
+  (str "postgresql://"
+       pguser ":" pgpassword
+       "@" (node-with-role test :node-role/upstream)
+       "/" pgdatabase))
+
+(defn- readyset-datasource
+  "Build a JDBC DataSource for connecting to the ReadySet cluster in the given
+  test"
+  [test]
+  (rs/make-datasource
+   {:dbtype "postgres"
+    :dbname pgdatabase
+    :user pguser
+    :password pgpassword
+    :host (name (node-with-role test :node-role/load-balancer))
+    :port 5432}))
+
+(defn- ensure-git-cloned
+  "Ensure that a git repository `repo` is cloned at ref `ref` in dir `dir`"
+  [repo ref dir]
+  (debian/install ["git"])
+
+  (when (and (cu/exists? dir)
+             (not (cu/exists? (str dir "/.git"))))
+    (c/exec :rm :-rf dir))
+  (letfn [(git [& args] (apply c/exec :git :-C dir args))]
+    (if (cu/exists? dir)
+      (git :fetch :origin)
+      (c/exec :git :clone repo dir))
+    (git :checkout ref)))
+
+(defn- compile-and-install-readyset-binary
+  [node ref bin & [{:keys [force?] :or {force? false}}]]
+  (if (and
+       (cu/file? (str "/usr/local/bin/" bin))
+       (not force?))
+    (info node bin "already exists, not re-installing")
+    (c/su
+     (debian/install ["clang"
+                      "libclang-dev"
+                      "libssl-dev"
+                      "liblz4-dev"
+                      "build-essential"
+                      "pkg-config"])
+     (c/exec* "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+     (ensure-git-cloned
+      "https://github.com/readysettech/readyset.git"
+      ref
+      "/opt/readyset")
+     (c/exec* "~/.cargo/bin/rustup install $(</opt/readyset/rust-toolchain)")
+     (info node "compiling" bin)
+     (c/cd "/opt/readyset"
+           (c/exec "~/.cargo/bin/cargo" "build" "--release" "--bin" bin)
+           (c/exec "mv"
+                   (str "target/release/" bin)
+                   "/usr/local/bin/")))))
+
+(defn- authority-address
+  [test]
+  (str (name (node-with-role test :node-role/consul))
+       ":8500"))
+
+(defn- append-to-file [s file]
+  (c/exec "echo" s (c/lit ">>") file))
+
+(defn db
+  "ReadySet DB at a given git ref"
+  [ref]
+  (let [consul (consul.db/db "1.16.1")]
+    (reify db/DB
+      (setup! [_ test node]
+        (if-let [role (node-role test node)]
+          (do
+            (info node "role is" role)
+            (case role
+              :node-role/load-balancer
+              (do
+                (debian/install ["haproxy"])
+                (let [haproxy-servers
+                      (->> test
+                           adapter-nodes
+                           (map #(str "server " (name %) " " (name %) ":5432 check"))
+                           (str/join "\n"))
+                      haproxy-cfg (-> (io/resource "haproxy.cfg.tpl")
+                                      (slurp)
+                                      (str/replace "${servers}" haproxy-servers))]
+                  (c/su
+                   (cu/write-file! haproxy-cfg "/etc/haproxy/haproxy.cfg")
+                   (c/exec "systemctl" "restart" "haproxy")))
+                (jepsen/synchronize test (* 60 30)))
+
+              :node-role/consul
+              (do
+                (db/setup! consul test node)
+                (jepsen/synchronize test (* 60 30)))
+
+              :node-role/upstream
+              (do
+                (debian/install ["postgresql"])
+                (info node "setting up postgresql database " pgdatabase)
+                (c/sudo
+                 "postgres"
+
+                 (try+
+                  (c/exec "psql" :-c (str "create database " pgdatabase))
+                  (catch #(re-find #"database \".*?\" already exists"
+                                   (:err %)) _))
+                 (c/exec "psql" :-c (str "alter user " pguser
+                                         " password '" pgpassword "'"))
+
+                 (append-to-file
+                  "listen_addresses = '*'\nwal_level = logical"
+                  "/etc/postgresql/14/main/postgresql.conf")
+                 (append-to-file
+                  "host all all 0.0.0.0/0 scram-sha-256"
+                  "/etc/postgresql/14/main/pg_hba.conf"))
+                (c/su (c/exec "systemctl" "restart" "postgresql"))
+                (jepsen/synchronize test (* 60 30)))
+
+              :node-role/readyset-adapter
+              (do
+                (compile-and-install-readyset-binary
+                 node
+                 ref
+                 "readyset"
+                 {:force? (:force-install test)})
+
+                ;; Don't try to start readyset processes until Consul is up
+                (jepsen/synchronize test (* 60 30))
+                (c/su
+                 (cu/start-daemon!
+                  {:logfile "/var/log/readyset.log"
+                   :pidfile "/var/run/readyset.pid"
+                   :chdir "/"}
+                  "/usr/local/bin/readyset"
+                  :--log-level (:log-level test "info")
+                  :--deployment "jepsen"
+                  :-a "0.0.0.0:5432"
+                  :--external-address (net/ip (name node))
+                  :--authority-address (authority-address test)
+                  :--upstream-db-url (upstream-db-url test)
+                  :--disable-upstream-ssl-verification
+                  :--embedded-readers
+                  :--reader-replicas (str (num-adapters test)))))
+
+              :node-role/readyset-server
+              (do
+                (compile-and-install-readyset-binary
+                 node
+                 ref
+                 "readyset-server"
+                 {:force? (:force-install test)})
+
+                ;; Don't try to start readyset processes until Consul is up
+                (jepsen/synchronize test (* 60 30))
+                (c/su
+                 (c/exec :mkdir "/opt/readyset/data")
+                 (cu/start-daemon!
+                  {:logfile "/var/log/readyset-server.log"
+                   :pidfile "/var/run/readyset-server.pid"
+                   :chdir "/"}
+                  "/usr/local/bin/readyset-server"
+                  :--log-level (:log-level test "info")
+                  :--deployment "jepsen"
+                  :--db-dir "/opt/readyset/data"
+                  :-a "0.0.0.0"
+                  :--external-address (net/ip (name node))
+                  :--authority-address (authority-address test)
+                  :--upstream-db-url (upstream-db-url test)
+                  :--disable-upstream-ssl-verification
+                  :--no-readers
+                  :--reader-replicas (str (num-adapters test))))
+
+                (let [ds (readyset-datasource test)]
+                  (rs/wait-for-snapshot-completed ds))
+                (info "ReadySet is running"))))
+
+          (error node "unknown role")))
+
+      (teardown! [_ test node]
+        (if-let [role (node-role test node)]
+          (do
+            (info node "tearing down for role" role)
+            (case role
+              :node-role/load-balancer nil
+              :node-role/consul (db/teardown! consul test node)
+
+              :node-role/upstream
+              (try+
+               (info node "dropping database" pgdatabase)
+               (c/sudo "postgres" (c/exec "psql"
+                                          :-c (str "drop database " pgdatabase)))
+               (catch #(re-find #"psql: command not found" (:err %)) _)
+               (catch #(re-find #"database \".*?\" does not exist" (:err %)) _)
+               (catch
+                   #(re-find #"database \".*?\" is used by an active logical"
+                             (:err %))
+                   e
+                 (warn node "Could not drop database:" e)))
+
+              :node-role/readyset-adapter
+              (c/su
+               (cu/stop-daemon! "/var/run/readyset.pid")
+               (info node "ReadySet Adapter killed")
+               (c/exec :rm :-rf
+                       "/var/run/readyset.pid"
+                       "/var/log/readyset.log"))
+
+              :node-role/readyset-server
+              (c/su
+               (cu/stop-daemon! "/var/run/readyset-server.pid")
+               (info node "ReadySet Server killed")
+               (c/exec :rm :-rf
+                       "/var/run/readyset-server.pid"
+                       "/var/log/readyset-server.log"
+                       "/opt/readyset/data"))))
+          (error node "unknown role")))
+
+      db/LogFiles
+      (log-files [_ test node]
+        (if-let [role (node-role test node)]
+          (case role
+            :node-role/load-balancer nil
+            :node-role/consul (db/log-files consul test node)
+            :node-role/upstream nil
+            :node-role/readyset-adapter ["/var/log/readyset.log"]
+            :node-role/readyset-server ["/var/log/readyset-server.log"])
+          (error node "unknown role"))))))
+
+(defn readyset-test
+  [opts]
+  (merge
+   tests/noop-test
+   opts
+   {:name "ReadySet"
+    :os ubuntu/os
+    :db (db "1eebd43bd6befd8acc9104b4239a414d72a4bd55"  ; Needs at least this commit
+            #_"refs/tags/beta-2023-07-26")
+    :pure-generators true}))
+
+(def opt-spec
+  [[nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
+    :default "info"]
+   [nil "--force-install" "Force install readyset binaries"]])
+
+(defn -main
+  [& args]
+  (cli/run! (merge (cli/single-test-cmd {:test-fn readyset-test
+                                         :opt-spec opt-spec})
+                   (cli/serve-cmd))
+            args))

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -259,20 +259,24 @@
               {:model (rs.model/eventually-consistent-table)
                :algorithm :linear})
     :generator (->> (gen/mix [rs/r rs/w])
-                    (gen/stagger 1)
+                    (gen/stagger (/ (:rate opts)))
                     (gen/nemesis
                      (cycle
                       [(gen/sleep 5)
                        {:type :info, :f :start}
                        (gen/sleep 5)
                        {:type :info, :f :stop}]))
-                    (gen/time-limit 30))
+                    (gen/time-limit (:time-limit opts)))
     :pure-generators true}))
 
 (def opt-spec
   [[nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
     :default "info"]
-   [nil "--force-install" "Force install readyset binaries"]])
+   [nil "--force-install" "Force install readyset binaries"]
+   ["-r" "--rate HZ" "Approximate number of requests per second, per thread"
+    :default 10
+    :parse-fn read-string
+    :validate [#(and (number? %) (pos? %)) "Must be a positive number"]]])
 
 (defn -main
   [& args]

--- a/jepsen/src/jepsen/readyset/automation.clj
+++ b/jepsen/src/jepsen/readyset/automation.clj
@@ -1,0 +1,100 @@
+(ns jepsen.readyset.automation
+  (:require [clojure.tools.logging :refer [info]]
+            [jepsen.control :as c]
+            [jepsen.control.net :as net]
+            [jepsen.control.util :as cu]
+            [jepsen.os.debian :as debian]
+            [jepsen.readyset.client :as rs]
+            [jepsen.readyset.nodes :as nodes]))
+
+(defn ensure-git-cloned
+  "Ensure that a git repository `repo` is cloned at ref `ref` in dir `dir`"
+  [repo ref dir]
+  (debian/install ["git"])
+
+  (when (and (cu/exists? dir)
+             (not (cu/exists? (str dir "/.git"))))
+    (c/exec :rm :-rf dir))
+  (letfn [(git [& args] (apply c/exec :git :-C dir args))]
+    (if (cu/exists? dir)
+      (git :fetch :origin)
+      (c/exec :git :clone repo dir))
+    (git :checkout ref)))
+
+(defn compile-and-install-readyset-binary!
+  [node ref bin & [{:keys [force?] :or {force? false}}]]
+  (if (and
+       (cu/file? (str "/usr/local/bin/" bin))
+       (not force?))
+    (info node bin "already exists, not re-installing")
+    (c/su
+     (debian/install ["clang"
+                      "libclang-dev"
+                      "libssl-dev"
+                      "liblz4-dev"
+                      "build-essential"
+                      "pkg-config"])
+     (c/exec* "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y")
+     (ensure-git-cloned
+      "https://github.com/readysettech/readyset.git"
+      ref
+      "/opt/readyset")
+     (c/exec* "~/.cargo/bin/rustup install $(</opt/readyset/rust-toolchain)")
+     (info node "compiling" bin)
+     (c/cd "/opt/readyset"
+           (c/exec "~/.cargo/bin/cargo" "build" "--release" "--bin" bin)
+           (c/exec "mv"
+                   (str "target/release/" bin)
+                   "/usr/local/bin/")))))
+
+
+(defn authority-address
+  [test]
+  (str (name (nodes/node-with-role test :node-role/consul))
+       ":8500"))
+
+(defn upstream-db-url
+  "Returns the upstream DB URL for the given test"
+  [test]
+  (str "postgresql://"
+       rs/pguser ":" rs/pgpassword
+       "@" (nodes/node-with-role test :node-role/upstream)
+       "/" rs/pgdatabase))
+
+(defn start-readyset-adapter! [node test]
+  (c/su
+   (cu/start-daemon!
+    {:logfile "/var/log/readyset.log"
+     :pidfile "/var/run/readyset.pid"
+     :chdir "/"}
+    "/usr/local/bin/readyset"
+    :--log-level (:log-level test "info")
+    :--deployment "jepsen"
+    :-a "0.0.0.0:5432"
+    :--controller-address "0.0.0.0"
+    :--external-address (net/ip (name node))
+    :--authority-address (authority-address test)
+    :--upstream-db-url (upstream-db-url test)
+    :--disable-upstream-ssl-verification
+    :--embedded-readers
+    :--reader-replicas (str (nodes/num-adapters test)))))
+
+(defn start-readyset-server! [node test]
+  (c/su
+   (c/exec :mkdir :-p "/opt/readyset/data")
+   (cu/start-daemon!
+    {:logfile "/var/log/readyset-server.log"
+     :pidfile "/var/run/readyset-server.pid"
+     :chdir "/"}
+    "/usr/local/bin/readyset-server"
+    :--log-level (:log-level test "info")
+    :--deployment "jepsen"
+    :--db-dir "/opt/readyset/data"
+    :-a "0.0.0.0"
+    :--external-address (net/ip (name node))
+    :--authority-address (authority-address test)
+    :--upstream-db-url (upstream-db-url test)
+    :--allow-full-materialization
+    :--disable-upstream-ssl-verification
+    :--no-readers
+    :--reader-replicas (str (nodes/num-adapters test)))))

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -103,6 +103,7 @@
 
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn final-r [_ _] {:type :invoke, :f :final-read, :value nil})
 
 (defrecord Client [conn table-created? tables]
   client/Client
@@ -126,11 +127,13 @@
   (invoke! [_ test op]
     (try+
      (case (:f op)
-       :read (assoc op
-                    :type :ok
-                    :value
-                    (map (some-fn :t1/x :x)
-                         (jdbc/execute! conn ["select x from t1"])))
+       (:read :final-read)
+       (assoc op
+              :type :ok
+              :value
+              (map (some-fn :t1/x :x)
+                   (jdbc/execute! conn ["select x from t1"])))
+
        :write
        (do (jdbc/execute! conn ["insert into t1 (x) values (?)"
                                 (:value op)])

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -104,7 +104,7 @@
 (defn r [_ _] {:type :invoke, :f :read, :value nil})
 (defn w [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
 
-(defrecord Client [conn table-created?]
+(defrecord Client [conn table-created? tables]
   client/Client
   (open! [this test node]
     (assoc this :conn (test-datasource test)))
@@ -128,7 +128,9 @@
      (case (:f op)
        :read (assoc op
                     :type :ok
-                    :value (jdbc/execute! conn ["select x from t1"]))
+                    :value
+                    (map (some-fn :t1/x :x)
+                         (jdbc/execute! conn ["select x from t1"])))
        :write
        (do (jdbc/execute! conn ["insert into t1 (x) values (?)"
                                 (:value op)])

--- a/jepsen/src/jepsen/readyset/client.clj
+++ b/jepsen/src/jepsen/readyset/client.clj
@@ -1,0 +1,82 @@
+(ns jepsen.readyset.client
+  "Utilities for interacting with a ReadySet cluster"
+  (:require
+   [clojure.tools.logging :refer [info warn]]
+   [dom-top.core :refer [with-retry]]
+   [next.jdbc :as jdbc]
+   [slingshot.slingshot :refer [throw+]]
+   [clojure.set :as set])
+  (:import
+   (org.postgresql.util PSQLException)))
+
+(defn make-datasource
+  "Make a new JDBC DataSource for connecting to ReadySet, using the options
+  accepted by `jdbc/get-datasource`"
+  [db-info]
+  (jdbc/get-datasource
+   (assoc db-info
+          ;; Use simple queries where possible, so that we can run readyset
+          ;; commands (to work around REA-2960
+          :preferQueryMode "simple"
+          ;; Avoid sending `SET extra_float_digits = 3` on connection
+          ;; (see https://github.com/pgjdbc/pgjdbc/issues/168)
+          :assumeMinServerVersion "9.0")))
+
+(defn wait-for-connection
+  "Wait for a connection to the given ReadySet datasource (as creaated by
+  `make-datasource`) to succeed"
+  [ds]
+  (info "Waiting for ReadySet to be connectable")
+  (with-retry [attempts 5]
+    (jdbc/execute! ds ["show readyset version"])
+    (catch PSQLException e
+      (if (pos? attempts)
+        (do
+          (warn "Error connecting to readyset adapter:" (ex-message e))
+          (Thread/sleep 1000)
+          (retry (dec attempts)))
+        (throw+ {:error :retry-attempts-exceeded
+                 :exception e})))))
+
+(defn readyset-status
+  "Return the status of the ReadySet cluster for the given data source,
+  represented as a map giving the results of the `SHOW READYSET STATUS` command"
+  [ds]
+  (let [res (jdbc/execute! ds ["show readyset status"])]
+    (set/rename-keys
+     (into {} (map (juxt :name :value)) res)
+     {"Snapshot Status" :snapshot-status
+      "Maximum Replication Offset" :maximum-replication-offset
+      "Minimum Replication Offset" :minimum-replication-offset
+      "Last Started Controller" :last-started-controller
+      "Last Completed Snapshot" :last-completed-snapshot
+      "Last Started Replication" :last-started-replication})))
+
+(defn wait-for-snapshot-completed
+  "Wait for the ReadySet cluster at the given datasource to report that
+  snapshotting has completed"
+  [ds]
+  (wait-for-connection ds)
+  (info "Waiting for snapshot status = Completed")
+  (with-retry [attempts 5]
+    (let [{:keys [snapshot-status]} (readyset-status ds)]
+      (when-not (= snapshot-status "Completed")
+        (if (pos? attempts)
+          (do
+            (Thread/sleep 200)
+            (retry (dec attempts)))
+          (throw+ {:error :retry-attempts-exceeded}))))))
+
+(comment
+  (def --ds
+    (make-datasource {:dbtype "postgres"
+                      :dbname "jepsen"
+                      :user "postgres"
+                      :password "password"
+                      :host "aspen-jepsen-n1"
+                      :port 5432}))
+
+  (wait-for-connection --ds)
+
+  (readyset-status --ds)
+  )

--- a/jepsen/src/jepsen/readyset/model.clj
+++ b/jepsen/src/jepsen/readyset/model.clj
@@ -1,0 +1,29 @@
+(ns jepsen.readyset.model
+  "A Knossos Model for ReadySet eventual consistency"
+  (:require
+   [knossos.model :as model])
+  (:import
+   (knossos.model Model)))
+
+(defrecord
+    ^{:doc "A model for an eventually-consistent table with a single column.
+    Supports :write ops to write new rows, and :read ops to read the list of
+    rows out of the table"}
+    EventuallyConsistentTable [rows past-results]
+  Model
+  (step [this op]
+    (case (:f op)
+      :write (-> this
+                 (update :rows conj (:value op))
+                 (#(update % :past-results conj (sort (:rows %)))))
+      :read (let [results (sort (:value op))]
+              (if (or (nil? (:value op))
+                      (contains? past-results results))
+                this
+                (model/inconsistent (str "can't read " results
+                                         "; valid results: " past-results)))))))
+
+(defn eventually-consistent-table []
+  (map->EventuallyConsistentTable
+   {:rows []
+    :past-results #{[]}}))

--- a/jepsen/src/jepsen/readyset/nodes.clj
+++ b/jepsen/src/jepsen/readyset/nodes.clj
@@ -1,0 +1,55 @@
+(ns jepsen.readyset.nodes)
+
+(defn node->role
+  [test]
+  (zipmap
+   (:nodes test)
+   (concat [:node-role/load-balancer
+            :node-role/consul
+            :node-role/readyset-server
+            :node-role/upstream]
+           (repeat :node-role/readyset-adapter))))
+
+(defn role->node
+  [test]
+  (into {} (map (comp vec reverse)) (node->role test)))
+
+(defn node-role
+  "Given a test and a node in that test, returns what will be running on that
+  node for the test, represented as a keyword in
+  `#{:node-role/consul
+     :node-role/readyset-adapter
+     :node-role/load-balancer
+     :node-role/readyset-server
+     :node-role/upstream}`.
+
+  Note that we must always have at least 5 nodes to run a test.
+
+  Roles will be assigned to nodes in the following order:
+
+    1. `:node-role/load-balancer`
+    2. `:node-role/consul`
+    3. `:node-role/readyset-server`
+    4. `:node-role/upstream`
+    5. ... and all remaining nodes will have `:node-role/readyset-adapter`"
+  [test node]
+  (assert
+   (>= (count (:nodes test)) 5)
+   "Must have at least 5 nodes to run a high-availability ReadySet cluster")
+  (get (node->role test) node))
+
+(defn node-with-role
+  "Returns the node with the given role in the given test"
+  [test role]
+  (get (role->node test) role))
+
+(defn adapter-nodes
+  "Returns a sequence of adapter nodes in the given test"
+  [test]
+  (->> test :nodes (drop 4)))
+
+(defn num-adapters
+  "Returns the number of adapter instances that will be running in the given
+  test"
+  [test]
+  (- (count (:nodes test)) 4))

--- a/jepsen/test/readyset/jepsen_test.clj
+++ b/jepsen/test/readyset/jepsen_test.clj
@@ -1,7 +1,0 @@
-(ns readyset.jepsen-test
-  (:require [clojure.test :refer :all]
-            [readyset.jepsen :refer :all]))
-
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))

--- a/jepsen/test/readyset/jepsen_test.clj
+++ b/jepsen/test/readyset/jepsen_test.clj
@@ -1,0 +1,7 @@
+(ns readyset.jepsen-test
+  (:require [clojure.test :refer :all]
+            [readyset.jepsen :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))


### PR DESCRIPTION
Fix (or configure around) all existing clj-kondo lints, and run
clj-kondo in CI. Since it was unused, this deletes the test
file (generated by `lein new`) entirely. If we want to do unit tests
later we can add it back.

Fixes: REA-3371
