### PR TITLE
psql-srv: Use SqlIdentifier for column names

### DIFF
--- a/psql-srv/src/codec/encoder.rs
+++ b/psql-srv/src/codec/encoder.rs
@@ -1089,7 +1089,7 @@ mod tests {
                 RowDescription {
                     field_descriptions: vec![
                         FieldDescription {
-                            field_name: "one".to_string(),
+                            field_name: "one".into(),
                             table_id: 1,
                             col_id: 2,
                             data_type: Type::INT4,
@@ -1098,7 +1098,7 @@ mod tests {
                             transfer_format: Binary,
                         },
                         FieldDescription {
-                            field_name: "two".to_string(),
+                            field_name: "two".into(),
                             table_id: 3,
                             col_id: 4,
                             data_type: Type::INT8,
@@ -1107,7 +1107,7 @@ mod tests {
                             transfer_format: Text,
                         },
                         FieldDescription {
-                            field_name: "three".to_string(),
+                            field_name: "three".into(),
                             table_id: 5,
                             col_id: 6,
                             data_type: Type::TEXT,

--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use futures::Stream;
+use nom_sql::SqlIdentifier;
 use postgres::SimpleQueryMessage;
 use postgres_types::Type;
 use protocol::Protocol;
@@ -120,7 +121,7 @@ pub trait PsqlBackend {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Column {
     /// The name of the column
-    pub name: String,
+    pub name: SqlIdentifier,
 
     /// The type of the column
     pub col_type: Type,

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use nom_sql::SqlIdentifier;
 use postgres::error::ErrorPosition;
 pub use postgres::error::SqlState;
 use postgres::SimpleQueryRow;
@@ -126,7 +127,7 @@ pub enum ErrorSeverity {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct FieldDescription {
-    pub field_name: String,
+    pub field_name: SqlIdentifier,
     pub table_id: i32,
     pub col_id: i16,
     pub data_type: Type,

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -1006,11 +1006,11 @@ mod tests {
                 Ok(QueryResponse::Select {
                     schema: vec![
                         Column {
-                            name: "col1".to_string(),
+                            name: "col1".into(),
                             col_type: Type::INT4,
                         },
                         Column {
-                            name: "col2".to_string(),
+                            name: "col2".into(),
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1038,11 +1038,11 @@ mod tests {
                     param_schema: vec![Type::FLOAT8, Type::INT4],
                     row_schema: vec![
                         Column {
-                            name: "col1".to_string(),
+                            name: "col1".into(),
                             col_type: Type::INT4,
                         },
                         Column {
-                            name: "col2".to_string(),
+                            name: "col2".into(),
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1063,11 +1063,11 @@ mod tests {
                 Ok(QueryResponse::Select {
                     schema: vec![
                         Column {
-                            name: "col1".to_string(),
+                            name: "col1".into(),
                             col_type: Type::INT4,
                         },
                         Column {
-                            name: "col2".to_string(),
+                            name: "col2".into(),
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1423,7 +1423,7 @@ mod tests {
                     Some(RowDescription {
                         field_descriptions: vec![
                             FieldDescription {
-                                field_name: "col1".to_string(),
+                                field_name: "col1".into(),
                                 table_id: UNKNOWN_TABLE,
                                 col_id: UNKNOWN_COLUMN,
                                 data_type: Type::INT4,
@@ -1432,7 +1432,7 @@ mod tests {
                                 transfer_format: TransferFormat::Text
                             },
                             FieldDescription {
-                                field_name: "col2".to_string(),
+                                field_name: "col2".into(),
                                 table_id: UNKNOWN_TABLE,
                                 col_id: UNKNOWN_COLUMN,
                                 data_type: Type::FLOAT8,
@@ -1547,11 +1547,11 @@ mod tests {
                 param_schema: vec![Type::FLOAT8, Type::INT4],
                 row_schema: vec![
                     Column {
-                        name: "col1".to_string(),
+                        name: "col1".into(),
                         col_type: Type::INT4
                     },
                     Column {
-                        name: "col2".to_string(),
+                        name: "col2".into(),
                         col_type: Type::FLOAT8
                     },
                 ],
@@ -1941,7 +1941,7 @@ mod tests {
                     RowDescription {
                         field_descriptions: vec![
                             FieldDescription {
-                                field_name: "col1".to_string(),
+                                field_name: "col1".into(),
                                 table_id: UNKNOWN_TABLE,
                                 col_id: UNKNOWN_COLUMN,
                                 data_type: Type::INT4,
@@ -1950,7 +1950,7 @@ mod tests {
                                 transfer_format: TransferFormat::Text
                             },
                             FieldDescription {
-                                field_name: "col2".to_string(),
+                                field_name: "col2".into(),
                                 table_id: UNKNOWN_TABLE,
                                 col_id: UNKNOWN_COLUMN,
                                 data_type: Type::FLOAT8,
@@ -2028,7 +2028,7 @@ mod tests {
                 RowDescription {
                     field_descriptions: vec![
                         FieldDescription {
-                            field_name: "col1".to_string(),
+                            field_name: "col1".into(),
                             table_id: UNKNOWN_TABLE,
                             col_id: UNKNOWN_COLUMN,
                             data_type: Type::INT4,
@@ -2037,7 +2037,7 @@ mod tests {
                             transfer_format: TransferFormat::Text
                         },
                         FieldDescription {
-                            field_name: "col2".to_string(),
+                            field_name: "col2".into(),
                             table_id: UNKNOWN_TABLE,
                             col_id: UNKNOWN_COLUMN,
                             data_type: Type::FLOAT8,

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -59,7 +59,7 @@ impl PsqlBackend for ErrorBackend {
                 prepared_statement_id: 1,
                 param_schema: vec![],
                 row_schema: vec![Column {
-                    name: "x".to_owned(),
+                    name: "x".into(),
                     col_type: Type::BOOL,
                 }],
             })
@@ -75,7 +75,7 @@ impl PsqlBackend for ErrorBackend {
             ErrorPosition::Execute => Err(Error::InternalError("a database".to_owned())),
             ErrorPosition::Serialize => Ok(QueryResponse::Select {
                 schema: vec![Column {
-                    name: "x".to_owned(),
+                    name: "x".into(),
                     col_type: Type::BOOL,
                 }],
                 resultset: stream::iter(vec![Err(Error::InternalError("factory".to_owned()))]),

--- a/readyset-psql/src/schema.rs
+++ b/readyset-psql/src/schema.rs
@@ -19,7 +19,7 @@ impl<'a> TryFrom<SelectSchema<'a>> for Vec<ps::Column> {
             .iter()
             .map(|c| {
                 Ok(ps::Column {
-                    name: c.column.name.to_string(),
+                    name: c.column.name.clone(),
                     col_type: type_to_pgsql(&c.column_type)?,
                 })
             })
@@ -48,7 +48,7 @@ impl<'a> TryFrom<NoriaSchema<'a>> for Vec<ps::Column> {
         s.0.iter()
             .map(|c| {
                 Ok(ps::Column {
-                    name: c.column.name.to_string(),
+                    name: c.column.name.clone(),
                     col_type: type_to_pgsql(&c.column_type)?,
                 })
             })

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -256,7 +256,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                 .iter()
                 .map(|col| -> Result<_, Error> {
                     Ok(Column {
-                        name: col.name().to_owned(),
+                        name: col.name().into(),
                         col_type: col.type_().clone(),
                     })
                 })


### PR DESCRIPTION
Column names are usually short and are cloned often, so keeping them in
the stack rather than always using a heap reference (which is what
SqlIdentifier does) is likely much faster. This is an easy enough change
that I haven't benchmarked it, but I'd imagine it helps a bit especially
for very wide result sets.

