### PR TITLE
database-utils: Provide more detail on parse failure.

### DIFF
--- a/database-utils/src/error.rs
+++ b/database-utils/src/error.rs
@@ -69,10 +69,10 @@ pub enum DatabaseURLParseError {
     #[error("Invalid database URL format; ReadySet requires that Postgres database URLs contain a database name")]
     MissingPostgresDbName,
 
-    #[error(transparent)]
+    #[error("Invalid database URL format: {0}; Make sure any special characters are percent-encoded. See https://docs.readyset.io/reference/cli/readyset#--upstream-db-url for more details.")]
     PostgreSQL(#[from] pgsql::Error),
 
-    #[error(transparent)]
+    #[error("Invalid database URL format: {0}; Make sure any special characters are percent-encoded. See https://docs.readyset.io/reference/cli/readyset#--upstream-db-url for more details.")]
     MySQL(#[from] mysql::UrlError),
 }
 


### PR DESCRIPTION
If the upstream db url fails to parse due to special characters in the
password, it can result in confusing error messages like "Invalid port
number" because the parser doesn't fail until a later element in the
uri.

This commit adds more detail to the error message recommending that the
user percent-encode special characters as well as point to our
public documentation (since there may be other issues that cause the url
to fail parsing, and it's not easy to provide detailed guidance for
every possible case).

Release-Note-Core: Provided a better error message and guidance for
  passwords that include special characters, which must be
  percent-encoded.

