### PR TITLE
jepsen: Add the start of a simple liveness checker

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -8,7 +8,8 @@
                  [clj-http "3.10.0"]
                  [com.github.seancorfield/next.jdbc "1.3.883"]
                  [org.postgresql/postgresql "42.6.0"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 [org.clojure/core.match "1.0.1"]]
   :plugins [[com.github.clj-kondo/lein-clj-kondo "0.2.5"]]
   :repl-options {:init-ns jepsen.readyset}
   :main jepsen.readyset

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -16,10 +16,11 @@
    [jepsen.os.debian :as debian]
    [jepsen.os.ubuntu :as ubuntu]
    [jepsen.readyset.automation :as rs.auto]
+   [jepsen.readyset.checker :as rs.checker]
    [jepsen.readyset.client :as rs]
-   [jepsen.readyset.model :as rs.model]
    [jepsen.readyset.nemesis :as rs.nemesis]
    [jepsen.readyset.nodes :as nodes]
+   [jepsen.readyset.model :as rs.model]
    [jepsen.tests :as tests]
    [slingshot.slingshot :refer [try+]]))
 
@@ -191,9 +192,12 @@
                 :start-adapter :stop} (rs.nemesis/kill-adapters)
                {:kill-server :start
                 :start-server :stop} (rs.nemesis/kill-server)})
-    :checker (checker/linearizable
-              {:model (rs.model/eventually-consistent-table)
-               :algorithm :linear})
+    :checker (checker/compose
+              {:liveness (rs.checker/liveness)
+               :eventually-consistent
+               (checker/linearizable
+                {:model (rs.model/eventually-consistent-table)
+                 :algorithm :linear})})
     :generator (gen/phases
                 (->> (gen/mix [rs/r rs/w])
                      (gen/stagger (/ (:rate opts)))

--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -1,0 +1,43 @@
+(ns jepsen.readyset.checker
+  (:require
+   [clojure.core.match :refer [match]]
+   [clojure.set :as set]
+   [jepsen.checker :as checker]
+   [jepsen.readyset.nodes :as nodes]))
+
+(defn liveness
+  "All queries should succeed if at least one adapter is alive"
+  []
+  (reify checker/Checker
+    (check [_this test history _opts]
+      (let [initial-live-adapters (into #{}
+                                        (nodes/nodes-with-role
+                                         test
+                                         :node-role/readyset-adapter))]
+        (reduce
+         (fn [state {:keys [index type f value]}]
+           (match [type f value]
+             [:info :kill-adapter (_ :guard map?)]
+             (update
+              state
+              :live-adapters
+              #(set/difference %
+                               ;; `value` looks like a map from node name to ""
+                               (into #{} (keys value))))
+
+             [:info :start-adapter (_ :guard map?)]
+             (update state :live-adapters into (keys value))
+
+             [:fail _ _]
+             (if (seq (:live-adapters state))
+               (reduced
+                (assoc state
+                       :valid? false
+                       :failed-at index))
+               state)
+
+             :else state))
+         {:valid? true
+          :failed-at nil
+          :live-adapters initial-live-adapters}
+         history)))))


### PR DESCRIPTION
Add the start of a checker for the ReadySet liveness guarantees. This
runs through the history keeping track of whether at least one adapter
is alive at any given time, and checks that all queries succeed as long
as at least one adapter is running.

Since we might kill an adapter while a query is actively running, this
also extends the Client to support a `:retry-queries?` option, which if
true will retry all queries once before considering them failed.

