### PR TITLE
readyset-server: use info log for failed worker handler

### DIFF
--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -712,7 +712,7 @@ impl Leader {
         // kill
         let mut downstream_domains = HashSet::new();
         for wi in failed {
-            warn!(worker = %wi, "handling failure of worker");
+            info!(worker = %wi, "handling failure of worker");
             for di in ds.remove_worker(&wi) {
                 downstream_domains.extend(ds.downstream_domains(di.domain_index)?);
             }


### PR DESCRIPTION
Since we expect workers to fail occasionally and the logic for handling
the failed worker is a normal thing in that case, use info log instead
of warn log to clarify that the system is behaving as intended.

