### PR TITLE
psql-srv: Allow Resultsets to yield raw rows via new enum type

### DIFF
--- a/psql-srv/src/channel.rs
+++ b/psql-srv/src/channel.rs
@@ -5,9 +5,8 @@ use tokio_util::codec::Framed;
 
 use crate::codec::{Codec, DecodeError, EncodeError};
 use crate::error::Error;
-use crate::message::FrontendMessage;
+use crate::message::{FrontendMessage, PsqlSrvRow};
 use crate::response::Response;
-use crate::value::PsqlValue;
 
 const CHANNEL_INITIAL_CAPACITY: usize = 4096;
 
@@ -66,7 +65,7 @@ where
     /// Write a `Response` (actually the `BackendMessage`s generated a `Response`) to the channel.
     pub async fn send<S>(&mut self, item: Response<S>) -> Result<(), EncodeError>
     where
-        S: Stream<Item = Result<Vec<PsqlValue>, Error>> + Unpin,
+        S: Stream<Item = Result<PsqlSrvRow, Error>> + Unpin,
     {
         item.write(&mut self.0).await
     }

--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -39,6 +39,7 @@ use tokio_native_tls::TlsAcceptor;
 
 pub use crate::bytes::BytesStr;
 pub use crate::error::Error;
+pub use crate::message::PsqlSrvRow;
 pub use crate::value::PsqlValue;
 
 pub enum CredentialsNeeded {
@@ -61,7 +62,7 @@ pub enum Credentials<'a> {
 pub trait PsqlBackend {
     /// An associated type representing a resultset returned by a SQL query, which can be iterated
     /// to produce `Self::Row`s.
-    type Resultset: Stream<Item = Result<Vec<PsqlValue>, Error>> + Unpin;
+    type Resultset: Stream<Item = Result<PsqlSrvRow, Error>> + Unpin;
 
     /// The postgresql server version number to send to the client on startup, along with ReadySet
     /// info

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -83,7 +83,6 @@ pub enum BackendMessage {
     },
     PassThroughRowDescription(Vec<OwnedField>),
     PassThroughSimpleRow(SimpleQueryRow),
-    #[allow(unused)]
     PassThroughDataRow(Row),
     SSLResponse {
         byte: u8,
@@ -136,4 +135,23 @@ pub struct FieldDescription {
     pub data_type_size: i16,
     pub type_modifier: i32,
     pub transfer_format: TransferFormat,
+}
+
+#[derive(Debug)]
+pub enum PsqlSrvRow {
+    #[allow(unused)]
+    RawRow(Row),
+    ValueVec(Vec<PsqlValue>),
+}
+
+impl From<Vec<PsqlValue>> for PsqlSrvRow {
+    fn from(value: Vec<PsqlValue>) -> Self {
+        Self::ValueVec(value)
+    }
+}
+
+impl From<Row> for PsqlSrvRow {
+    fn from(value: Row) -> Self {
+        Self::RawRow(value)
+    }
 }

--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -8,8 +8,8 @@ use postgres::error::SqlState;
 use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
-    run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlValue,
-    QueryResponse,
+    run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlSrvRow,
+    PsqlValue, QueryResponse,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -33,7 +33,7 @@ struct ScramSha256Backend {
 
 #[async_trait]
 impl PsqlBackend for ScramSha256Backend {
-    type Resultset = stream::Iter<vec::IntoIter<Result<Vec<PsqlValue>, psql_srv::Error>>>;
+    type Resultset = stream::Iter<vec::IntoIter<Result<PsqlSrvRow, psql_srv::Error>>>;
 
     fn version(&self) -> String {
         "13.4 ReadySet".to_string()

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -6,7 +6,7 @@ use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Column, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend,
-    PsqlValue, QueryResponse,
+    PsqlSrvRow, PsqlValue, QueryResponse,
 };
 use tokio::join;
 use tokio::net::TcpListener;
@@ -26,7 +26,7 @@ struct ErrorBackend(ErrorPosition);
 
 #[async_trait]
 impl PsqlBackend for ErrorBackend {
-    type Resultset = stream::Iter<vec::IntoIter<Result<Vec<PsqlValue>, psql_srv::Error>>>;
+    type Resultset = stream::Iter<vec::IntoIter<Result<PsqlSrvRow, psql_srv::Error>>>;
 
     fn credentials_for_user(&self, _user: &str) -> Option<Credentials> {
         Some(Credentials::Any)

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use database_utils::{DatabaseURL, QueryableConnection};
 use futures::stream;
 use postgres_types::Type;
-use psql_srv::{run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlValue};
+use psql_srv::{run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_native_tls::{native_tls, TlsAcceptor};
@@ -25,7 +25,7 @@ impl TryFrom<TestValue> for psql_srv::PsqlValue {
 
 #[async_trait]
 impl PsqlBackend for TestBackend {
-    type Resultset = stream::Iter<vec::IntoIter<Result<Vec<PsqlValue>, Error>>>;
+    type Resultset = stream::Iter<vec::IntoIter<Result<PsqlSrvRow, Error>>>;
 
     fn credentials_for_user(&self, _user: &str) -> Option<Credentials> {
         Some(Credentials::Any)


### PR DESCRIPTION
This commit doesn't change the existing behavior at all, but it does add
a new DataRowValue enum type that can contain either a Vec<PsqlValue>
(as is currently yielded by psql-srv::Backend implementors) or a raw
tokio-postgres Row. This lays more groundwork for passing through raw
rows from proxied queries directly back to the client.

Refs: #268
