### PR TITLE
benchmarks: remove heaptrack from open_write_latency.sh

### DIFF
--- a/benchmarks/scripts/open_write_latency.sh
+++ b/benchmarks/scripts/open_write_latency.sh
@@ -24,7 +24,7 @@ done
 cargo build --release --bin benchmarks
 for num_indices in "${indices[@]}"; do
     echo "=== Benchmarking ${num_indices} indices ==="
-    heaptrack target/release/benchmarks \
+    target/release/benchmarks \
         --local \
         --database-type "${DATABASE_TYPE:-mysql}" \
         --graph \


### PR DESCRIPTION
heaptrack was inadvertently committed to this script.

