### PR TITLE
jepsen: COUNT(*) returns 0 before any writes

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -203,11 +203,7 @@
                 {:liveness (rs.checker/liveness)
                  :eventually-consistent
                  (rs.checker/commutative-eventual-consistency
-                  (->> workload
-                       :queries
-                       (map (fn [[k {:keys [expected-results]}]]
-                              [k expected-results]))
-                       (into {})))})
+                  (:queries workload))})
       :generator (gen/phases
                   (->>
                    (apply

--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -87,8 +87,8 @@
                    :past-results
                    (fn [results]
                      (reduce-kv
-                      (fn [results query-id compute-results]
-                        (let [expected (compute-results new-rows)]
+                      (fn [results query-id {:keys [expected-results]}]
+                        (let [expected (expected-results new-rows)]
                           (update-in results
                                      [query-id
                                       (if (fn? expected)
@@ -124,7 +124,9 @@
          :rows {}
          :past-results
          (into {}
-               (map (fn [[k _]] [k {:expected-results/set #{[]}}]))
+               (map (fn [[k {:keys [initial-expected-results]}]]
+                      [k {:expected-results/set (or initial-expected-results
+                                                    #{[]})}]))
                expected-query-results)}
         history)
        ;; Don't include these keys in the final map; they get big and are

--- a/jepsen/src/jepsen/readyset/workloads.clj
+++ b/jepsen/src/jepsen/readyset/workloads.clj
@@ -8,6 +8,7 @@
     {:query-id-one
      {:query ; honeysql :select map
       :gen-params ; optional, generate params for this query
+      :initial-expected-results ; allowed results before any insert op
       :expected-results ; fn from rows map (from table kw to list of rows) to
                           expected results for this query
       :gen-write ; fn from rows map to generated honeysql query maps for writes
@@ -47,6 +48,7 @@
                :where [:= :grp [:param :grp]]}
 
               :gen-params (fn [_] {:grp (rand-int 10)})
+              :initial-expected-results #{[{:count 0}]}
               :expected-results
               (fn [rows]
                 (fn [params]


### PR DESCRIPTION
Allow queries in workloads to specify a `:initial-expected-results` key,
to support the fact that `COUNT(*)` returns a single row with a 0 count
rather than an empty result set before any rows have been written.

