### PR TITLE
psql-srv: Pass result formats to on_execute

### DIFF
--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -39,7 +39,7 @@ use tokio_native_tls::TlsAcceptor;
 
 pub use crate::bytes::BytesStr;
 pub use crate::error::Error;
-pub use crate::message::PsqlSrvRow;
+pub use crate::message::{PsqlSrvRow, TransferFormat};
 pub use crate::value::PsqlValue;
 
 pub enum CredentialsNeeded {
@@ -104,12 +104,15 @@ pub trait PsqlBackend {
     ///
     /// * `statement_id` - The identifier of the previously created prepared statement.
     /// * `params` - The values to substitute for the prepared statement's parameter placeholders.
+    /// * `result_transfer_formats` - The Postgres protocol formats requested for result columns in
+    ///   the Bind message that preceded this Execute.
     /// * returns - A `QueryResponse` containing either the data retrieved (for a read query) or a
     ///   confirmation (for a write query), or else an `Error` if a failure occurs.
     async fn on_execute(
         &mut self,
         statement_id: u32,
         params: &[PsqlValue],
+        result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, Error>;
 
     /// Closes (deallocates) a prepared statement.

--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -9,7 +9,7 @@ use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlSrvRow,
-    PsqlValue, QueryResponse,
+    PsqlValue, QueryResponse, TransferFormat,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -67,6 +67,7 @@ impl PsqlBackend for ScramSha256Backend {
         &mut self,
         _statement_id: u32,
         _params: &[PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, Error> {
         unreachable!()
     }

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -6,7 +6,7 @@ use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Column, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend,
-    PsqlSrvRow, PsqlValue, QueryResponse,
+    PsqlSrvRow, PsqlValue, QueryResponse, TransferFormat,
 };
 use tokio::join;
 use tokio::net::TcpListener;
@@ -72,6 +72,7 @@ impl PsqlBackend for ErrorBackend {
         &mut self,
         _statement_id: u32,
         _params: &[PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, Error> {
         match self.0 {
             ErrorPosition::Execute => Err(Error::InternalError("a database".to_owned())),

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -5,7 +5,9 @@ use async_trait::async_trait;
 use database_utils::{DatabaseURL, QueryableConnection};
 use futures::stream;
 use postgres_types::Type;
-use psql_srv::{run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow};
+use psql_srv::{
+    run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow, TransferFormat,
+};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_native_tls::{native_tls, TlsAcceptor};
@@ -58,6 +60,7 @@ impl PsqlBackend for TestBackend {
         &mut self,
         _statement_id: u32,
         _params: &[psql_srv::PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<psql_srv::QueryResponse<Self::Resultset>, psql_srv::Error> {
         panic!() // never called
     }

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -25,6 +25,7 @@ use futures::{ready, Stream, StreamExt, TryStreamExt};
 use postgres_types::Type;
 use psql_srv::{
     Credentials, CredentialsNeeded, PrepareResponse, PsqlBackend, PsqlSrvRow, QueryResponse,
+    TransferFormat,
 };
 use readyset_data::DfValue;
 use readyset_psql::ParamRef;
@@ -205,6 +206,7 @@ impl PsqlBackend for Backend {
         &mut self,
         statement_id: u32,
         params: &[psql_srv::PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, psql_srv::Error> {
         let stmt = self
             .statements

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use eui48::MacAddressFormat;
 use postgres_types::Type;
-use ps::PsqlValue;
+use ps::{PsqlValue, TransferFormat};
 use psql_srv as ps;
 use readyset_adapter::backend as cl;
 use readyset_data::DfValue;
@@ -141,6 +141,7 @@ impl ps::PsqlBackend for Backend {
         &mut self,
         statement_id: u32,
         params: &[PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<ps::QueryResponse<Resultset>, ps::Error> {
         let params = params
             .iter()


### PR DESCRIPTION
We don't do anything with this yet (other than the test code that now
checks this) but this is one of the last piece of the puzzle before we
can tie everything together and do direct passthrough proxying of result
rows for Execute.

Refs: #268
