### PR TITLE
readyset-server: Reword full materialization error

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -8,7 +8,8 @@
                  [clj-http "3.10.0"]
                  [com.github.seancorfield/next.jdbc "1.3.883"]
                  [org.postgresql/postgresql "42.6.0"]
-                 [slingshot "0.12.2"]]
+                 [slingshot "0.12.2"]
+                 [org.clojure/core.match "1.0.1"]]
   :plugins [[com.github.clj-kondo/lein-clj-kondo "0.2.5"]]
   :repl-options {:init-ns jepsen.readyset}
   :main jepsen.readyset

--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -16,10 +16,11 @@
    [jepsen.os.debian :as debian]
    [jepsen.os.ubuntu :as ubuntu]
    [jepsen.readyset.automation :as rs.auto]
+   [jepsen.readyset.checker :as rs.checker]
    [jepsen.readyset.client :as rs]
-   [jepsen.readyset.model :as rs.model]
    [jepsen.readyset.nemesis :as rs.nemesis]
    [jepsen.readyset.nodes :as nodes]
+   [jepsen.readyset.model :as rs.model]
    [jepsen.tests :as tests]
    [slingshot.slingshot :refer [try+]]))
 
@@ -191,9 +192,12 @@
                 :start-adapter :stop} (rs.nemesis/kill-adapters)
                {:kill-server :start
                 :start-server :stop} (rs.nemesis/kill-server)})
-    :checker (checker/linearizable
-              {:model (rs.model/eventually-consistent-table)
-               :algorithm :linear})
+    :checker (checker/compose
+              {:liveness (rs.checker/liveness)
+               :eventually-consistent
+               (checker/linearizable
+                {:model (rs.model/eventually-consistent-table)
+                 :algorithm :linear})})
     :generator (gen/phases
                 (->> (gen/mix [rs/r rs/w])
                      (gen/stagger (/ (:rate opts)))

--- a/jepsen/src/jepsen/readyset/automation.clj
+++ b/jepsen/src/jepsen/readyset/automation.clj
@@ -61,7 +61,7 @@
        "@" (nodes/node-with-role test :node-role/upstream)
        "/" rs/pgdatabase))
 
