### PR TITLE
replicatiors: Implemented --replication-tables-ignore

### DIFF
--- a/database-utils/src/lib.rs
+++ b/database-utils/src/lib.rs
@@ -80,6 +80,10 @@ pub struct UpstreamConfig {
     #[serde(default)]
     pub replication_tables: Option<RedactedString>,
 
+    #[clap(long, env = "REPLICATION_TABLES_IGNORE")]
+    #[serde(default)]
+    pub replication_tables_ignore: Option<RedactedString>,
+
     /// Sets the time (in seconds) between reports of progress snapshotting the database. A value
     /// of 0 disables reporting.
     #[clap(long, default_value = "30", hide = true)]
@@ -140,6 +144,7 @@ impl Default for UpstreamConfig {
             replication_server_id: Default::default(),
             replicator_restart_timeout: Duration::from_secs(1),
             replication_tables: Default::default(),
+            replication_tables_ignore: Default::default(),
             snapshot_report_interval_secs: 30,
             ssl_root_cert: None,
             replication_pool_size: 50,

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -287,6 +287,7 @@ impl NoriaAdapter {
         let table_filter = TableFilter::try_new(
             nom_sql::Dialect::MySQL,
             config.replication_tables.take(),
+            config.replication_tables_ignore.take(),
             mysql_options.db_name(),
         )?;
 
@@ -497,6 +498,7 @@ impl NoriaAdapter {
         let table_filter = TableFilter::try_new(
             nom_sql::Dialect::PostgreSQL,
             config.replication_tables.take(),
+            config.replication_tables_ignore.take(),
             None,
         )?;
 


### PR DESCRIPTION
Sometimes we have an extensive number of tables but only a few of them
we want to avoid replication. Currently, we can only do this via
--replication-tables, However, if we want to filter out just one table,
we need to list all the ones we want, instead of the single one that we
do not want.

Added an option to blacklist the tables that are going to be
replicated.
This option is mutually exclusive with --replication-tables.

Release-Note-Core: Added a --replication-tables-ignore flag that allows
  you to replicate all tables other than the ones explicity ignored.
  Thanks, altmannmarcelo!

