### PR TITLE
readyset-psql: Add test for column metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "postgres-derive"
 version = "0.4.3"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.26",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -6288,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/readysettech/rust-postgres.git#5302d7ed0b9cca0b4672b8a3fdde21c7b0643f3d"
+source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/psql-srv/src/codec/encoder.rs
+++ b/psql-srv/src/codec/encoder.rs
@@ -358,7 +358,7 @@ fn encode(message: BackendMessage, dst: &mut BytesMut) -> Result<(), Error> {
             put_i16(i16::try_from(field_descriptions.len())?, dst);
             for d in field_descriptions {
                 put_str(&d.field_name, dst);
-                put_i32(d.table_id, dst);
+                put_u32(d.table_id, dst);
                 put_i16(d.col_id, dst);
                 put_type(d.data_type, dst)?;
                 put_i16(d.data_type_size, dst);

--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -123,6 +123,12 @@ pub struct Column {
     /// The name of the column
     pub name: SqlIdentifier,
 
+    /// The OID of the column's table, if known
+    pub table_oid: Option<u32>,
+
+    /// The attribute number of the column, if known
+    pub attnum: Option<i16>,
+
     /// The type of the column
     pub col_type: Type,
 }

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -128,7 +128,7 @@ pub enum ErrorSeverity {
 #[derive(Debug, PartialEq, Eq)]
 pub struct FieldDescription {
     pub field_name: SqlIdentifier,
-    pub table_id: i32,
+    pub table_id: u32,
     pub col_id: i16,
     pub data_type: Type,
     pub data_type_size: i16,

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -41,7 +41,7 @@ const TYPLEN_32: i16 = 32;
 const TYPLEN_VARLENA: i16 = -1;
 const TYPLEN_CSTRING: i16 = -2; // Null-terminated C string
 const UNKNOWN_COLUMN: i16 = 0;
-const UNKNOWN_TABLE: i32 = 0;
+const UNKNOWN_TABLE: u32 = 0;
 
 /// State machine for an ongoing SASL authentication flow
 ///
@@ -907,8 +907,8 @@ async fn make_field_description<B: PsqlBackend>(
 
     Ok(FieldDescription {
         field_name: col.name.clone(),
-        table_id: UNKNOWN_TABLE,
-        col_id: UNKNOWN_COLUMN,
+        table_id: col.table_oid.unwrap_or(UNKNOWN_TABLE),
+        col_id: col.attnum.unwrap_or(UNKNOWN_COLUMN),
         data_type: col.col_type.clone(),
         data_type_size,
         type_modifier: ATTTYPMOD_NONE,
@@ -1007,10 +1007,14 @@ mod tests {
                     schema: vec![
                         Column {
                             name: "col1".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::INT4,
                         },
                         Column {
                             name: "col2".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1039,10 +1043,14 @@ mod tests {
                     row_schema: vec![
                         Column {
                             name: "col1".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::INT4,
                         },
                         Column {
                             name: "col2".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1064,10 +1072,14 @@ mod tests {
                     schema: vec![
                         Column {
                             name: "col1".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::INT4,
                         },
                         Column {
                             name: "col2".into(),
+                            table_oid: None,
+                            attnum: None,
                             col_type: Type::FLOAT8,
                         },
                     ],
@@ -1548,10 +1560,14 @@ mod tests {
                 row_schema: vec![
                     Column {
                         name: "col1".into(),
+                        table_oid: None,
+                        attnum: None,
                         col_type: Type::INT4
                     },
                     Column {
                         name: "col2".into(),
+                        table_oid: None,
+                        attnum: None,
                         col_type: Type::FLOAT8
                     },
                 ],

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -60,6 +60,8 @@ impl PsqlBackend for ErrorBackend {
                 param_schema: vec![],
                 row_schema: vec![Column {
                     name: "x".into(),
+                    table_oid: None,
+                    attnum: None,
                     col_type: Type::BOOL,
                 }],
             })
@@ -76,6 +78,8 @@ impl PsqlBackend for ErrorBackend {
             ErrorPosition::Serialize => Ok(QueryResponse::Select {
                 schema: vec![Column {
                     name: "x".into(),
+                    table_oid: None,
+                    attnum: None,
                     col_type: Type::BOOL,
                 }],
                 resultset: stream::iter(vec![Err(Error::InternalError("factory".to_owned()))]),

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -614,7 +614,6 @@ pub enum MigrationMode {
 
 #[derive(Debug, Clone)]
 pub struct SelectSchema<'a> {
-    pub use_bogo: bool,
     pub schema: Cow<'a, [ColumnSchema]>,
     pub columns: Cow<'a, [SqlIdentifier]>,
 }
@@ -622,7 +621,6 @@ pub struct SelectSchema<'a> {
 impl<'a> SelectSchema<'a> {
     pub fn into_owned(self) -> SelectSchema<'static> {
         SelectSchema {
-            use_bogo: self.use_bogo,
             schema: Cow::Owned(self.schema.into_owned()),
             columns: Cow::Owned(self.columns.into_owned()),
         }
@@ -1719,7 +1717,6 @@ where
             queries.retain(|q| &q.id.to_string() == q_id);
         }
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 create_dummy_column("query id"),
                 create_dummy_column("proxied query"),
@@ -1791,7 +1788,6 @@ where
         }
 
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 create_dummy_column("query id"),
                 create_dummy_column("cache name"),
@@ -2506,7 +2502,6 @@ where
             .collect();
 
         let select_schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![create_dummy_column("query text")]),
             columns: Cow::Owned(vec!["query text".into()]),
         };

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -538,7 +538,6 @@ impl NoriaConnector {
     pub(crate) async fn explain_domains(&mut self) -> ReadySetResult<QueryResult<'static>> {
         let domains = self.inner.get_mut()?.noria.domains().await?;
         let schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![
                 ColumnSchema {
                     column: nom_sql::Column {
@@ -991,7 +990,6 @@ impl NoriaConnector {
         )?;
 
         let schema = SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(
                 ["table", "status"]
                     .iter()
@@ -1743,8 +1741,6 @@ async fn do_read<'a>(
 
     Ok(QueryResult::from_iter(
         SelectSchema {
-            // TODO(vlad): looks like poor `use_bogo` is unused except in js? Should just remove it.
-            use_bogo: false,
             schema: Cow::Borrowed(
                 reader_handle
                     .schema()

--- a/readyset-client/src/view.rs
+++ b/readyset-client/src/view.rs
@@ -148,6 +148,10 @@ pub struct ColumnBase {
     pub table: Relation,
     /// A list of constraints on the column
     pub constraints: Vec<ColumnConstraint>,
+    /// If known, the PostgreSQL OID for the column's base table
+    pub table_oid: Option<u32>,
+    /// If known, the PostgreSQL `attnum` for the column
+    pub attnum: Option<i16>,
 }
 
 /// Combines the specification for a columns with its base name
@@ -174,6 +178,8 @@ impl ColumnSchema {
                 column: spec.column.name.clone(),
                 table,
                 constraints: spec.constraints,
+                table_oid: None,
+                attnum: None,
             }),
             column: spec.column,
             column_type: DfType::from_sql_type(
@@ -2083,6 +2089,8 @@ mod tests {
                             table: "t".into(),
                             column: "x".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                     ColumnSchema {
@@ -2095,6 +2103,8 @@ mod tests {
                             table: "t".into(),
                             column: "y".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                 ],
@@ -2109,6 +2119,8 @@ mod tests {
                             table: "t".into(),
                             column: "x".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                     ColumnSchema {
@@ -2121,6 +2133,8 @@ mod tests {
                             table: "t".into(),
                             column: "y".into(),
                             constraints: vec![],
+                            table_oid: None,
+                            attnum: None,
                         }),
                     },
                 ],

--- a/readyset-mysql/src/query_handler.rs
+++ b/readyset-mysql/src/query_handler.rs
@@ -850,7 +850,6 @@ impl QueryHandler for MySqlQueryHandler {
                     format!("@@{}", MAX_ALLOWED_PACKET_VARIABLE_NAME).into();
                 Ok(QueryResult::from_owned(
                     SelectSchema {
-                        use_bogo: false,
                         schema: Cow::Owned(vec![ColumnSchema {
                             column: Column {
                                 name: field_name.clone(),
@@ -865,7 +864,6 @@ impl QueryHandler for MySqlQueryHandler {
                 ))
             }
             _ => Ok(QueryResult::empty(SelectSchema {
-                use_bogo: false,
                 schema: Cow::Owned(vec![]),
                 columns: Cow::Owned(vec![]),
             })),

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -153,6 +153,8 @@ impl PsqlBackend for Backend {
                         .map(|col| psql_srv::Column {
                             name: col.name().into(),
                             col_type: col.type_().clone(),
+                            table_oid: None,
+                            attnum: None,
                         })
                         .collect()
                 })
@@ -181,6 +183,8 @@ impl PsqlBackend for Backend {
                 .map(|c| psql_srv::Column {
                     name: c.name().into(),
                     col_type: c.type_().clone(),
+                    table_oid: None,
+                    attnum: None,
                 })
                 .collect(),
         };
@@ -223,6 +227,8 @@ impl PsqlBackend for Backend {
                     .map(|col| psql_srv::Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
+                        table_oid: None,
+                        attnum: None,
                     })
                     .collect()
             })

--- a/readyset-psql/src/query_handler.rs
+++ b/readyset-psql/src/query_handler.rs
@@ -347,7 +347,6 @@ impl QueryHandler for PostgreSqlQueryHandler {
 
     fn default_response(_: &SqlQuery) -> ReadySetResult<QueryResult<'static>> {
         Ok(noria_connector::QueryResult::empty(SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![]),
             columns: Cow::Owned(vec![]),
         }))

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -94,7 +94,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 let columns = vars.iter().map(|v| v.name.clone()).collect::<Vec<_>>();
 
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(
                         vars.iter()
                             .map(|v| ColumnSchema {
@@ -124,7 +123,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
             }
             Noria(NoriaResult::MetaVariables(vars)) => {
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(vec![
                         ColumnSchema {
                             column: nom_sql::Column {
@@ -163,7 +161,6 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 let (col1_header, col2_header): (SqlIdentifier, SqlIdentifier) =
                     (vars[0].name.clone(), vars[0].value.clone().into());
                 let select_schema = SelectSchema(readyset_adapter::backend::SelectSchema {
-                    use_bogo: false,
                     schema: Cow::Owned(vec![
                         ColumnSchema {
                             column: nom_sql::Column {

--- a/readyset-psql/src/resultset.rs
+++ b/readyset-psql/src/resultset.rs
@@ -148,7 +148,6 @@ mod tests {
     async fn create_resultset() {
         let results = vec![];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,
@@ -168,7 +167,6 @@ mod tests {
     async fn stream_resultset() {
         let results = vec![Results::new(vec![vec![DfValue::Int(10)]])];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,
@@ -191,7 +189,6 @@ mod tests {
             Results::new(vec![vec![DfValue::Int(11)], vec![DfValue::Int(12)]]),
         ];
         let schema = SelectSchema(cl::SelectSchema {
-            use_bogo: false,
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
                 column_type: DfType::BigInt,

--- a/readyset-psql/src/schema.rs
+++ b/readyset-psql/src/schema.rs
@@ -15,15 +15,7 @@ pub struct SelectSchema<'a>(pub cl::SelectSchema<'a>);
 impl<'a> TryFrom<SelectSchema<'a>> for Vec<ps::Column> {
     type Error = Error;
     fn try_from(s: SelectSchema) -> Result<Self, Self::Error> {
-        s.0.schema
-            .iter()
-            .map(|c| {
-                Ok(ps::Column {
-                    name: c.column.name.clone(),
-                    col_type: type_to_pgsql(&c.column_type)?,
-                })
-            })
-            .collect()
+        NoriaSchema(&s.0.schema).try_into()
     }
 }
 
@@ -50,6 +42,8 @@ impl<'a> TryFrom<NoriaSchema<'a>> for Vec<ps::Column> {
                 Ok(ps::Column {
                     name: c.column.name.clone(),
                     col_type: type_to_pgsql(&c.column_type)?,
+                    table_oid: c.base.as_ref().and_then(|b| b.table_oid),
+                    attnum: c.base.as_ref().and_then(|b| b.attnum),
                 })
             })
             .collect()

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -258,10 +258,8 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                     Ok(Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
-                        // TODO: Load the following two fields from upstream, once tokio-postgres
-                        // provides them
-                        table_oid: None,
-                        attnum: None,
+                        table_oid: col.table_oid(),
+                        attnum: col.column_id(),
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -258,6 +258,10 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                     Ok(Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
+                        // TODO: Load the following two fields from upstream, once tokio-postgres
+                        // provides them
+                        table_oid: None,
+                        attnum: None,
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?,


### PR DESCRIPTION
Now that we're properly returning the table OID and column attnum both
from queries proxied upstream and cached queries - and now that
tokio-postgres has been patched to expose those fields - we can add a
test to fallback.rs to test that we return those fields correctly

Release-Note-Core: ReadySet now correctly returns metadata about the
  table and column for queries that reference columns from tables
  directly. This allows client libraries that use that metadata to know
  which columns come from which tables in a query, either proxied or
  cached.
Fixes: REA-3380
