### PR TITLE
readyset-client: Add a `pg_meta` field to Change::CreateTable

### DIFF
--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1474,20 +1474,22 @@ mod tests {
                         schema: Some("s1".into()),
                         name: "t".into(),
                     }),
-                    Change::CreateTable(
-                        parse_create_table(
+                    Change::CreateTable {
+                        statement: parse_create_table(
                             Dialect::MySQL,
                             "CREATE TABLE s2.snapshotting_t (x int);",
                         )
                         .unwrap(),
-                    ),
-                    Change::CreateTable(
-                        parse_create_table(
+                        pg_meta: None,
+                    },
+                    Change::CreateTable {
+                        statement: parse_create_table(
                             Dialect::MySQL,
                             "CREATE TABLE s2.snapshotted_t (x int);",
                         )
                         .unwrap(),
-                    ),
+                        pg_meta: None,
+                    },
                 ],
                 DataDialect::DEFAULT_MYSQL,
             ))
@@ -1562,9 +1564,11 @@ mod tests {
         let (mut noria, shutdown_tx) = start_simple("domains").await;
         noria
             .extend_recipe(ChangeList::from_change(
-                Change::CreateTable(
-                    parse_create_table(Dialect::MySQL, "CREATE TABLE t1 (x int);").unwrap(),
-                ),
+                Change::CreateTable {
+                    statement: parse_create_table(Dialect::MySQL, "CREATE TABLE t1 (x int);")
+                        .unwrap(),
+                    pg_meta: None,
+                },
                 DataDialect::DEFAULT_MYSQL,
             ))
             .await

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -210,7 +210,9 @@ impl SqlIncorporator {
 
         for change in changes {
             match change {
-                Change::CreateTable(mut cts) => {
+                Change::CreateTable {
+                    statement: mut cts, ..
+                } => {
                     cts = self.rewrite(cts, &schema_search_path, dialect, None)?;
                     let body = match cts.body {
                         Ok(body) => body,

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -8948,9 +8948,11 @@ async fn multiple_simultaneous_migrations() {
     let mut g2 = g.clone();
 
     g.extend_recipe(ChangeList::from_change(
-        Change::CreateTable(
-            parse_create_table(nom_sql::Dialect::MySQL, "CREATE TABLE t (x int, y int)").unwrap(),
-        ),
+        Change::CreateTable {
+            statement: parse_create_table(nom_sql::Dialect::MySQL, "CREATE TABLE t (x int, y int)")
+                .unwrap(),
+            pg_meta: None,
+        },
         Dialect::DEFAULT_MYSQL,
     ))
     .await

--- a/replicators/src/postgres_connector/ddl_replication.rs
+++ b/replicators/src/postgres_connector/ddl_replication.rs
@@ -237,12 +237,15 @@ impl DdlEvent {
                     });
 
                 match create_table_body {
-                    Ok(body) => Change::CreateTable(CreateTableStatement {
-                        if_not_exists: false,
-                        table,
-                        body: Ok(body),
-                        options: Ok(vec![]),
-                    }),
+                    Ok(body) => Change::CreateTable {
+                        statement: CreateTableStatement {
+                            if_not_exists: false,
+                            table,
+                            body: Ok(body),
+                            options: Ok(vec![]),
+                        },
+                        pg_meta: None, // TODO
+                    },
                     Err(_) => Change::AddNonReplicatedRelation(table),
                 }
             }


### PR DESCRIPTION
As the first step of tracking the Postgres oids of tables and attrids of
their columns, add an optional (and currently unset and unused)
`pg_meta` field to `Change::CreateTable`. This will be passed by the
replicator, and saved on the Base node, so that we can return column
metadata to postgresql clients with table oids and column attribute IDs
filled in.

Refs: REA-3380
