### PR TITLE
server: Reduce cloning in Schema

### DIFF
--- a/readyset-server/src/controller/schema.rs
+++ b/readyset-server/src/controller/schema.rs
@@ -57,7 +57,7 @@ fn get_base_for_column(
 
         let source_node = &graph[*ni];
         if source_node.is_base() {
-            if let Some(Schema::Table(ref schema)) = recipe.schema_for(source_node.name()) {
+            if let Some(Schema::Table(schema)) = recipe.schema_for(source_node.name()) {
                 let col_index = cols.first().unwrap().unwrap();
                 #[allow(clippy::unwrap_used)] // occurs after implied table rewrite
                 return Ok(Some(ColumnBase {

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -814,14 +814,12 @@ impl SqlIncorporator {
         Ok(())
     }
 
-    pub(super) fn get_base_schema(&self, table: &Relation) -> Option<CreateTableBody> {
-        self.base_schemas.get(table).cloned()
+    pub(super) fn get_base_schema<'a>(&'a self, table: &Relation) -> Option<&'a CreateTableBody> {
+        self.base_schemas.get(table)
     }
 
-    pub(super) fn get_view_schema(&self, name: &Relation) -> Option<Vec<String>> {
-        self.view_schemas
-            .get(name)
-            .map(|s| s.iter().map(SqlIdentifier::to_string).collect())
+    pub(super) fn get_view_schema<'a>(&'a self, name: &Relation) -> Option<&'a [SqlIdentifier]> {
+        self.view_schemas.get(name).as_ref().map(|v| v.as_slice())
     }
 
     /// Retrieves the flow node associated with a given query's leaf view.

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -1,9 +1,8 @@
 use std::str;
-use std::vec::Vec;
 
 use nom_sql::{
     CacheInner, CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
-    Relation, SqlQuery,
+    Relation, SqlIdentifier, SqlQuery,
 };
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::ChangeList;
@@ -36,9 +35,9 @@ impl PartialEq for Recipe {
 }
 
 #[derive(Debug)]
-pub(crate) enum Schema {
-    Table(CreateTableBody),
-    View(Vec<String>),
+pub(crate) enum Schema<'a> {
+    Table(&'a CreateTableBody),
+    View(&'a [SqlIdentifier]),
 }
 
 impl Recipe {
@@ -142,7 +141,7 @@ impl Recipe {
     }
 
     /// Get schema for a base table or view in the recipe.
-    pub(crate) fn schema_for(&self, name: &Relation) -> Option<Schema> {
+    pub(crate) fn schema_for<'a>(&'a self, name: &Relation) -> Option<Schema<'a>> {
         match self.inc.get_base_schema(name) {
             None => {
                 let s = match self.resolve_alias(name) {

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -634,7 +634,7 @@ impl DfState {
             .schema_for(base)
             .map(|s| -> ReadySetResult<_> {
                 match s {
-                    Schema::Table(s) => Ok(s),
+                    Schema::Table(s) => Ok(s.clone()),
                     _ => internal!(
                         "non-base schema {:?} returned for table {}",
                         s,


### PR DESCRIPTION
The `Schema` enum that we construct for the schema of a base of a query
contained owned fields which were always cloned, often unnecessarily or
twice - this makes them references so that they can be cloned only as
necessary.

