### PR TITLE
readyset-psql: Un-ignore passing fallback test

### DIFF
--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -680,7 +680,6 @@ async fn deletion_propagation_after_alter() {
     shutdown_tx.shutdown().await;
 }
 
-#[ignore = "ENG-3041 Test reproduces write drop due to known bug"]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 async fn write_propagation_after_alter_and_drop() {


### PR DESCRIPTION
This was fixed some time ago when we fixed #106 by reverting the
following commit:

670413429 (replicators: Skip catch up if ReadySet did not snapshot any table., 2023-03-30)

in this revert commit here:

0e8746ac3 (Revert "replicators: Skip catch up if ReadySet did not snapshot any table.", 2023-07-10)

But I neglected to also enable the test after the revert was merged.
Since the test now passes, I'm removing the ignore.

Refs: #106
Refs: REA-2664
Refs: REA-2437
