### PR TITLE
server: Store pg_meta on SqlIncorporator::base_schemas

### DIFF
--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1474,20 +1474,22 @@ mod tests {
                         schema: Some("s1".into()),
                         name: "t".into(),
                     }),
-                    Change::CreateTable(
-                        parse_create_table(
+                    Change::CreateTable {
+                        statement: parse_create_table(
                             Dialect::MySQL,
                             "CREATE TABLE s2.snapshotting_t (x int);",
                         )
                         .unwrap(),
-                    ),
-                    Change::CreateTable(
-                        parse_create_table(
+                        pg_meta: None,
+                    },
+                    Change::CreateTable {
+                        statement: parse_create_table(
                             Dialect::MySQL,
                             "CREATE TABLE s2.snapshotted_t (x int);",
                         )
                         .unwrap(),
-                    ),
+                        pg_meta: None,
+                    },
                 ],
                 DataDialect::DEFAULT_MYSQL,
             ))
@@ -1562,9 +1564,11 @@ mod tests {
         let (mut noria, shutdown_tx) = start_simple("domains").await;
         noria
             .extend_recipe(ChangeList::from_change(
-                Change::CreateTable(
-                    parse_create_table(Dialect::MySQL, "CREATE TABLE t1 (x int);").unwrap(),
-                ),
+                Change::CreateTable {
+                    statement: parse_create_table(Dialect::MySQL, "CREATE TABLE t1 (x int);")
+                        .unwrap(),
+                    pg_meta: None,
+                },
                 DataDialect::DEFAULT_MYSQL,
             ))
             .await

--- a/readyset-server/src/controller/schema.rs
+++ b/readyset-server/src/controller/schema.rs
@@ -5,7 +5,7 @@ use readyset_data::DfType;
 use tracing::trace;
 
 use super::keys::provenance_of;
-use super::sql::{Recipe, Schema};
+use super::sql::{BaseSchema, Recipe, Schema};
 
 type Path<'a> = &'a [(
     petgraph::graph::NodeIndex,
@@ -57,18 +57,20 @@ fn get_base_for_column(
 
         let source_node = &graph[*ni];
         if source_node.is_base() {
-            if let Some(Schema::Table(schema)) = recipe.schema_for(source_node.name()) {
+            if let Some(Schema::Table(BaseSchema { statement, .. })) =
+                recipe.schema_for(source_node.name())
+            {
                 let col_index = cols.first().unwrap().unwrap();
                 #[allow(clippy::unwrap_used)] // occurs after implied table rewrite
                 return Ok(Some(ColumnBase {
-                    column: schema.fields[col_index].column.name.clone(),
-                    table: schema.fields[col_index]
+                    column: statement.fields[col_index].column.name.clone(),
+                    table: statement.fields[col_index]
                         .column
                         .table
                         .as_ref()
                         .unwrap()
                         .clone(),
-                    constraints: schema.fields[col_index].constraints.clone(),
+                    constraints: statement.fields[col_index].constraints.clone(),
                 }));
             }
         }

--- a/readyset-server/src/controller/schema.rs
+++ b/readyset-server/src/controller/schema.rs
@@ -57,7 +57,7 @@ fn get_base_for_column(
 
         let source_node = &graph[*ni];
         if source_node.is_base() {
-            if let Some(Schema::Table(ref schema)) = recipe.schema_for(source_node.name()) {
+            if let Some(Schema::Table(schema)) = recipe.schema_for(source_node.name()) {
                 let col_index = cols.first().unwrap().unwrap();
                 #[allow(clippy::unwrap_used)] // occurs after implied table rewrite
                 return Ok(Some(ColumnBase {

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -814,14 +814,12 @@ impl SqlIncorporator {
         Ok(())
     }
 
-    pub(super) fn get_base_schema(&self, table: &Relation) -> Option<CreateTableBody> {
-        self.base_schemas.get(table).cloned()
+    pub(super) fn get_base_schema<'a>(&'a self, table: &Relation) -> Option<&'a CreateTableBody> {
+        self.base_schemas.get(table)
     }
 
-    pub(super) fn get_view_schema(&self, name: &Relation) -> Option<Vec<String>> {
-        self.view_schemas
-            .get(name)
-            .map(|s| s.iter().map(SqlIdentifier::to_string).collect())
+    pub(super) fn get_view_schema<'a>(&'a self, name: &Relation) -> Option<&'a [SqlIdentifier]> {
+        self.view_schemas.get(name).as_ref().map(|v| v.as_slice())
     }
 
     /// Retrieves the flow node associated with a given query's leaf view.

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -210,7 +210,9 @@ impl SqlIncorporator {
 
         for change in changes {
             match change {
-                Change::CreateTable(mut cts) => {
+                Change::CreateTable {
+                    statement: mut cts, ..
+                } => {
                     cts = self.rewrite(cts, &schema_search_path, dialect, None)?;
                     let body = match cts.body {
                         Ok(body) => body,

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -1,8 +1,8 @@
 use std::str;
 
 use nom_sql::{
-    CacheInner, CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
-    Relation, SqlIdentifier, SqlQuery,
+    CacheInner, CreateCacheStatement, CreateTableStatement, CreateViewStatement, Relation,
+    SqlIdentifier, SqlQuery,
 };
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::ChangeList;
@@ -14,6 +14,7 @@ use tracing::warn;
 use vec1::Vec1;
 
 use super::registry::{MatchedCache, RecipeExpr};
+use super::BaseSchema;
 use crate::controller::sql::SqlIncorporator;
 use crate::controller::Migration;
 
@@ -36,7 +37,7 @@ impl PartialEq for Recipe {
 
 #[derive(Debug)]
 pub(crate) enum Schema<'a> {
-    Table(&'a CreateTableBody),
+    Table(&'a BaseSchema),
     View(&'a [SqlIdentifier]),
 }
 
@@ -44,7 +45,7 @@ impl Recipe {
     /// Get the id associated with an alias
     pub(crate) fn expression_by_alias(&self, alias: &Relation) -> Option<SqlQuery> {
         let expr = self.inc.registry.get(alias).map(|e| match e {
-            RecipeExpr::Table { name, body } => SqlQuery::CreateTable(CreateTableStatement {
+            RecipeExpr::Table { name, body, .. } => SqlQuery::CreateTable(CreateTableStatement {
                 if_not_exists: false,
                 table: name.clone(),
                 body: Ok(body.clone()),

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -1,9 +1,8 @@
 use std::str;
-use std::vec::Vec;
 
 use nom_sql::{
     CacheInner, CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
-    Relation, SqlQuery,
+    Relation, SqlIdentifier, SqlQuery,
 };
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::ChangeList;
@@ -36,9 +35,9 @@ impl PartialEq for Recipe {
 }
 
 #[derive(Debug)]
-pub(crate) enum Schema {
-    Table(CreateTableBody),
-    View(Vec<String>),
+pub(crate) enum Schema<'a> {
+    Table(&'a CreateTableBody),
+    View(&'a [SqlIdentifier]),
 }
 
 impl Recipe {
@@ -142,7 +141,7 @@ impl Recipe {
     }
 
     /// Get schema for a base table or view in the recipe.
-    pub(crate) fn schema_for(&self, name: &Relation) -> Option<Schema> {
+    pub(crate) fn schema_for<'a>(&'a self, name: &Relation) -> Option<Schema<'a>> {
         match self.inc.get_base_schema(name) {
             None => {
                 let s = match self.resolve_alias(name) {

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -634,7 +634,7 @@ impl DfState {
             .schema_for(base)
             .map(|s| -> ReadySetResult<_> {
                 match s {
-                    Schema::Table(s) => Ok(s.clone()),
+                    Schema::Table(s) => Ok(s.statement.clone()),
                     _ => internal!(
                         "non-base schema {:?} returned for table {}",
                         s,

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -634,7 +634,7 @@ impl DfState {
             .schema_for(base)
             .map(|s| -> ReadySetResult<_> {
                 match s {
-                    Schema::Table(s) => Ok(s),
+                    Schema::Table(s) => Ok(s.clone()),
                     _ => internal!(
                         "non-base schema {:?} returned for table {}",
                         s,

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -3804,7 +3804,8 @@ async fn finkelstein1982_queries() {
                     let stmt = inc
                         .rewrite(stmt, &[], Dialect::DEFAULT_MYSQL, None)
                         .unwrap();
-                    inc.add_table(stmt.table, stmt.body.unwrap(), mig).unwrap();
+                    inc.add_table(stmt.table, stmt.body.unwrap(), None, mig)
+                        .unwrap();
                 }
                 SqlQuery::Select(stmt) => {
                     inc.add_query(None, stmt, false, &[], mig).unwrap();

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -8948,9 +8948,11 @@ async fn multiple_simultaneous_migrations() {
     let mut g2 = g.clone();
 
     g.extend_recipe(ChangeList::from_change(
-        Change::CreateTable(
-            parse_create_table(nom_sql::Dialect::MySQL, "CREATE TABLE t (x int, y int)").unwrap(),
-        ),
+        Change::CreateTable {
+            statement: parse_create_table(nom_sql::Dialect::MySQL, "CREATE TABLE t (x int, y int)")
+                .unwrap(),
+            pg_meta: None,
+        },
         Dialect::DEFAULT_MYSQL,
     ))
     .await

--- a/readyset-sql-passes/src/lib.rs
+++ b/readyset-sql-passes/src/lib.rs
@@ -66,7 +66,7 @@ pub struct RewriteContext<'a> {
     /// Map from names of *tables* in the database, to the body of the `CREATE TABLE` statement
     /// that was used to create that table. Each key in this map should also exist in
     /// [`view_schemas`].
-    pub base_schemas: &'a HashMap<Relation, CreateTableBody>,
+    pub base_schemas: HashMap<&'a Relation, &'a CreateTableBody>,
 
     /// List of views that are known to exist but have not yet been compiled (so we can't know
     /// their fields yet)
@@ -171,7 +171,7 @@ impl Rewrite for SelectStatement {
             .normalize_topk_with_aggregate()?
             .detect_problematic_self_joins()?
             .remove_numeric_field_references()?
-            .order_limit_removal(context.base_schemas)
+            .order_limit_removal(&context.base_schemas)
     }
 }
 

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -691,15 +691,15 @@ impl NoriaAdapter {
         // Remove DDL changes outside the filtered scope
         let mut non_replicated_tables = vec![];
         changelist.changes_mut().retain(|change| match change {
-            Change::CreateTable(stmt) => {
+            Change::CreateTable { statement, .. } => {
                 let keep = self
                     .table_filter
-                    .should_be_processed(schema.as_str(), stmt.table.name.as_str())
-                    && stmt.body.is_ok();
+                    .should_be_processed(schema.as_str(), statement.table.name.as_str())
+                    && statement.body.is_ok();
                 if !keep {
                     non_replicated_tables.push(Relation {
                         schema: Some(schema.clone().into()),
-                        name: stmt.table.name.clone(),
+                        name: statement.table.name.clone(),
                     })
                 }
                 keep
@@ -734,7 +734,7 @@ impl NoriaAdapter {
         let tables = changelist
             .changes()
             .filter_map(|change| match change {
-                Change::CreateTable(t) => Some(t.table.clone()),
+                Change::CreateTable { statement, .. } => Some(statement.table.clone()),
                 _ => None,
             })
             .collect::<Vec<_>>();
@@ -757,7 +757,7 @@ impl NoriaAdapter {
                     .changes_mut()
                     .extend(changes.into_iter().filter_map(|change| {
                         Some(Change::AddNonReplicatedRelation(match change {
-                            Change::CreateTable(stmt) => stmt.table,
+                            Change::CreateTable { statement, .. } => statement.table,
                             Change::CreateView(stmt) => stmt.name,
                             Change::AddNonReplicatedRelation(rel) => rel,
                             _ => return None,

--- a/replicators/src/postgres_connector/ddl_replication.rs
+++ b/replicators/src/postgres_connector/ddl_replication.rs
@@ -237,12 +237,15 @@ impl DdlEvent {
                     });
 
                 match create_table_body {
-                    Ok(body) => Change::CreateTable(CreateTableStatement {
-                        if_not_exists: false,
-                        table,
-                        body: Ok(body),
-                        options: Ok(vec![]),
-                    }),
+                    Ok(body) => Change::CreateTable {
+                        statement: CreateTableStatement {
+                            if_not_exists: false,
+                            table,
+                            body: Ok(body),
+                            options: Ok(vec![]),
+                        },
+                        pg_meta: None, // TODO
+                    },
                     Err(_) => Change::AddNonReplicatedRelation(table),
                 }
             }

--- a/replicators/src/postgres_connector/ddl_replication.sql
+++ b/replicators/src/postgres_connector/ddl_replication.sql
@@ -68,9 +68,12 @@ BEGIN
         json_build_object(
             'schema', object.schema_name,
             'data', json_build_object('CreateTable', json_build_object(
+                -- OID->json makes a string by default, so cast to bigint
+                'oid', cls.oid::bigint,
                 'name', cls.relname,
                 'columns', (
                     SELECT json_agg(json_build_object(
+                        'attnum', attr.attnum,
                         'name', attr.attname,
                         'column_type', pg_catalog.format_type(
                             attr.atttypid,


### PR DESCRIPTION
Change the value type for `base_schemas` in SqlIncorporator from being
`CreateTableBody` directly to being a new `BaseSchema` struct, which
stores the `CreateTableBody` in addition to (now) the `pg_meta` for the
table. This is passed from the Change::CreateTable change in the recipe,
and will eventually be used when constructing postgres result set
metadata for queries that reference columns on tables directly.

Since a reference to `base_schemas` was previously passed directly to
the `RewriteContext` in `readyset_sql_passes`, some stuff had to change
there to make the various reference types and lifetimes work out.

Refs: REA-3380
