### PR TITLE
server: Save pg_meta on MIR Base node

### DIFF
--- a/readyset-mir/src/graph.rs
+++ b/readyset-mir/src/graph.rs
@@ -460,6 +460,7 @@ mod tests {
         let t1 = graph.add_node(MirNode::new(
             "t1".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![],
                 primary_key: None,
                 unique_keys: Default::default(),
@@ -468,6 +469,7 @@ mod tests {
         let t2 = graph.add_node(MirNode::new(
             "t2".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![],
                 primary_key: None,
                 unique_keys: Default::default(),

--- a/readyset-mir/src/node.rs
+++ b/readyset-mir/src/node.rs
@@ -133,6 +133,7 @@ mod tests {
             graph.add_node(MirNode::new(
                 "base".into(),
                 MirNodeInner::Base {
+                    pg_meta: None,
                     column_specs: vec![
                         ColumnSpecification {
                             column: "base.a".into(),
@@ -157,6 +158,7 @@ mod tests {
             graph.add_node(MirNode::new(
                 "base2".into(),
                 MirNodeInner::Base {
+                    pg_meta: None,
                     column_specs: vec![
                         ColumnSpecification {
                             column: "base2.a".into(),
@@ -570,6 +572,7 @@ mod tests {
                 name: "a".into(),
                 owners: HashSet::new(),
                 inner: MirNodeInner::Base {
+                    pg_meta: None,
                     column_specs: vec![cspec("c1"), cspec("c2"), cspec("c3")],
                     primary_key: Some([Column::from("c1")].into()),
                     unique_keys: Default::default(),
@@ -614,6 +617,7 @@ mod tests {
                 name: "a".into(),
                 owners: HashSet::new(),
                 inner: MirNodeInner::Base {
+                    pg_meta: None,
                     column_specs: vec![cspec("c1"), cspec("c2"), cspec("c3")],
                     primary_key: Some([Column::from("c1")].into()),
                     unique_keys: Default::default(),
@@ -652,6 +656,7 @@ mod tests {
                 name: "a".into(),
                 owners: HashSet::new(),
                 inner: MirNodeInner::Base {
+                    pg_meta: None,
                     column_specs: vec![cspec("c1")],
                     primary_key: Some([Column::from("c1")].into()),
                     unique_keys: Default::default(),

--- a/readyset-mir/src/node/node_inner.rs
+++ b/readyset-mir/src/node/node_inner.rs
@@ -8,6 +8,7 @@ use dataflow::PostLookupAggregates;
 use derive_more::From;
 use itertools::Itertools;
 use nom_sql::{BinaryOperator, ColumnSpecification, Expr, OrderType, Relation, SqlIdentifier};
+use readyset_client::recipe::changelist::PostgresTableMetadata;
 use readyset_client::{PlaceholderIdx, ViewPlaceholder};
 use readyset_errors::{internal, ReadySetResult};
 use serde::{Deserialize, Serialize};
@@ -91,6 +92,7 @@ pub enum MirNodeInner {
     ///
     /// [`Aggregator`]: dataflow::node::special::Base
     Base {
+        pg_meta: Option<PostgresTableMetadata>,
         column_specs: Vec<ColumnSpecification>,
         primary_key: Option<Box<[Column]>>,
         unique_keys: Box<[Box<[Column]>]>,

--- a/readyset-mir/src/rewrite/add_bogokey.rs
+++ b/readyset-mir/src/rewrite/add_bogokey.rs
@@ -112,6 +112,7 @@ mod tests {
         let base = mir_graph.add_node(MirNode::new(
             "base".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: nom_sql::Column::from("a"),
                     sql_type: SqlType::Int(None),
@@ -178,6 +179,7 @@ mod tests {
         let base = mir_graph.add_node(MirNode::new(
             "base".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: nom_sql::Column::from("a"),
                     sql_type: SqlType::Int(None),
@@ -258,6 +260,7 @@ mod tests {
         let base = mir_graph.add_node(MirNode::new(
             "base".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: nom_sql::Column::from("a"),
                     sql_type: SqlType::Int(None),

--- a/readyset-mir/src/rewrite/decorrelate.rs
+++ b/readyset-mir/src/rewrite/decorrelate.rs
@@ -300,6 +300,7 @@ mod tests {
         let t2 = graph.add_node(MirNode::new(
             "t2".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: nom_sql::Column::from("t2.a"),
                     sql_type: SqlType::Int(None),
@@ -390,6 +391,7 @@ mod tests {
         let t1 = graph.add_node(MirNode::new(
             "t1".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: nom_sql::Column::from("t1.a"),
                     sql_type: SqlType::Int(None),
@@ -508,6 +510,7 @@ mod tests {
         let t2 = graph.add_node(MirNode::new(
             "t2".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![
                     ColumnSpecification {
                         column: nom_sql::Column::from("t2.a"),
@@ -641,6 +644,7 @@ mod tests {
         let t1 = graph.add_node(MirNode::new(
             "t1".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: nom_sql::Column::from("t1.a"),
                     sql_type: SqlType::Int(None),

--- a/readyset-mir/src/rewrite/filters_to_join_keys.rs
+++ b/readyset-mir/src/rewrite/filters_to_join_keys.rs
@@ -197,6 +197,7 @@ mod tests {
         let t1 = mir_graph.add_node(MirNode::new(
             "t1".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![
                     ColumnSpecification {
                         column: nom_sql::Column::from("t1.a"),
@@ -233,6 +234,7 @@ mod tests {
         let t2 = mir_graph.add_node(MirNode::new(
             "t2".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![
                     ColumnSpecification {
                         column: nom_sql::Column::from("t2.a"),

--- a/readyset-mir/src/rewrite/pull_columns.rs
+++ b/readyset-mir/src/rewrite/pull_columns.rs
@@ -77,6 +77,7 @@ mod tests {
         mir_graph.add_node(MirNode::new(
             "base".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![
                     ColumnSpecification {
                         column: nom_sql::Column::from("a"),

--- a/readyset-mir/src/rewrite/pull_keys.rs
+++ b/readyset-mir/src/rewrite/pull_keys.rs
@@ -133,6 +133,7 @@ mod tests {
         let t = graph.add_node(MirNode::new(
             "t".into(),
             MirNodeInner::Base {
+                pg_meta: None,
                 column_specs: vec![ColumnSpecification {
                     column: "t.x".into(),
                     sql_type: SqlType::Int(None),

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1474,20 +1474,22 @@ mod tests {
                         schema: Some("s1".into()),
                         name: "t".into(),
                     }),
-                    Change::CreateTable(
-                        parse_create_table(
+                    Change::CreateTable {
+                        statement: parse_create_table(
                             Dialect::MySQL,
                             "CREATE TABLE s2.snapshotting_t (x int);",
                         )
                         .unwrap(),
-                    ),
-                    Change::CreateTable(
-                        parse_create_table(
+                        pg_meta: None,
+                    },
+                    Change::CreateTable {
+                        statement: parse_create_table(
                             Dialect::MySQL,
                             "CREATE TABLE s2.snapshotted_t (x int);",
                         )
                         .unwrap(),
-                    ),
+                        pg_meta: None,
+                    },
                 ],
                 DataDialect::DEFAULT_MYSQL,
             ))
@@ -1562,9 +1564,11 @@ mod tests {
         let (mut noria, shutdown_tx) = start_simple("domains").await;
         noria
             .extend_recipe(ChangeList::from_change(
-                Change::CreateTable(
-                    parse_create_table(Dialect::MySQL, "CREATE TABLE t1 (x int);").unwrap(),
-                ),
+                Change::CreateTable {
+                    statement: parse_create_table(Dialect::MySQL, "CREATE TABLE t1 (x int);")
+                        .unwrap(),
+                    pg_meta: None,
+                },
                 DataDialect::DEFAULT_MYSQL,
             ))
             .await

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -210,7 +210,9 @@ impl SqlIncorporator {
 
         for change in changes {
             match change {
-                Change::CreateTable(mut cts) => {
+                Change::CreateTable {
+                    statement: mut cts, ..
+                } => {
                     cts = self.rewrite(cts, &schema_search_path, dialect, None)?;
                     let body = match cts.body {
                         Ok(body) => body,

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -45,7 +45,7 @@ impl Recipe {
     /// Get the id associated with an alias
     pub(crate) fn expression_by_alias(&self, alias: &Relation) -> Option<SqlQuery> {
         let expr = self.inc.registry.get(alias).map(|e| match e {
-            RecipeExpr::Table { name, body } => SqlQuery::CreateTable(CreateTableStatement {
+            RecipeExpr::Table { name, body, .. } => SqlQuery::CreateTable(CreateTableStatement {
                 if_not_exists: false,
                 table: name.clone(),
                 body: Ok(body.clone()),

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -3804,7 +3804,8 @@ async fn finkelstein1982_queries() {
                     let stmt = inc
                         .rewrite(stmt, &[], Dialect::DEFAULT_MYSQL, None)
                         .unwrap();
-                    inc.add_table(stmt.table, stmt.body.unwrap(), mig).unwrap();
+                    inc.add_table(stmt.table, stmt.body.unwrap(), None, mig)
+                        .unwrap();
                 }
                 SqlQuery::Select(stmt) => {
                     inc.add_query(None, stmt, false, &[], mig).unwrap();

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -8948,9 +8948,11 @@ async fn multiple_simultaneous_migrations() {
     let mut g2 = g.clone();
 
     g.extend_recipe(ChangeList::from_change(
-        Change::CreateTable(
-            parse_create_table(nom_sql::Dialect::MySQL, "CREATE TABLE t (x int, y int)").unwrap(),
-        ),
+        Change::CreateTable {
+            statement: parse_create_table(nom_sql::Dialect::MySQL, "CREATE TABLE t (x int, y int)")
+                .unwrap(),
+            pg_meta: None,
+        },
         Dialect::DEFAULT_MYSQL,
     ))
     .await

--- a/replicators/src/postgres_connector/ddl_replication.rs
+++ b/replicators/src/postgres_connector/ddl_replication.rs
@@ -237,12 +237,15 @@ impl DdlEvent {
                     });
 
                 match create_table_body {
-                    Ok(body) => Change::CreateTable(CreateTableStatement {
-                        if_not_exists: false,
-                        table,
-                        body: Ok(body),
-                        options: Ok(vec![]),
-                    }),
+                    Ok(body) => Change::CreateTable {
+                        statement: CreateTableStatement {
+                            if_not_exists: false,
+                            table,
+                            body: Ok(body),
+                            options: Ok(vec![]),
+                        },
+                        pg_meta: None, // TODO
+                    },
                     Err(_) => Change::AddNonReplicatedRelation(table),
                 }
             }

--- a/replicators/src/postgres_connector/ddl_replication.sql
+++ b/replicators/src/postgres_connector/ddl_replication.sql
@@ -68,9 +68,12 @@ BEGIN
         json_build_object(
             'schema', object.schema_name,
             'data', json_build_object('CreateTable', json_build_object(
+                -- OID->json makes a string by default, so cast to bigint
+                'oid', cls.oid::bigint,
                 'name', cls.relname,
                 'columns', (
                     SELECT json_agg(json_build_object(
+                        'attnum', attr.attnum,
                         'name', attr.attname,
                         'column_type', pg_catalog.format_type(
                             attr.atttypid,


### PR DESCRIPTION
Pass through the pg_meta optionally provided on the Change::CreateTable
change to a new pg_meta field on the MIR base node that we create (or
re-create, in the case of dropping and recreating tables in response to
other schema changes). This will (eventually) be used when constructing
postgres result set metadata for queries that reference columns on
tables directly

Refs: REA-3380