-(defn start-readyset-adapter! [node test]
+(defn start-readyset-adapter! [test node]
   (c/su
    (cu/start-daemon!
     {:logfile "/var/log/readyset.log"
@@ -79,7 +79,13 @@
     :--embedded-readers
     :--reader-replicas (str (nodes/num-adapters test)))))
 
-(defn start-readyset-server! [node test]
+(defn kill-readyset-adapter!
+  "Kill the readyset adapter process running on the current node."
+  [& [_test _node]]
+  (c/su
+   (cu/stop-daemon! "/var/run/readyset.pid")))
+
+(defn start-readyset-server! [test node]
   (c/su
    (c/exec :mkdir :-p "/opt/readyset/data")
    (cu/start-daemon!
@@ -98,3 +104,9 @@
     :--disable-upstream-ssl-verification
     :--no-readers
     :--reader-replicas (str (nodes/num-adapters test)))))
+
+(defn kill-readyset-server!
+  "Kill the readyset server process running on the current node."
+  [& [_test _node]]
+  (c/su
+   (cu/stop-daemon! "/var/run/readyset-server.pid")))

--- a/jepsen/src/jepsen/readyset/checker.clj
+++ b/jepsen/src/jepsen/readyset/checker.clj
@@ -1,0 +1,43 @@
+(ns jepsen.readyset.checker
+  (:require
+   [clojure.core.match :refer [match]]
+   [clojure.set :as set]
+   [jepsen.checker :as checker]
+   [jepsen.readyset.nodes :as nodes]))
+
+(defn liveness
+  "All queries should succeed if at least one adapter is alive"
+  []
+  (reify checker/Checker
+    (check [_this test history _opts]
+      (let [initial-live-adapters (into #{}
+                                        (nodes/nodes-with-role
+                                         test
+                                         :node-role/readyset-adapter))]
+        (reduce
+         (fn [state {:keys [index type f value]}]
+           (match [type f value]
+             [:info :kill-adapter (_ :guard map?)]
+             (update
+              state
+              :live-adapters
+              #(set/difference %
+                               ;; `value` looks like a map from node name to ""
+                               (into #{} (keys value))))
+
+             [:info :start-adapter (_ :guard map?)]
+             (update state :live-adapters into (keys value))
+
+             [:fail _ _]
+             (if (seq (:live-adapters state))
+               (reduced
+                (assoc state
+                       :valid? false
+                       :failed-at index))
+               state)
+
+             :else state))
+         {:valid? true
+          :failed-at nil
+          :live-adapters initial-live-adapters}
+         history)))))

--- a/jepsen/src/jepsen/readyset/nemesis.clj
+++ b/jepsen/src/jepsen/readyset/nemesis.clj
@@ -1,0 +1,37 @@
+(ns jepsen.readyset.nemesis
+  (:require [jepsen.nemesis :as nemesis]
+            [jepsen.readyset.nodes :as nodes]
+            [jepsen.readyset.automation :as rs.auto]))
+
+(defn- wrap-reflection [fs nemesis]
+  (reify
+    nemesis/Nemesis
+    (setup! [_ test] (nemesis/setup! nemesis test))
+    (invoke! [_ test op] (nemesis/invoke! nemesis test op))
+    (teardown! [_ test] (nemesis/teardown! nemesis test))
+
+    nemesis/Reflection
+    (fs [_] fs)))
+
+(defn kill-adapters
+  "Nemesis which kills a random adapter at `{:f :start}`, and starts the adapter
+  at `{:f :stop}`"
+  []
+  (wrap-reflection
+   #{:start :stop}
+   (nemesis/node-start-stopper
+    (fn [test _nodes]
+      [(rand-nth (nodes/nodes-with-role test :node-role/readyset-adapter))])
+    rs.auto/kill-readyset-adapter!
+    rs.auto/start-readyset-adapter!)))
+
+(defn kill-server
+  "Nemesis which kills the server at `{:f :start}`, and starts the server at
+  `{:f :stop}`"
+  []
+  (wrap-reflection
+   #{:start :stop}
+   (nemesis/node-start-stopper
+    (fn [test _nodes] [(nodes/node-with-role test :node-role/readyset-server)])
+    rs.auto/kill-readyset-server!
+    rs.auto/start-readyset-server!)))

--- a/jepsen/src/jepsen/readyset/nodes.clj
+++ b/jepsen/src/jepsen/readyset/nodes.clj
@@ -39,9 +39,17 @@
   (get (node->role test) node))
 
 (defn node-with-role
-  "Returns the node with the given role in the given test"
+  "Returns the first node with the given role in the given test"
   [test role]
   (get (role->node test) role))
+
+(defn nodes-with-role
+  "Returns a list of the nodes with the given role in the given test"
+  [test role]
+  (->> test
+       node->role
+       (filter (comp #{role} val))
+       (map key)))
 
 (defn adapter-nodes
   "Returns a sequence of adapter nodes in the given test"
@@ -53,3 +61,9 @@
   test"
   [test]
   (- (count (:nodes test)) 4))
+
+(comment
+  (def example-test {:nodes (map #(str "node-" %) (range 10))})
+
+  (nodes-with-role example-test :node-role/readyset-adapter)
+  )

--- a/readyset-server/src/controller/migrate/materialization/mod.rs
+++ b/readyset-server/src/controller/migrate/materialization/mod.rs
@@ -612,7 +612,7 @@ impl Materializations {
                     replay_obligations.entry(mi).or_default().extend(indices);
                 }
             } else if !graph[ni].is_base() && !self.config.allow_full_materialization {
-                unsupported!("Creation of fully materialized query is forbidden");
+                unsupported!("Creation of fully materialized query is disabled.");
             } else {
                 invariant!(
                     !graph[ni].purge,

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -8489,7 +8489,7 @@ async fn forbid_full_materialization() {
     let err = res.err().unwrap();
     assert!(err
         .to_string()
-        .contains("Creation of fully materialized query is forbidden"));
+        .contains("Creation of fully materialized query is disabled."));
     assert!(err.caused_by_unsupported());
 
     shutdown_tx.shutdown().await;


### PR DESCRIPTION
This rewords the unsupported error for full materializations when
`--allow-full-materialization` is not supplied to say "disabled" rather
than "forbidden" in order to sound less strong.

Refs: #458
