### PR TITLE
replicators: Pass table OID and column attnums in pg_meta

### DIFF
--- a/replicators/src/postgres_connector/ddl_replication.sql
+++ b/replicators/src/postgres_connector/ddl_replication.sql
@@ -68,9 +68,12 @@ BEGIN
         json_build_object(
             'schema', object.schema_name,
             'data', json_build_object('CreateTable', json_build_object(
+                -- OID->json makes a string by default, so cast to bigint
+                'oid', cls.oid::bigint,
                 'name', cls.relname,
                 'columns', (
                     SELECT json_agg(json_build_object(
+                        'attnum', attr.attnum,
                         'name', attr.attname,
                         'column_type', pg_catalog.format_type(
                             attr.atttypid,


### PR DESCRIPTION
In both snapshotting and DDL replication, collect the oid of the table
and the attnums of its columns, and pass them as part of the new pg_meta
field when building `Change::CreateTable` changes to send to the
controller. We'll use these later when constructing result sets to fill
in the relevant fields on column metadata when columns are returned in
query results directly.

Refs: REA-3380
