### PR TITLE
readyset-adapter: Add new type and param for passing metadata to exec

### DIFF
--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -614,7 +614,7 @@ where
             info!(target: "client_statement", "Execute: {{id: {id}, params: {:?}}}", value_params)
         }
 
-        match self.execute(id, &value_params).await {
+        match self.execute(id, &value_params, ()).await {
             Ok(QueryResult::Noria(noria_connector::QueryResult::Select { mut rows, schema })) => {
                 let CachedSchema {
                     mysql_schema,

--- a/readyset-mysql/src/upstream.rs
+++ b/readyset-mysql/src/upstream.rs
@@ -234,6 +234,7 @@ impl UpstreamDatabase for MySqlUpstream {
     type QueryResult<'a> = QueryResult<'a>;
     type StatementMeta = StatementMeta;
     type PrepareData<'a> = ();
+    type ExecMeta<'a> = ();
     type Error = Error;
     const DEFAULT_DB_VERSION: &'static str = "8.0.26-readyset\0";
 
@@ -315,6 +316,7 @@ impl UpstreamDatabase for MySqlUpstream {
         &'a mut self,
         id: u32,
         params: &[DfValue],
+        _exec_meta: Self::ExecMeta<'_>,
     ) -> Result<Self::QueryResult<'a>, Error> {
         let params = dt_to_value_params(params)?;
         let result = self

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -93,7 +93,7 @@ impl Backend {
     }
 
     async fn execute(&mut self, id: u32, params: &[DfValue]) -> Result<QueryResponse<'_>, Error> {
-        Ok(QueryResponse(self.inner.execute(id, params).await?))
+        Ok(QueryResponse(self.inner.execute(id, params, ()).await?))
     }
 }
 

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -156,6 +156,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
     type StatementMeta = StatementMeta;
     type QueryResult<'a> = QueryResult;
     type PrepareData<'a> = &'a [Type];
+    type ExecMeta<'a> = ();
     type Error = Error;
     const DEFAULT_DB_VERSION: &'static str = "13.4 (ReadySet)";
 
@@ -296,6 +297,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
         &'a mut self,
         statement_id: u32,
         params: &[DfValue],
+        _exec_meta: Self::ExecMeta<'_>,
     ) -> Result<Self::QueryResult<'a>, Error> {
         let statement = self
             .prepared_statements


### PR DESCRIPTION
This adds the ability for different backends to pass extra
protocol-specific metadata to `execute`, which will then be passed on to
the upstream `execute` call if needed.

This new ability isn't used yet (both backends just set the type to
the `()` type) but it will be used in a followup commit to pass transfer
formats through for Postgres queries so that the same transfer formats
are used for proxied queries as for the original corresponding client
queries. This is necessary for enabling direct proxying of data rows for
query results so that the transfer format matches what the client
expects.

Refs: #268
