### PR TITLE
jepsen: Generalize workloads + introduce votes

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -7,6 +7,7 @@
                  [cheshire "5.9.0"]
                  [clj-http "3.10.0"]
                  [com.github.seancorfield/next.jdbc "1.3.883"]
+                 [com.github.seancorfield/honeysql "2.4.1045"]
                  [org.postgresql/postgresql "42.6.0"]
                  [slingshot "0.12.2"]
                  [org.clojure/core.match "1.0.1"]]

--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -43,15 +43,20 @@
          history)))))
 
 (defn commutative-eventual-consistency
-  "A simpler, faster (than Knossos) checker for eventual consistency of a single
-  table, which works if writes are commutative.
+  "A simpler, faster (than Knossos) checker for eventual consistency of a
+  database, which works if writes are commutative.
 
-  * `{:f :write, :value x}` ops are inserted into the table
-  * `{:f :read, :value rows}` ops must return the state of the table as of *some
-    point* in the past
-  * `{:f :final-read :value rows}` ops must return the *current* state of the
-    table"
-  []
+  The argument is a map where the key is query-id, and the value is a function
+  which takes a map from tables to rows known to exist in those tables, and
+  returns the expected results for that query
+
+  * `{:type :ok, :f :insert, :value {:table table :rows rows}}` ops are inserted
+    into the table
+  * `{:f :query, :value {:query-id query-id :results results}}` ops must return
+    the results for the query as of *some point* in the past
+  * `{:f :consistent-query, :value {:query-id query-id :results results}}` ops
+    must return the *current* results for the query"
+  [expected-query-results]
   (reify checker/Checker
     (check [_this _test history _opts]
       (->
@@ -59,24 +64,42 @@
         (fn [{:keys [rows past-results] :as state}
              {:keys [index type f value]}]
           (case [type f]
-            [:ok :write]
-            (let [new-rows (-> rows (conj value) sort)]
+            [:ok :insert]
+            (let [{:keys [table] inserted-rows :rows} value
+                  new-rows (update rows table into inserted-rows)]
               (-> state
                   (assoc :rows new-rows)
-                  (update :past-results conj (sort new-rows))))
+                  (update
+                   :past-results
+                   (fn [results]
+                     (reduce-kv
+                      (fn [results query-id compute-results]
+                        (update results
+                                query-id
+                                conj
+                                (compute-results new-rows)))
+                      results
+                      expected-query-results)))))
 
-            [:ok :read]
-            (if (contains? past-results (sort value))
-              state
-              (reduced
-               (assoc state
-                      :valid? false
-                      :failed-at index)))
+            [:ok :query]
+            (let [{:keys [query-id results]} value
+                  past-results (get past-results query-id)]
+              (if (contains? past-results results)
+                state
+                (reduced
+                 (assoc state
+                        :valid? false
+                        :failed-at index
+                        :expected past-results
+                        :got results))))
 
             state))
         {:valid? true
-         :rows []
-         :past-results #{[]}}
+         :rows {}
+         :past-results
+         (into {}
+               (map (fn [[k _]] [k #{[]}]))
+               expected-query-results)}
         history)
        ;; Don't include these keys in the final map; they get big and are
        ;; mostly noise
@@ -85,12 +108,74 @@
 (comment
   (require '[jepsen.store :as store])
 
-  (def t (store/test -2))
+  (def t (store/latest))
 
-  (checker/check
-   (commutative-eventual-consistency)
-   t
-   (:history t)
-   {}
-   )
+  ;; Looking at consistency
+
+  (->> t
+       :history
+       (filter (comp #{:query :insert :consistent-query} :f))
+       (filter (comp #{:ok} :type)))
+
+  (def example-result
+    (->> t
+         :history
+         (filter (comp #{:query} :f))
+         (filter (comp #{:ok} :type))
+         first))
+
+  (def rows
+    (->> t
+         :history
+         (filter (comp #{:insert} :f))
+         (filter (comp #{:ok} :type))
+         (map :value)
+         (group-by :table)
+         (map (fn [[k ops]] [k (mapcat :rows ops)]))
+         (into {})))
+
+  (require '[jepsen.readyset.workloads :as workloads])
+  (def compute-votes
+    (get-in workloads/votes [:queries :votes :expected-results]))
+
+  (compute-votes rows)
+
+  (def final-consistent-result
+    (->> t
+         :history
+         (filter (comp #{:consistent-query} :f))
+         (filter (comp #{:ok} :type))
+         first
+         :value
+         :results))
+
+  (assert
+   (= final-consistent-result (compute-votes rows)))
+
+  (assert
+   (:valid?
+    (checker/check
+     (commutative-eventual-consistency
+      {:votes compute-votes})
+     t
+     (:history t)
+     {})))
+
+  ;; looking at failures
+
+  (def first-failure
+    (->> t
+         :history
+         (filter (comp #{:fail} :type))
+         first))
+
+  (def upto-first-failure
+    (->> t
+         :history
+         (take-while #(not= :fail (:type %)))))
+
+  (def after-first-failure
+    (second (split-at (:index first-failure) (:history t))))
+
+  (filter (comp #{:kill-adapter} :f) upto-first-failure)
   )

--- a/jepsen/src/jepsen/readyset/workloads.clj
+++ b/jepsen/src/jepsen/readyset/workloads.clj
@@ -1,0 +1,73 @@
+(ns jepsen.readyset.workloads
+  "ReadySet workloads.
+
+  Workloads are represented as maps with the following structure:
+
+  `{:tables ; list of honeysql :create-table maps
+    :queries
+    {:query-id-one
+     {:query ; honeysql :select map
+      :expected-results ; fn from rows map (from table kw to list of rows) to
+                          expected results for this query
+      :gen-insert ; fn from rows map to generated honeysql :insert-into map
+     }}``")
+
+(def votes
+  {:tables
+   [{:create-table :stories
+     :with-columns [[:id :serial]
+                    [:title :text]
+                    [[:primary-key :id]]]}
+    {:create-table :votes
+     :with-columns [[:story-id :int]
+                    [:user-id :int]]}]
+
+   :queries
+   {:votes
+    {:query
+     {:select [:id :title :vcount]
+      :from [:stories]
+      :left-join
+      [[{:select [:story-id [:%count.* :vcount]]
+         :from [:votes]
+         :group-by :story-id}
+        :vote-count]
+       [:= :stories.id :vote-count.story-id]]
+      :order-by [:stories.id]}
+     :expected-results
+     (fn compute-votes [rows]
+       (let [vote-counts
+             (->> rows
+                  :votes
+                  (group-by :votes/story-id)
+                  (map
+                   (fn [[story-id rows]]
+                     [story-id (count rows)]))
+                  (into {}))]
+         (->> rows
+              :stories
+              (map #(select-keys % [:stories/id :stories/title]))
+              (map (fn [{:stories/keys [id] :as story}]
+                     (assoc story :vcount (get vote-counts id))))
+              (sort-by :stories/id))))}}
+
+   :gen-insert
+   (fn [rows]
+     (let [candidate-tables (if (contains? rows :stories)
+                              [:stories :votes]
+                              [:stories])]
+       (case (rand-nth candidate-tables)
+         :stories
+         {:insert-into :stories
+          :columns [:title]
+          ;; generate between 1 and 5 stories
+          :values (for [_ (range 0 (inc (rand-int 5)))]
+                    [(str "story-" (rand-int (Integer/MAX_VALUE)))])}
+         :votes
+         (let [candidate-stories (->> rows :stories (map :stories/id))]
+           {:insert-into :votes
+            :columns [:story-id :user-id]
+            ;; generate between 1 and 5 votes
+            :values (for [_ (range 0 (inc (rand-int 5)))]
+                      [(rand-nth candidate-stories)
+                       (rand-int Integer/MAX_VALUE)])}))))})

--- a/jepsen/test/jepsen/readyset/client_test.clj
+++ b/jepsen/test/jepsen/readyset/client_test.clj
@@ -1,0 +1,31 @@
+(ns jepsen.readyset.client-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [honey.sql :as sql]
+   [jepsen.readyset.client]))
+
+(deftest honeysql-create-cache-test
+  (is (= ["CREATE CACHE FROM SELECT * FROM t"]
+         (sql/format {:create-cache :_
+                      :select [:*]
+                      :from [:t]}))
+      "Without a name")
+
+  (is (= ["CREATE CACHE mycache FROM SELECT * FROM t"]
+         (sql/format {:create-cache :mycache
+                      :select [:*]
+                      :from [:t]}))
+      "With a name")
+
+  (is (= ["CREATE CACHE my_cache FROM SELECT * FROM t"]
+         (sql/format {:create-cache :my-cache
+                      :select [:*]
+                      :from [:t]}))
+      "With a name requiring character replacing")
+
+  (is (= ["CREATE CACHE \"table\" FROM SELECT * FROM \"t\""]
+         (sql/format {:create-cache :table
+                      :select [:*]
+                      :from [:t]}
+                     {:dialect :ansi}))
+      "With a name requiring quoting"))

--- a/jepsen/test/jepsen/readyset/workloads_test.clj
+++ b/jepsen/test/jepsen/readyset/workloads_test.clj
@@ -1,0 +1,15 @@
+(ns jepsen.readyset.workloads-test
+  (:require [jepsen.readyset.workloads :as sut]
+            [clojure.test :refer [deftest is]]))
+
+
+(deftest compute-votes-test
+  (let [compute-votes
+        (get-in sut/votes [:queries :votes :expected-results])]
+
+    (is (= [{:stories/id 1 :stories/title "a" :vcount 2}
+            {:stories/id 2 :stories/title "b" :vcount nil}]
+           (compute-votes {:stories [#:stories{:id 1 :title "a"}
+                                     #:stories{:id 2 :title "b"}]
+                           :votes [#:votes{:story-id 1 :user-id 1}
+                                   #:votes{:story-id 1 :user-id 2}]})))))


### PR DESCRIPTION
This commit significantly refactors the workloads (tables, rows
inserted, and queries run) that we use when testing ReadySet in Jepsen.
The client can now be configured with a list of tables to create and
queries to cache on init, and uses that same map of queries when
executing the `:query` op (renamed from `:read`) to generate SQL for
queries. The `commutative-eventual-consistency` checker now takes a map
from query ID to a function to compute the expected results for that
query given a map from table name to the list of rows for that table. To
demonstrate this all working, this comes along with a version of the
"votes" workload from the Noria thesis.

For representing queries (both SELECT statements and DDL) this uses the
HoneySQL library, which is nice as it allows us to both pass around and
introspect queries as Clojure data structures.

Since things are starting to get a *bit* complex, this starts writing a
few unit tests for the bits I wanted to make sure worked.

Fixes: REA-3386
