### PR TITLE
jepsen: Generate deletes

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -210,7 +210,7 @@
                        (into {})))})
       :generator (gen/phases
                   (->>
-                   (gen/any (rs/inserts (:gen-insert workload))
+                   (gen/any (rs/writes (:gen-write workload))
                             (repeat (rs/query :votes)))
                    (gen/stagger (/ (:rate opts)))
                    (gen/nemesis

--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -3,7 +3,8 @@
    [clojure.core.match :refer [match]]
    [clojure.set :as set]
    [jepsen.checker :as checker]
-   [jepsen.readyset.nodes :as nodes]))
+   [jepsen.readyset.nodes :as nodes]
+   [jepsen.readyset.memory-db :as memory-db]))
 
 (defn liveness
   "All queries should succeed if at least one adapter is alive"
@@ -50,8 +51,7 @@
   which takes a map from tables to rows known to exist in those tables, and
   returns the expected results for that query
 
-  * `{:type :ok, :f :insert, :value {:table table :rows rows}}` ops are inserted
-    into the table
+  * `{:type :ok, :f :value, :value query}` ops are applied to the db
   * `{:f :query, :value {:query-id query-id :results results}}` ops must return
     the results for the query as of *some point* in the past
   * `{:f :consistent-query, :value {:query-id query-id :results results}}` ops
@@ -64,9 +64,8 @@
         (fn [{:keys [rows past-results] :as state}
              {:keys [index type f value]}]
           (case [type f]
-            [:ok :insert]
-            (let [{:keys [table] inserted-rows :rows} value
-                  new-rows (update rows table into inserted-rows)]
+            [:ok :write]
+            (let [new-rows (:rows (memory-db/apply-write {:rows rows} value))]
               (-> state
                   (assoc :rows new-rows)
                   (update
@@ -127,9 +126,9 @@
   (def rows
     (->> t
          :history
-         (filter (comp #{:insert} :f))
+         (filter (comp #{:write} :f))
          (filter (comp #{:ok} :type))
-         (map :value)
+         (map :values)
          (group-by :table)
          (map (fn [[k ops]] [k (mapcat :rows ops)]))
          (into {})))

--- a/jepsen/src/jepsen/readyset/memory_db.clj
+++ b/jepsen/src/jepsen/readyset/memory_db.clj
@@ -1,0 +1,52 @@
+(ns jepsen.readyset.memory-db
+  "Functions for tracking the in-memory state of the DB, responding to SQL
+  statements expressed as HoneySQL maps.
+
+  All functions which take a `db` argument in this `ns` also work on maps with a
+  `:rows` key"
+  (:require [clojure.core.match :refer [match]]))
+
+(defrecord DB [rows])
+
+(defn empty-db
+  "Construct a new, empty DB"
+  []
+  (map->DB {:rows {}}))
+
+(defn insert
+  "Returns a new DB with the given rows inserted into the given table"
+  [db table rows]
+  (update-in db [:rows table] into rows))
+
+(defn- where-clause->pred [table where-clause]
+  (letfn [(get-col [col] (some-fn col
+                                  (keyword (name table) (name col))))]
+    (match where-clause
+      [:= (col :guard keyword?) v]
+      #(= v ((get-col col) %))
+
+      [:in (col :guard keyword?) l]
+      (comp (into #{} l) (get-col col))
+
+      [:and pred1 pred2]
+      (every-pred (where-clause->pred table pred1)
+                  (where-clause->pred table pred2)))))
+
+(defn delete-where
+  "Delete all rows matching the given WHERE clause in the table"
+  [db table where-clause]
+  (update-in
+   db
+   [:rows table]
+   (fn [rows]
+     (remove (where-clause->pred table where-clause) rows))))
+
+(defn apply-write
+  "Apply the given write, which should be a HoneySQL map, to the given db"
+  [db write]
+  (match write
+    {:insert-into table :values rows}
+    (insert db table rows)
+
+    {:delete-from table :where pred}
+    (delete-where db table pred)))

--- a/jepsen/src/jepsen/readyset/workloads.clj
+++ b/jepsen/src/jepsen/readyset/workloads.clj
@@ -9,7 +9,7 @@
      {:query ; honeysql :select map
       :expected-results ; fn from rows map (from table kw to list of rows) to
                           expected results for this query
-      :gen-insert ; fn from rows map to generated honeysql :insert-into map
+      :gen-write ; fn from rows map to generated honeysql query maps for writes
      }}``")
 
 (def votes
@@ -51,23 +51,60 @@
                      (assoc story :vcount (get vote-counts id))))
               (sort-by :stories/id))))}}
 
-   :gen-insert
+   :gen-write
    (fn [rows]
-     (let [candidate-tables (if (contains? rows :stories)
-                              [:stories :votes]
-                              [:stories])]
-       (case (rand-nth candidate-tables)
-         :stories
+     (let [write-candidate-tables (if (seq (:stories rows))
+                                    [:stories :votes]
+                                    [:stories])
+           delete-candidate-tables (->> rows (filter (comp seq val)) (map key))
+           candidates (concat
+                       (map (partial vector :insert) write-candidate-tables)
+                       (map (partial vector :delete) delete-candidate-tables))]
+       (case (rand-nth candidates)
+         [:insert :stories]
          {:insert-into :stories
           :columns [:title]
           ;; generate between 1 and 5 stories
           :values (for [_ (range 0 (inc (rand-int 5)))]
                     [(str "story-" (rand-int (Integer/MAX_VALUE)))])}
-         :votes
+
+         [:insert :votes]
          (let [candidate-stories (->> rows :stories (map :stories/id))]
            {:insert-into :votes
             :columns [:story-id :user-id]
             ;; generate between 1 and 5 votes
             :values (for [_ (range 0 (inc (rand-int 5)))]
                       [(rand-nth candidate-stories)
-                       (rand-int Integer/MAX_VALUE)])}))))})
+                       (rand-int Integer/MAX_VALUE)])})
+
+         [:delete :stories]
+         ;; delete between 1 and 5 stories
+         (let [ids-to-delete (->> rows
+                                  :stories
+                                  (map :stories/id)
+                                  shuffle
+                                  (take (inc (rand-int 5))))]
+           {:delete-from :stories
+            :where (if (= 1 (count ids-to-delete))
+                     [:= :id (first ids-to-delete)]
+                     [:in :id ids-to-delete])})
+
+         [:delete :votes]
+         ;; delete 1 vote
+         (let [vote-to-delete (rand-nth (:votes rows))]
+           {:delete-from :votes
+            :where [:and
+                    [:= :story-id (:votes/story-id vote-to-delete)]
+                    [:= :user-id (:votes/user-id vote-to-delete)]]}))))})
+
+(comment
+  (def sample-rows
+    {:stories [#:stories{:id 1 :title "a"}
+               #:stories{:id 2 :title "b"}]
+     :votes [#:votes{:story-id 1 :user-id 1}
+             #:votes{:story-id 1 :user-id 2}]})
+
+  (def sample-writes
+    (for [_ (range 10)]
+      ((:gen-write votes) sample-rows)))
+  )

--- a/jepsen/test/jepsen/readyset/memory_db_test.clj
+++ b/jepsen/test/jepsen/readyset/memory_db_test.clj
@@ -1,0 +1,22 @@
+(ns jepsen.readyset.memory-db-test
+  (:require [jepsen.readyset.memory-db :as sut]
+            [clojure.test :refer [deftest is]]))
+
+(deftest apply-writes-test
+  (is (= {:t1 [{:t1/x 2} {:t1/x 1}]
+          :t2 [{:t2/y 3 :t2/z 4}]}
+         (:rows
+          (reduce
+           sut/apply-write
+           (sut/empty-db)
+           [{:insert-into :t1 :values [{:t1/x 1}]}
+            {:insert-into :t1 :values [{:t1/x 2} {:t1/x 3}]}
+            {:insert-into :t2 :values [{:t2/y 3 :t2/z 4}
+                                       {:t2/y 3 :t2/z 5}
+                                       {:t2/y 4 :t2/z 4}
+                                       {:t2/y 5 :t2/z 6}]}
+            {:delete-from :t1 :where [:= :x 3]}
+            {:delete-from :t2 :where [:in :y [4 5]]}
+            {:delete-from :t2 :where [:and
+                                      [:= :y 3]
+                                      [:= :z 5]]}])))))


### PR DESCRIPTION
Rename the previous `:insert` op to `:write` and generalize it to
support deletes in addition to just inserts, and make the generator for
writes (renamed from `:gen-insert` to `:gen-write`) also generate
deletes.

Since tracking the expected state of the db is getting complex and now
needs to happen in two places (the Writes generator to generate writes,
and the eventual-consistency checker to track the state of the db), this
also generalizes that out into a new `jepsen.readyset.memory-db`
namespace.

Fixes: REA-3396
