### PR TITLE
jepsen: Generalize passing current rows to generators

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -210,8 +210,9 @@
                        (into {})))})
       :generator (gen/phases
                   (->>
-                   (gen/any (rs/writes (:gen-write workload))
-                            (repeat (rs/query :votes)))
+                   (gen/any
+                    (rs/with-rows (:gen-write workload))
+                    (repeat (rs/query :votes)))
                    (gen/stagger (/ (:rate opts)))
                    (gen/nemesis
                     (->> (gen/mix

--- a/jepsen/src/jepsen/readyset/workloads.clj
+++ b/jepsen/src/jepsen/readyset/workloads.clj
@@ -10,7 +10,8 @@
       :expected-results ; fn from rows map (from table kw to list of rows) to
                           expected results for this query
       :gen-write ; fn from rows map to generated honeysql query maps for writes
-     }}``")
+     }}``"
+  (:require [jepsen.readyset.client :as rs]))
 
 (def votes
   {:tables
@@ -52,50 +53,51 @@
               (sort-by :stories/id))))}}
 
    :gen-write
-   (fn [rows]
-     (let [write-candidate-tables (if (seq (:stories rows))
-                                    [:stories :votes]
-                                    [:stories])
-           delete-candidate-tables (->> rows (filter (comp seq val)) (map key))
-           candidates (concat
-                       (map (partial vector :insert) write-candidate-tables)
-                       (map (partial vector :delete) delete-candidate-tables))]
-       (case (rand-nth candidates)
-         [:insert :stories]
-         {:insert-into :stories
-          :columns [:title]
-          ;; generate between 1 and 5 stories
-          :values (for [_ (range 0 (inc (rand-int 5)))]
-                    [(str "story-" (rand-int (Integer/MAX_VALUE)))])}
+   (fn [_test {:keys [rows]}]
+     (rs/write
+      (let [write-candidate-tables (if (seq (:stories rows))
+                                     [:stories :votes]
+                                     [:stories])
+            delete-candidate-tables (->> rows (filter (comp seq val)) (map key))
+            candidates (concat
+                        (map (partial vector :insert) write-candidate-tables)
+                        (map (partial vector :delete) delete-candidate-tables))]
+        (case (rand-nth candidates)
+          [:insert :stories]
+          {:insert-into :stories
+           :columns [:title]
+           ;; generate between 1 and 5 stories
+           :values (for [_ (range 0 (inc (rand-int 5)))]
+                     [(str "story-" (rand-int (Integer/MAX_VALUE)))])}
 
-         [:insert :votes]
-         (let [candidate-stories (->> rows :stories (map :stories/id))]
-           {:insert-into :votes
-            :columns [:story-id :user-id]
-            ;; generate between 1 and 5 votes
-            :values (for [_ (range 0 (inc (rand-int 5)))]
-                      [(rand-nth candidate-stories)
-                       (rand-int Integer/MAX_VALUE)])})
+          [:insert :votes]
+          (let [candidate-stories (->> rows :stories (map :stories/id))]
+            {:insert-into :votes
+             :columns [:story-id :user-id]
+             ;; generate between 1 and 5 votes
+             :values (for [_ (range 0 (inc (rand-int 5)))]
+                       [(rand-nth candidate-stories)
+                        (rand-int Integer/MAX_VALUE)])})
 
-         [:delete :stories]
-         ;; delete between 1 and 5 stories
-         (let [ids-to-delete (->> rows
-                                  :stories
-                                  (map :stories/id)
-                                  shuffle
-                                  (take (inc (rand-int 5))))]
-           {:delete-from :stories
-            :where (if (= 1 (count ids-to-delete))
-                     [:= :id (first ids-to-delete)]
-                     [:in :id ids-to-delete])})
+          [:delete :stories]
+          ;; delete between 1 and 5 stories
+          (let [ids-to-delete (->> rows
+                                   :stories
+                                   (map :stories/id)
+                                   shuffle
+                                   (take (inc (rand-int 5))))]
+            {:delete-from :stories
+             :where (if (= 1 (count ids-to-delete))
+                      [:= :id (first ids-to-delete)]
+                      [:in :id ids-to-delete])})
 
-         [:delete :votes]
-         ;; delete 1 vote
-         (let [vote-to-delete (rand-nth (:votes rows))]
-           {:delete-from :votes
-            :where [:and
-                    [:= :story-id (:votes/story-id vote-to-delete)]
-                    [:= :user-id (:votes/user-id vote-to-delete)]]}))))})
+          [:delete :votes]
+          ;; delete 1 vote
+          (let [vote-to-delete (rand-nth (:votes rows))]
+            {:delete-from :votes
+             :where [:and
+                     [:= :story-id (:votes/story-id vote-to-delete)]
+                     [:= :user-id (:votes/user-id vote-to-delete)]]})))))})
 
 (comment
   (def sample-rows


### PR DESCRIPTION
Rather than packaging up the "track current rows and pass them to
generators" behavior in a custom Writes generator, make it into a
generator *wrapper* which can add tracking of the current rows within
the `context` map to *any* generator. This follows the pattern Jepsen
uses for its own generators more closely, and also allows us to use this
to generate more than just write ops that care about the current rows in
the table.

