### PR TITLE
adapter: Remove SelectSchema::use_bogo

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -614,7 +614,6 @@ pub enum MigrationMode {
 
 #[derive(Debug, Clone)]
 pub struct SelectSchema<'a> {
-    pub use_bogo: bool,
     pub schema: Cow<'a, [ColumnSchema]>,
     pub columns: Cow<'a, [SqlIdentifier]>,
 }
@@ -622,7 +621,6 @@ pub struct SelectSchema<'a> {
 impl<'a> SelectSchema<'a> {
     pub fn into_owned(self) -> SelectSchema<'static> {
         SelectSchema {
-            use_bogo: self.use_bogo,
             schema: Cow::Owned(self.schema.into_owned()),
             columns: Cow::Owned(self.columns.into_owned()),
         }
@@ -1719,7 +1717,6 @@ where
             queries.retain(|q| &q.id.to_string() == q_id);
         }
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 create_dummy_column("query id"),
                 create_dummy_column("proxied query"),
@@ -1791,7 +1788,6 @@ where
         }
 
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 create_dummy_column("query id"),
                 create_dummy_column("cache name"),
@@ -2506,7 +2502,6 @@ where
             .collect();
 
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![create_dummy_column("query text")]),
             columns: Cow::Owned(vec!["query text".into()]),
         };

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -538,7 +538,6 @@ impl NoriaConnector {
     pub(crate) async fn explain_domains(&mut self) -> ReadySetResult<QueryResult<'static>> {
         let domains = self.inner.get_mut()?.noria.domains().await?;
         let schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 ColumnSchema {
                     column: nom_sql::Column {
@@ -991,7 +990,6 @@ impl NoriaConnector {
         )?;
 
         let schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(
                 ["table", "status"]
                     .iter()
@@ -1743,8 +1741,6 @@ async fn do_read<'a>(
 
     Ok(QueryResult::from_iter(
         SelectSchema {
-            // TODO(vlad): looks like poor `use_bogo` is unused except in js? Should just remove it.
-            use_bogo: false,
             schema: Cow::Borrowed(
                 reader_handle
                     .schema()

--- a/readyset-mysql/src/query_handler.rs
+++ b/readyset-mysql/src/query_handler.rs
@@ -850,7 +850,6 @@ impl QueryHandler for MySqlQueryHandler {
                     format!("@@{}", MAX_ALLOWED_PACKET_VARIABLE_NAME).into();
                 Ok(QueryResult::from_owned(
                     SelectSchema {
-                        use_bogo: false,
                         schema: Cow::Owned(vec![ColumnSchema {
                             column: Column {
                                 name: field_name.clone(),
@@ -865,7 +864,6 @@ impl QueryHandler for MySqlQueryHandler {
                 ))
             }
             _ => Ok(QueryResult::empty(SelectSchema {
-                use_bogo: false,
                 schema: Cow::Owned(vec![]),
                 columns: Cow::Owned(vec![]),
             })),

--- a/readyset-psql/src/query_handler.rs
+++ b/readyset-psql/src/query_handler.rs
@@ -347,7 +347,6 @@ impl QueryHandler for PostgreSqlQueryHandler {
 
     fn default_response(_: &SqlQuery) -> ReadySetResult<QueryResult<'static>> {
         Ok(noria_connector::QueryResult::empty(SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![]),
             columns: Cow::Owned(vec![]),
         }))

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -94,7 +94,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 let columns = vars.iter().map(|v| v.name.clone()).collect::<Vec<_>>();
 
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(
                         vars.iter()
                             .map(|v| ColumnSchema {
@@ -124,7 +123,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
             }
             Noria(NoriaResult::MetaVariables(vars)) => {
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(vec![
                         ColumnSchema {
                             column: nom_sql::Column {
@@ -163,7 +161,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 let (col1_header, col2_header): (SqlIdentifier, SqlIdentifier) =
                     (vars[0].name.clone(), vars[0].value.clone().into());
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(vec![
                         ColumnSchema {
                             column: nom_sql::Column {

--- a/readyset-psql/src/resultset.rs
+++ b/readyset-psql/src/resultset.rs
@@ -148,7 +148,6 @@ mod tests {
     async fn create_resultset() {
         let results = vec![];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,
@@ -168,7 +167,6 @@ mod tests {
     async fn stream_resultset() {
         let results = vec![Results::new(vec![vec![DfValue::Int(10)]])];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,
@@ -191,7 +189,6 @@ mod tests {
             Results::new(vec![vec![DfValue::Int(11)], vec![DfValue::Int(12)]]),
         ];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,


### PR DESCRIPTION
As indicated by a TODO comment, this is unused everywhere, so let's just
get rid of it.

