### PR TITLE
replicators: Don't add 1 to pos before ACK

### DIFF
--- a/replicators/src/postgres_connector/connector.rs
+++ b/replicators/src/postgres_connector/connector.rs
@@ -398,16 +398,14 @@ impl PostgresWalConnector {
             .as_micros() as i64
             - J2000_EPOCH_GAP;
 
-        let pos = ack + 1;
-
         // Can reply with StandbyStatusUpdate or HotStandbyFeedback
         let mut b = BytesMut::with_capacity(39);
         b.put_u8(b'd'); // Copy data
         b.put_i32(38); // Message length (including this field)
         b.put_u8(b'r'); // Status update
-        pos.put_into(&mut b); // Acked
-        pos.put_into(&mut b); // Flushed
-        pos.put_into(&mut b); // Applied - this tells the server that it can remove prior WAL entries for this slot
+        ack.put_into(&mut b); // Acked
+        ack.put_into(&mut b); // Flushed - this tells the server that it can remove prior WAL entries for this slot
+        ack.put_into(&mut b); // Applied
         b.put_i64(now);
         b.put_u8(0);
         self.client


### PR DESCRIPTION
Previously, we were adding 1 to the position we ACK in our standby
status updates to Postgres because the Postgres docs describe the
position in that status message as "the location of the last WAL
byte + 1 flushed to disk in the standby".

My understanding at the time of this commit is that the status update
message is documented this way to allow for replication receivers always
to report their current position and the position given in keepalive
requests without having to worry about whether they've seen every event
at that position. In other words, the Postgres WAL sender understands
that when a replication receiver ACKs a given LSN, it understands that
to mean that the receiver has seen every event *up until* that LSN. The
documentation describes the position as including a "+ 1" to account for
this "off-by-one" behavior. Even the Postgres logical replication receiver
itself does not add 1 to the positions it reports in status updates.

This commit removes the "+ 1" from our standby status updates to be
consistent with what Postgres does.

