### PR TITLE
migrate: Fix new-materializations-above-existing-nodes check

### DIFF
--- a/logictests/shared_ingress.test
+++ b/logictests/shared_ingress.test
@@ -84,3 +84,36 @@ ORDER BY A.title, A.id LIMIT 20
 3
 4
 5
+
+statement ok
+CREATE TABLE title_basics (
+    tconst text NOT NULL,
+    titletype text,
+    primarytitle text,
+    originaltitle text,
+    isadult boolean,
+    startyear integer,
+    endyear integer,
+    runtimeminutes integer,
+    genres text
+);
+
+statement ok
+CREATE TABLE title_ratings (
+    tconst text NOT NULL,
+    averagerating numeric,
+    numvotes integer
+);
+
+
+onlyif readyset
+statement ok
+CREATE CACHE FROM SELECT count(*) FROM title_ratings
+JOIN title_basics ON title_ratings.tconst = title_basics.tconst
+WHERE title_basics.startyear = 2000 AND title_ratings.averagerating > 5;
+
+onlyif readyset
+statement ok
+CREATE CACHE FROM SELECT count(*) FROM title_ratings
+JOIN title_basics ON title_ratings.tconst = title_basics.tconst
+WHERE title_basics.endyear = 2000 AND title_ratings.averagerating > 5;


### PR DESCRIPTION
When we modified the materialization code to always add indexes to nodes
during migrations in e6f42f252 (server: Always add indexes during
recovery, 2023-07-26), the condition that was being used to check if we
were making a previously *non*-materialized node newly-materialized
broke subtly - because we were *always* writing to `self.added` even
when the node was already materialized, we'd always think a node that
was receiving a new index was materialized, even when it already had
that index.

This fixes that by tracking a set of nodes that *were* materialized as
of the last time we called `commit` in a new field to `self.had`, and
only checking nodes that *aren't* in that set (and also aren't being
newly added) in this check.

I also added a note about this check itself noting what we might want to
do if it ever *correctly* gets hit, since I was thinking about it
anyway.

Fixes: #421
