### PR TITLE
server: Store pg_meta on SqlIncorporator::base_schemas

### DIFF
--- a/readyset-server/src/controller/schema.rs
+++ b/readyset-server/src/controller/schema.rs
@@ -5,7 +5,7 @@ use readyset_data::DfType;
 use tracing::trace;
 
 use super::keys::provenance_of;
-use super::sql::{Recipe, Schema};
+use super::sql::{BaseSchema, Recipe, Schema};
 
 type Path<'a> = &'a [(
     petgraph::graph::NodeIndex,
@@ -57,18 +57,20 @@ fn get_base_for_column(
 
         let source_node = &graph[*ni];
         if source_node.is_base() {
-            if let Some(Schema::Table(schema)) = recipe.schema_for(source_node.name()) {
+            if let Some(Schema::Table(BaseSchema { statement, .. })) =
+                recipe.schema_for(source_node.name())
+            {
                 let col_index = cols.first().unwrap().unwrap();
                 #[allow(clippy::unwrap_used)] // occurs after implied table rewrite
                 return Ok(Some(ColumnBase {
-                    column: schema.fields[col_index].column.name.clone(),
-                    table: schema.fields[col_index]
+                    column: statement.fields[col_index].column.name.clone(),
+                    table: statement.fields[col_index]
                         .column
                         .table
                         .as_ref()
                         .unwrap()
                         .clone(),
-                    constraints: schema.fields[col_index].constraints.clone(),
+                    constraints: statement.fields[col_index].constraints.clone(),
                 }));
             }
         }

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -1,8 +1,8 @@
 use std::str;
 
 use nom_sql::{
-    CacheInner, CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
-    Relation, SqlIdentifier, SqlQuery,
+    CacheInner, CreateCacheStatement, CreateTableStatement, CreateViewStatement, Relation,
+    SqlIdentifier, SqlQuery,
 };
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::ChangeList;
@@ -14,6 +14,7 @@ use tracing::warn;
 use vec1::Vec1;
 
 use super::registry::{MatchedCache, RecipeExpr};
+use super::BaseSchema;
 use crate::controller::sql::SqlIncorporator;
 use crate::controller::Migration;
 
@@ -36,7 +37,7 @@ impl PartialEq for Recipe {
 
 #[derive(Debug)]
 pub(crate) enum Schema<'a> {
-    Table(&'a CreateTableBody),
+    Table(&'a BaseSchema),
     View(&'a [SqlIdentifier]),
 }
 
@@ -44,7 +45,7 @@ impl Recipe {
     /// Get the id associated with an alias
     pub(crate) fn expression_by_alias(&self, alias: &Relation) -> Option<SqlQuery> {
         let expr = self.inc.registry.get(alias).map(|e| match e {
-            RecipeExpr::Table { name, body } => SqlQuery::CreateTable(CreateTableStatement {
+            RecipeExpr::Table { name, body, .. } => SqlQuery::CreateTable(CreateTableStatement {
                 if_not_exists: false,
                 table: name.clone(),
                 body: Ok(body.clone()),

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -634,7 +634,7 @@ impl DfState {
             .schema_for(base)
             .map(|s| -> ReadySetResult<_> {
                 match s {
-                    Schema::Table(s) => Ok(s.clone()),
+                    Schema::Table(s) => Ok(s.statement.clone()),
                     _ => internal!(
                         "non-base schema {:?} returned for table {}",
                         s,

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -3804,7 +3804,8 @@ async fn finkelstein1982_queries() {
                     let stmt = inc
                         .rewrite(stmt, &[], Dialect::DEFAULT_MYSQL, None)
                         .unwrap();
-                    inc.add_table(stmt.table, stmt.body.unwrap(), mig).unwrap();
+                    inc.add_table(stmt.table, stmt.body.unwrap(), None, mig)
+                        .unwrap();
                 }
                 SqlQuery::Select(stmt) => {
                     inc.add_query(None, stmt, false, &[], mig).unwrap();

--- a/readyset-sql-passes/src/lib.rs
+++ b/readyset-sql-passes/src/lib.rs
@@ -66,7 +66,7 @@ pub struct RewriteContext<'a> {
     /// Map from names of *tables* in the database, to the body of the `CREATE TABLE` statement
     /// that was used to create that table. Each key in this map should also exist in
     /// [`view_schemas`].
-    pub base_schemas: &'a HashMap<Relation, CreateTableBody>,
+    pub base_schemas: HashMap<&'a Relation, &'a CreateTableBody>,
 
     /// List of views that are known to exist but have not yet been compiled (so we can't know
     /// their fields yet)
@@ -171,7 +171,7 @@ impl Rewrite for SelectStatement {
             .normalize_topk_with_aggregate()?
             .detect_problematic_self_joins()?
             .remove_numeric_field_references()?
-            .order_limit_removal(context.base_schemas)
+            .order_limit_removal(&context.base_schemas)
     }
 }
 


### PR DESCRIPTION
Change the value type for `base_schemas` in SqlIncorporator from being
`CreateTableBody` directly to being a new `BaseSchema` struct, which
stores the `CreateTableBody` in addition to (now) the `pg_meta` for the
table. This is passed from the Change::CreateTable change in the recipe,
and will eventually be used when constructing postgres result set
metadata for queries that reference columns on tables directly.

Since a reference to `base_schemas` was previously passed directly to
the `RewriteContext` in `readyset_sql_passes`, some stuff had to change
there to make the various reference types and lifetimes work out.

Refs: REA-3380
