### PR TITLE
dataflow-expression: Function names are case-insensitive

### DIFF
--- a/dataflow-expression/src/lower.rs
+++ b/dataflow-expression/src/lower.rs
@@ -175,7 +175,7 @@ impl BuiltinFunction {
             null_on_failure: true,
         };
 
-        let result = match name {
+        let result = match name.to_lowercase().as_str() {
             "convert_tz" => {
                 // Type is inferred from input argument
                 let input = next_arg()?;
@@ -1247,6 +1247,44 @@ pub(crate) mod tests {
     fn call_coalesce() {
         let input = AstExpr::Call(FunctionExpr::Call {
             name: "coalesce".into(),
+            arguments: vec![AstExpr::Column("t.x".into()), AstExpr::Literal(2.into())],
+        });
+
+        let result = Expr::lower(
+            input,
+            Dialect::DEFAULT_MYSQL,
+            resolve_columns(|c| {
+                if c == "t.x".into() {
+                    Ok((0, DfType::Int))
+                } else {
+                    internal!("what's this column!?")
+                }
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            Expr::Call {
+                func: Box::new(BuiltinFunction::Coalesce(
+                    Expr::Column {
+                        index: 0,
+                        ty: DfType::Int
+                    },
+                    vec![Expr::Literal {
+                        val: 2.into(),
+                        ty: DfType::BigInt
+                    }]
+                )),
+                ty: DfType::Int
+            }
+        );
+    }
+
+    #[test]
+    fn call_coalesce_uppercase() {
+        let input = AstExpr::Call(FunctionExpr::Call {
+            name: "COALESCE".into(),
             arguments: vec![AstExpr::Column("t.x".into()), AstExpr::Literal(2.into())],
         });
 

--- a/logictests/functions.test
+++ b/logictests/functions.test
@@ -1,0 +1,11 @@
+statement ok
+create table t1 (x int, y int);
+
+statement ok
+insert into t1 (x, y) values (1, null);
+
+query II nosort
+select x, COALESCE(y, 2) FROM t1;
+----
+1
+2


### PR DESCRIPTION
SQL function names are case-insensitive, but we only accepted
all-lowercase versions of built-in functions. This commit modifies expr
lowering to compare function names case-insensitively (by calling
`to_lowercase` before matching on the name of the function).

