### PR TITLE
psql-srv: Add From impl to convert TransferFormat to i16

### DIFF
--- a/psql-srv/src/codec/encoder.rs
+++ b/psql-srv/src/codec/encoder.rs
@@ -215,7 +215,7 @@ fn encode(message: BackendMessage, dst: &mut BytesMut) -> Result<(), Error> {
             set_i16(i16::try_from(n_values)?, dst, start_ofs + 5)?;
         }
 
-        PassThroughDataRow(row) => {
+        PassThroughSimpleRow(row) => {
             put_u8(ID_DATA_ROW, dst);
             // Put the length of this row in bytes. The length is equal to the length of the data,
             // plus 4 bytes for the length field itself and two bytes for the number of values in
@@ -894,7 +894,7 @@ mod tests {
         data.extend_from_slice(b"fake data for testing");
         codec
             .encode(
-                PassThroughDataRow(
+                PassThroughSimpleRow(
                     SimpleQueryRow::new(
                         vec![OwnedField::new("name".into(), 1, 2, 3, 4, 5, 6)].into(),
                         DataRowBody::new(data.into(), 1),

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -26,7 +26,7 @@ const SSL_RESPONSE_WILLING: u8 = b'S';
 /// * `R` - Represents a row of data values. `BackendMessage` implementations are provided wherein a
 ///   value of type `R` will, upon iteration, emit values that are convertible into type
 ///   `PsqlValue`, which can be serialized along with the rest of the `BackendMessage`.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[allow(clippy::large_enum_variant)] // TODO: benchmark if this matters
 pub enum BackendMessage {
     AuthenticationCleartextPassword,

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -82,7 +82,7 @@ pub enum BackendMessage {
         field_descriptions: Vec<FieldDescription>,
     },
     PassThroughRowDescription(Vec<OwnedField>),
-    PassThroughDataRow(SimpleQueryRow),
+    PassThroughSimpleRow(SimpleQueryRow),
     SSLResponse {
         byte: u8,
     },

--- a/psql-srv/src/message/mod.rs
+++ b/psql-srv/src/message/mod.rs
@@ -9,3 +9,12 @@ pub enum TransferFormat {
     Binary,
     Text,
 }
+
+impl From<TransferFormat> for i16 {
+    fn from(value: TransferFormat) -> Self {
+        match value {
+            TransferFormat::Text => 0,
+            TransferFormat::Binary => 1,
+        }
+    }
+}

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -636,7 +636,7 @@ impl Protocol {
                                         processing_select = true;
                                     }
                                     // Create a message for each row
-                                    messages.push(BackendMessage::PassThroughDataRow(row))
+                                    messages.push(BackendMessage::PassThroughSimpleRow(row))
                                 }
                                 SimpleQueryMessage::CommandComplete(CommandCompleteContents {
                                     fields,

--- a/psql-srv/src/response.rs
+++ b/psql-srv/src/response.rs
@@ -11,7 +11,7 @@ use crate::value::PsqlValue;
 /// An encapsulation of a complete response produced by a Postgresql backend in response to a
 /// request. The response will be sent to the frontend as a sequence of zero or more
 /// `BackendMessage`s.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[warn(variant_size_differences)]
 pub enum Response<S> {
     Empty,


### PR DESCRIPTION
This will be useful in a followup commit to let us convert
TransferFormat values to a type usable by tokio-postgres.

Refs: #268
