### PR TITLE
psql-srv: Add support for encoding a passed-through Row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3708,7 +3708,7 @@ dependencies = [
 [[package]]
 name = "postgres-derive"
 version = "0.4.3"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.26",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3729,7 +3729,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "base64 0.20.0",
  "byteorder",
@@ -3746,7 +3746,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -6288,7 +6288,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/readysettech/rust-postgres.git#265eda970565382032371db11106d2d152dce846"
+source = "git+https://github.com/readysettech/rust-postgres.git#530ae67367c8286bb78648772dc265a873e14761"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use nom_sql::SqlIdentifier;
 use postgres::error::ErrorPosition;
 pub use postgres::error::SqlState;
-use postgres::SimpleQueryRow;
+use postgres::{Row, SimpleQueryRow};
 use postgres_types::Type;
 use tokio_postgres::OwnedField;
 
@@ -83,6 +83,8 @@ pub enum BackendMessage {
     },
     PassThroughRowDescription(Vec<OwnedField>),
     PassThroughSimpleRow(SimpleQueryRow),
+    #[allow(unused)]
+    PassThroughDataRow(Row),
     SSLResponse {
         byte: u8,
     },

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -302,6 +302,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                 .generic_query_raw(
                     statement,
                     &convert_params_for_upstream(params, statement.params())?,
+                    Some(1), // Hardcode to binary for now
                 )
                 .await?,
         );


### PR DESCRIPTION
We don't actually use this new code yet, but this updates the
rust-postgres dependencies and adds a new BackendMessage variant that
can be encoded as a DataRow, just like the existing PassThroughSimpleRow
variant.

Refs: #268
