### PR TITLE
nom-sql: Added support for SHOW PROXIED SUPPORTED QUERIES

### DIFF
--- a/readyset-client/src/query.rs
+++ b/readyset-client/src/query.rs
@@ -366,6 +366,14 @@ impl MigrationState {
             MigrationState::Pending | MigrationState::DryRunSucceeded
         )
     }
+
+    /// Returns true if the query should be considered "supported"
+    pub fn is_supported(&self) -> bool {
+        matches!(
+            self,
+            MigrationState::Dropped | MigrationState::DryRunSucceeded | MigrationState::Successful
+        )
+    }
 }
 
 impl Display for MigrationState {


### PR DESCRIPTION
On a heavy-load system, SHOW PROXIED QUERIES can show a large number of queries that might not be eligible for caching.

Added support for a variant of SHOW PROXIED QUERIES that accept an optional [SUPPORTED] keyword. If present, only queries that are eligible for caching are shown.

Closes #428 