### PR TITLE
psql-srv: Remove unused PartialEq derivation on Response

### DIFF
--- a/psql-srv/src/response.rs
+++ b/psql-srv/src/response.rs
@@ -11,7 +11,7 @@ use crate::value::PsqlValue;
 /// An encapsulation of a complete response produced by a Postgresql backend in response to a
 /// request. The response will be sent to the frontend as a sequence of zero or more
 /// `BackendMessage`s.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[warn(variant_size_differences)]
 pub enum Response<S> {
     Empty,


### PR DESCRIPTION
There's no need to implement this on Response, and doing so makes us
more dependent on having a PartialEq impl on BackendMessage. I'm
planning on removing PartialEq on BackendMessage in the next commit, so
this paves the way.

Refs: #268
