### PR TITLE
jepsen: Add a faster checker for commutative consistency

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -20,7 +20,6 @@
    [jepsen.readyset.client :as rs]
    [jepsen.readyset.nemesis :as rs.nemesis]
    [jepsen.readyset.nodes :as nodes]
-   [jepsen.readyset.model :as rs.model]
    [jepsen.tests :as tests]
    [slingshot.slingshot :refer [try+]]))
 
@@ -195,9 +194,7 @@
     :checker (checker/compose
               {:liveness (rs.checker/liveness)
                :eventually-consistent
-               (checker/linearizable
-                {:model (rs.model/eventually-consistent-table)
-                 :algorithm :linear})})
+               (rs.checker/commutative-eventual-consistency)})
     :generator (gen/phases
                 (->> (gen/mix [rs/r rs/w])
                      (gen/stagger (/ (:rate opts)))

--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -41,3 +41,56 @@
           :failed-at nil
           :live-adapters initial-live-adapters}
          history)))))
+
+(defn commutative-eventual-consistency
+  "A simpler, faster (than Knossos) checker for eventual consistency of a single
+  table, which works if writes are commutative.
+
+  * `{:f :write, :value x}` ops are inserted into the table
+  * `{:f :read, :value rows}` ops must return the state of the table as of *some
+    point* in the past
+  * `{:f :final-read :value rows}` ops must return the *current* state of the
+    table"
+  []
+  (reify checker/Checker
+    (check [_this _test history _opts]
+      (->
+       (reduce
+        (fn [{:keys [rows past-results] :as state}
+             {:keys [index type f value]}]
+          (case [type f]
+            [:ok :write]
+            (let [new-rows (-> rows (conj value) sort)]
+              (-> state
+                  (assoc :rows new-rows)
+                  (update :past-results conj (sort new-rows))))
+
+            [:ok :read]
+            (if (contains? past-results (sort value))
+              state
+              (reduced
+               (assoc state
+                      :valid? false
+                      :failed-at index)))
+
+            state))
+        {:valid? true
+         :rows []
+         :past-results #{[]}}
+        history)
+       ;; Don't include these keys in the final map; they get big and are
+       ;; mostly noise
+       (dissoc :rows :past-results)))))
+
+(comment
+  (require '[jepsen.store :as store])
+
+  (def t (store/test -2))
+
+  (checker/check
+   (commutative-eventual-consistency)
+   t
+   (:history t)
+   {}
+   )
+  )


### PR DESCRIPTION
In the case that writes are commutative (which the ones we're testing
with currently are, and which we likely *always* will test with) we can
check eventual consistency much much more easily, by just running
through the ops saving the past valid results for tables directly,
without having to run through a linearizability checker. This shaves
a *ton* off of the asymptotic complexity of checking consistency, which
allows us to practically run *much* larger tests.

Refs: REA-69
