### PR TITLE
psql-srv: Remove PartialEq from BackendMessage and update tests

### DIFF
--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -26,7 +26,7 @@ const SSL_RESPONSE_WILLING: u8 = b'S';
 /// * `R` - Represents a row of data values. `BackendMessage` implementations are provided wherein a
 ///   value of type `R` will, upon iteration, emit values that are convertible into type
 ///   `PsqlValue`, which can be serialized along with the rest of the `BackendMessage`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)] // TODO: benchmark if this matters
 pub enum BackendMessage {
     AuthenticationCleartextPassword,


### PR DESCRIPTION
The only place we use PartialEq for BackendMessage is in tests, and we
can easily adapt the tests to use pattern matching instead of equality
comparisons. Removing this trait will allow us to add more variants that
contain items that don't implement PartialEq without having to
arbitrarily add derives to the contained types (which is especially
important when those types are defined in dependencies that we can't
easily modify).

In some cases this makes the tests a bit more verbose, but
in other cases it arguably improves the tests by allowing us to not
match on particular field values that we don't care as much about; this
can make tests easier to read, and can also reduce test fragility by not
failing when we change stuff like error strings or server version
strings that don't actually need to contain a specific value in order
for the protocol implementation to be correct.

I also removed the startup_message test entirely, because it was mostly
just testing the hardcoded strings we send back in the ParameterStatus
messages. This doesn't seem like a high enough value test to warrant the
cost of maintaining it, since any change to these strings seems way more
likely to be a deliberate change than an accidental regression.

