### PR TITLE
readyset-psql: Finish implementation of raw row proxying for Execute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ postgres-protocol = {  git = "https://github.com/readysettech/rust-postgres.git"
 postgres-types = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio-postgres = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio = { version = "1.32",  features = ["full"] }
-rocksdb = { git = "https://github.com/readysettech/rust-rocksdb.git", default-features = false, features = ["lz4"] }
+rocksdb = { git = "https://github.com/readysettech/rust-rocksdb.git", default-features = false, features = ["lz4", "jemalloc"] }
 
 [profile.release]
 debug=true

--- a/psql-srv/src/channel.rs
+++ b/psql-srv/src/channel.rs
@@ -5,9 +5,8 @@ use tokio_util::codec::Framed;
 
 use crate::codec::{Codec, DecodeError, EncodeError};
 use crate::error::Error;
-use crate::message::FrontendMessage;
+use crate::message::{FrontendMessage, PsqlSrvRow};
 use crate::response::Response;
-use crate::value::PsqlValue;
 
 const CHANNEL_INITIAL_CAPACITY: usize = 4096;
 
@@ -66,7 +65,7 @@ where
     /// Write a `Response` (actually the `BackendMessage`s generated a `Response`) to the channel.
     pub async fn send<S>(&mut self, item: Response<S>) -> Result<(), EncodeError>
     where
-        S: Stream<Item = Result<Vec<PsqlValue>, Error>> + Unpin,
+        S: Stream<Item = Result<PsqlSrvRow, Error>> + Unpin,
     {
         item.write(&mut self.0).await
     }

--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -39,7 +39,7 @@ use tokio_native_tls::TlsAcceptor;
 
 pub use crate::bytes::BytesStr;
 pub use crate::error::Error;
-pub use crate::message::PsqlSrvRow;
+pub use crate::message::{PsqlSrvRow, TransferFormat};
 pub use crate::value::PsqlValue;
 
 pub enum CredentialsNeeded {
@@ -104,12 +104,15 @@ pub trait PsqlBackend {
     ///
     /// * `statement_id` - The identifier of the previously created prepared statement.
     /// * `params` - The values to substitute for the prepared statement's parameter placeholders.
+    /// * `result_transfer_formats` - The Postgres protocol formats requested for result columns in
+    ///   the Bind message that preceded this Execute.
     /// * returns - A `QueryResponse` containing either the data retrieved (for a read query) or a
     ///   confirmation (for a write query), or else an `Error` if a failure occurs.
     async fn on_execute(
         &mut self,
         statement_id: u32,
         params: &[PsqlValue],
+        result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, Error>;
 
     /// Closes (deallocates) a prepared statement.

--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -39,6 +39,7 @@ use tokio_native_tls::TlsAcceptor;
 
 pub use crate::bytes::BytesStr;
 pub use crate::error::Error;
+pub use crate::message::PsqlSrvRow;
 pub use crate::value::PsqlValue;
 
 pub enum CredentialsNeeded {
@@ -61,7 +62,7 @@ pub enum Credentials<'a> {
 pub trait PsqlBackend {
     /// An associated type representing a resultset returned by a SQL query, which can be iterated
     /// to produce `Self::Row`s.
-    type Resultset: Stream<Item = Result<Vec<PsqlValue>, Error>> + Unpin;
+    type Resultset: Stream<Item = Result<PsqlSrvRow, Error>> + Unpin;
 
     /// The postgresql server version number to send to the client on startup, along with ReadySet
     /// info

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -83,7 +83,6 @@ pub enum BackendMessage {
     },
     PassThroughRowDescription(Vec<OwnedField>),
     PassThroughSimpleRow(SimpleQueryRow),
-    #[allow(unused)]
     PassThroughDataRow(Row),
     SSLResponse {
         byte: u8,
@@ -136,4 +135,23 @@ pub struct FieldDescription {
     pub data_type_size: i16,
     pub type_modifier: i32,
     pub transfer_format: TransferFormat,
+}
+
+#[derive(Debug)]
+pub enum PsqlSrvRow {
+    #[allow(unused)]
+    RawRow(Row),
+    ValueVec(Vec<PsqlValue>),
+}
+
+impl From<Vec<PsqlValue>> for PsqlSrvRow {
+    fn from(value: Vec<PsqlValue>) -> Self {
+        Self::ValueVec(value)
+    }
+}
+
+impl From<Row> for PsqlSrvRow {
+    fn from(value: Row) -> Self {
+        Self::RawRow(value)
+    }
 }

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -139,7 +139,6 @@ pub struct FieldDescription {
 
 #[derive(Debug)]
 pub enum PsqlSrvRow {
-    #[allow(unused)]
     RawRow(Row),
     ValueVec(Vec<PsqlValue>),
 }

--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -8,8 +8,8 @@ use postgres::error::SqlState;
 use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
-    run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlValue,
-    QueryResponse,
+    run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlSrvRow,
+    PsqlValue, QueryResponse,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -33,7 +33,7 @@ struct ScramSha256Backend {
 
 #[async_trait]
 impl PsqlBackend for ScramSha256Backend {
-    type Resultset = stream::Iter<vec::IntoIter<Result<Vec<PsqlValue>, psql_srv::Error>>>;
+    type Resultset = stream::Iter<vec::IntoIter<Result<PsqlSrvRow, psql_srv::Error>>>;
 
     fn version(&self) -> String {
         "13.4 ReadySet".to_string()

--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -9,7 +9,7 @@ use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlSrvRow,
-    PsqlValue, QueryResponse,
+    PsqlValue, QueryResponse, TransferFormat,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -67,6 +67,7 @@ impl PsqlBackend for ScramSha256Backend {
         &mut self,
         _statement_id: u32,
         _params: &[PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, Error> {
         unreachable!()
     }

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -6,7 +6,7 @@ use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Column, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend,
-    PsqlSrvRow, PsqlValue, QueryResponse,
+    PsqlSrvRow, PsqlValue, QueryResponse, TransferFormat,
 };
 use tokio::join;
 use tokio::net::TcpListener;
@@ -72,6 +72,7 @@ impl PsqlBackend for ErrorBackend {
         &mut self,
         _statement_id: u32,
         _params: &[PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, Error> {
         match self.0 {
             ErrorPosition::Execute => Err(Error::InternalError("a database".to_owned())),

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -6,7 +6,7 @@ use postgres::NoTls;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Column, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend,
-    PsqlValue, QueryResponse,
+    PsqlSrvRow, PsqlValue, QueryResponse,
 };
 use tokio::join;
 use tokio::net::TcpListener;
@@ -26,7 +26,7 @@ struct ErrorBackend(ErrorPosition);
 
 #[async_trait]
 impl PsqlBackend for ErrorBackend {
-    type Resultset = stream::Iter<vec::IntoIter<Result<Vec<PsqlValue>, psql_srv::Error>>>;
+    type Resultset = stream::Iter<vec::IntoIter<Result<PsqlSrvRow, psql_srv::Error>>>;
 
     fn credentials_for_user(&self, _user: &str) -> Option<Credentials> {
         Some(Credentials::Any)

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use database_utils::{DatabaseURL, QueryableConnection};
 use futures::stream;
 use postgres_types::Type;
-use psql_srv::{run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlValue};
+use psql_srv::{run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_native_tls::{native_tls, TlsAcceptor};
@@ -25,7 +25,7 @@ impl TryFrom<TestValue> for psql_srv::PsqlValue {
 
 #[async_trait]
 impl PsqlBackend for TestBackend {
-    type Resultset = stream::Iter<vec::IntoIter<Result<Vec<PsqlValue>, Error>>>;
+    type Resultset = stream::Iter<vec::IntoIter<Result<PsqlSrvRow, Error>>>;
 
     fn credentials_for_user(&self, _user: &str) -> Option<Credentials> {
         Some(Credentials::Any)

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -5,7 +5,9 @@ use async_trait::async_trait;
 use database_utils::{DatabaseURL, QueryableConnection};
 use futures::stream;
 use postgres_types::Type;
-use psql_srv::{run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow};
+use psql_srv::{
+    run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow, TransferFormat,
+};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_native_tls::{native_tls, TlsAcceptor};
@@ -58,6 +60,7 @@ impl PsqlBackend for TestBackend {
         &mut self,
         _statement_id: u32,
         _params: &[psql_srv::PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<psql_srv::QueryResponse<Self::Resultset>, psql_srv::Error> {
         panic!() // never called
     }

--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -614,7 +614,7 @@ where
             info!(target: "client_statement", "Execute: {{id: {id}, params: {:?}}}", value_params)
         }
 
-        match self.execute(id, &value_params).await {
+        match self.execute(id, &value_params, ()).await {
             Ok(QueryResult::Noria(noria_connector::QueryResult::Select { mut rows, schema })) => {
                 let CachedSchema {
                     mysql_schema,

--- a/readyset-mysql/src/upstream.rs
+++ b/readyset-mysql/src/upstream.rs
@@ -234,6 +234,7 @@ impl UpstreamDatabase for MySqlUpstream {
     type QueryResult<'a> = QueryResult<'a>;
     type StatementMeta = StatementMeta;
     type PrepareData<'a> = ();
+    type ExecMeta<'a> = ();
     type Error = Error;
     const DEFAULT_DB_VERSION: &'static str = "8.0.26-readyset\0";
 
@@ -315,6 +316,7 @@ impl UpstreamDatabase for MySqlUpstream {
         &'a mut self,
         id: u32,
         params: &[DfValue],
+        _exec_meta: Self::ExecMeta<'_>,
     ) -> Result<Self::QueryResult<'a>, Error> {
         let params = dt_to_value_params(params)?;
         let result = self

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -25,6 +25,7 @@ use futures::{ready, Stream, StreamExt, TryStreamExt};
 use postgres_types::Type;
 use psql_srv::{
     Credentials, CredentialsNeeded, PrepareResponse, PsqlBackend, PsqlSrvRow, QueryResponse,
+    TransferFormat,
 };
 use readyset_data::DfValue;
 use readyset_psql::ParamRef;
@@ -205,6 +206,7 @@ impl PsqlBackend for Backend {
         &mut self,
         statement_id: u32,
         params: &[psql_srv::PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<QueryResponse<Self::Resultset>, psql_srv::Error> {
         let stmt = self
             .statements

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use eui48::MacAddressFormat;
 use postgres_types::Type;
-use ps::PsqlValue;
+use ps::{PsqlValue, TransferFormat};
 use psql_srv as ps;
 use readyset_adapter::backend as cl;
 use readyset_data::DfValue;
@@ -141,6 +141,7 @@ impl ps::PsqlBackend for Backend {
         &mut self,
         statement_id: u32,
         params: &[PsqlValue],
+        _result_transfer_formats: &[TransferFormat],
     ) -> Result<ps::QueryResponse<Resultset>, ps::Error> {
         let params = params
             .iter()

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -93,7 +93,7 @@ impl Backend {
     }
 
     async fn execute(&mut self, id: u32, params: &[DfValue]) -> Result<QueryResponse<'_>, Error> {
-        Ok(QueryResponse(self.inner.execute(id, params).await?))
+        Ok(QueryResponse(self.inner.execute(id, params, ()).await?))
     }
 }
 

--- a/readyset-psql/src/resultset.rs
+++ b/readyset-psql/src/resultset.rs
@@ -102,22 +102,7 @@ impl Stream for Resultset {
                     },
                 };
 
-                row.map(|r| {
-                    r.and_then(|r| {
-                        (0..r.columns().len())
-                            .map(|i| {
-                                r.try_get(i).map_err(|e| {
-                                    psql_srv::Error::InternalError(format!(
-                                        "could not retrieve expected column index {} from row \
-                                         while parsing psql result: {}",
-                                        i, e
-                                    ))
-                                })
-                            })
-                            .collect()
-                    })
-                    .map(PsqlSrvRow::ValueVec)
-                })
+                row.map(|res| res.map(PsqlSrvRow::RawRow))
             }
         };
 

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -156,6 +156,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
     type StatementMeta = StatementMeta;
     type QueryResult<'a> = QueryResult;
     type PrepareData<'a> = &'a [Type];
+    type ExecMeta<'a> = ();
     type Error = Error;
     const DEFAULT_DB_VERSION: &'static str = "13.4 (ReadySet)";
 
@@ -296,6 +297,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
         &'a mut self,
         statement_id: u32,
         params: &[DfValue],
+        _exec_meta: Self::ExecMeta<'_>,
     ) -> Result<Self::QueryResult<'a>, Error> {
         let statement = self
             .prepared_statements


### PR DESCRIPTION
This ties together a bunch of previous commits to actually start passing
through raw rows in response to Postgres queries that use the extended
query protocol. We now:

 - Yield raw rows from the resultset Stream implementation instead of
   converting rows to Vec<PsqlValue>
 - Use the new ExecMeta feature to pass the list of transfer formats
   through to the upstream code
 - Use the new From impl from the last commit to convert TransferFormat
   to i16 before passing into the tokio-postgres code

It was necessary to start passing through the transfer formats in the
same commit where we start passing through the raw rows, since otherwise
the client may not get the result format it expects when it requests
text format for specific results.

Fixes: #268
