### PR TITLE
jepsen: Switch to a simpler workload

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -179,7 +179,7 @@
 
 (defn readyset-test
   [opts]
-  (let [workload workloads/votes]
+  (let [workload workloads/grouped-count]
     (merge
      tests/noop-test
      opts


### PR DESCRIPTION
Only a week into jepsen testing, and I've already hit up into the
internal inconsistency problem. This probably shouldn't surprise me.

Writing an efficient checker for eventual consistency of a query with
joins when we don't have internal inconsistency is *hard*. We might
still do it at some point, but for the time being I'm switching to a
simpler workload that still exercises a few properties of the system - a
single count(*) with a group and a parameter - and I'm going to start
expanding on nemeses to try to introduce *some* kind of breakage.

