### PR TITLE
rocksdb: Build with jemalloc allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,6 +2557,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ postgres-protocol = {  git = "https://github.com/readysettech/rust-postgres.git"
 postgres-types = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio-postgres = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio = { version = "1.32",  features = ["full"] }
-rocksdb = { git = "https://github.com/readysettech/rust-rocksdb.git", default-features = false, features = ["lz4"] }
+rocksdb = { git = "https://github.com/readysettech/rust-rocksdb.git", default-features = false, features = ["lz4", "jemalloc"] }
 
 [profile.release]
 debug=true


### PR DESCRIPTION
We use jemalloc for memory tracking, so we need to build rocksdb with
jemalloc as well so that memory used by rocksdb is properly accounted
for. This particularly matters for evictions--if we don't properly
account for all memory used by the process, then we could possibly fail
to evict and the process could be oomkilled.

