### PR TITLE
psql-srv: Rename PassThroughDataRow to avoid name clash

### DIFF
--- a/psql-srv/src/codec/encoder.rs
+++ b/psql-srv/src/codec/encoder.rs
@@ -215,7 +215,7 @@ fn encode(message: BackendMessage, dst: &mut BytesMut) -> Result<(), Error> {
             set_i16(i16::try_from(n_values)?, dst, start_ofs + 5)?;
         }
 
-        PassThroughDataRow(row) => {
+        PassThroughSimpleRow(row) => {
             put_u8(ID_DATA_ROW, dst);
             // Put the length of this row in bytes. The length is equal to the length of the data,
             // plus 4 bytes for the length field itself and two bytes for the number of values in
@@ -894,7 +894,7 @@ mod tests {
         data.extend_from_slice(b"fake data for testing");
         codec
             .encode(
-                PassThroughDataRow(
+                PassThroughSimpleRow(
                     SimpleQueryRow::new(
                         vec![OwnedField::new("name".into(), 1, 2, 3, 4, 5, 6)].into(),
                         DataRowBody::new(data.into(), 1),

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -82,7 +82,7 @@ pub enum BackendMessage {
         field_descriptions: Vec<FieldDescription>,
     },
     PassThroughRowDescription(Vec<OwnedField>),
-    PassThroughDataRow(SimpleQueryRow),
+    PassThroughSimpleRow(SimpleQueryRow),
     SSLResponse {
         byte: u8,
     },

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -636,7 +636,7 @@ impl Protocol {
                                         processing_select = true;
                                     }
                                     // Create a message for each row
-                                    messages.push(BackendMessage::PassThroughDataRow(row))
+                                    messages.push(BackendMessage::PassThroughSimpleRow(row))
                                 }
                                 SimpleQueryMessage::CommandComplete(CommandCompleteContents {
                                     fields,


### PR DESCRIPTION
There are different types in tokio-postgres for data rows that are sent
as part of a SimpleQuery response vs data rows that are sent in response
to the parse/bind/describe/exec series of messages. We currently only
support passing through SimpleQuery rows, but we're about to add support
for doing the same thing for the other type of query. To minimize
confusion, I'm renaming the existing enum variant to make it clear it's
specific to SimpleQuery.

Refs: #268
