### PR TITLE
jepsen: Apply writes on invoke, not ok

### DIFF
--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -79,7 +79,7 @@
         (fn [{:keys [rows past-results] :as state}
              {:keys [index type f value]}]
           (case [type f]
-            [:ok :write]
+            [:invoke :write]
             (let [new-rows (:rows (memory-db/apply-write {:rows rows} value))]
               (-> state
                   (assoc :rows new-rows)

--- a/jepsen/src/jepsen/readyset/memory_db.clj
+++ b/jepsen/src/jepsen/readyset/memory_db.clj
@@ -41,10 +41,19 @@
    (fn [rows]
      (remove (where-clause->pred table where-clause) rows))))
 
+(defn- ->rows [rows table columns]
+  (for [row rows]
+    (condp #(%1 %2) row
+      map? row
+      vector? (zipmap (map #(keyword (name table) (name %)) columns) row))))
+
 (defn apply-write
   "Apply the given write, which should be a HoneySQL map, to the given db"
   [db write]
   (match write
+    {:insert-into table :columns columns :values rows}
+    (insert db table (->rows rows table columns))
+
     {:insert-into table :values rows}
     (insert db table rows)
 


### PR DESCRIPTION
If things happen fast enough (which they do some of the time in
practice!) a query can see the effect of a write after it starts, but
before Jepsen reports the op as having finished. This updates the
eventual-consistency checker to apply writes on `:invoke`, not `:ok`, to
allow for this. Since the shape of the insert map is slightly different,
this also has to update the `memory-db` to turn the map into the shape
we expect.

