### PR TITLE
replicators: Use end LSN of commit as pos

### DIFF
--- a/replication-offset/src/postgres.rs
+++ b/replication-offset/src/postgres.rs
@@ -36,16 +36,6 @@ impl PostgresPosition {
         }
     }
 
-    /// Constructs a [`PostgresPosition`] from a [`CommitLsn`] that points to the highest possible
-    /// position in the given commit. In other words, this method constructs a [`PostgresPosition`]
-    /// that points to `(commit_lsn, commit_lsn)`.
-    pub fn commit_end(commit_lsn: CommitLsn) -> Self {
-        Self {
-            commit_lsn,
-            lsn: Lsn(commit_lsn.0),
-        }
-    }
-
     /// Consumes `self`, constructing a new [`PostgresPosition`] with `self`'s [`CommitLsn`] and the
     /// given [`Lsn`].
     pub fn with_lsn(self, lsn: impl Into<Lsn>) -> Self {

--- a/replicators/src/postgres_connector/wal.rs
+++ b/replicators/src/postgres_connector/wal.rs
@@ -220,9 +220,7 @@ pub enum WalRecord {
         flags: u8,
         /// The LSN of the commit. This value matches `final_lsn` in `WalData::Begin`.
         lsn: CommitLsn,
-        /// The end LSN of the transaction. This LSN may be the same as the subsequent BEGIN
-        /// operation, so it should **not** be used to report our position in the WAL to the
-        /// upstream database or to advance replication offsets on base tables.
+        /// The end LSN of the transaction.
         end_lsn: Lsn,
         /// Commit timestamp of the transaction. The value is in number of microseconds since
         /// PostgreSQL epoch (2000-01-01).

--- a/replicators/src/postgres_connector/wal_reader.rs
+++ b/replicators/src/postgres_connector/wal_reader.rs
@@ -44,6 +44,7 @@ pub(crate) enum WalEvent {
     },
     Commit {
         lsn: CommitLsn,
+        end_lsn: Lsn,
     },
     Insert {
         schema: String,
@@ -149,7 +150,9 @@ impl WalReader {
 
             match record {
                 WalRecord::Begin { final_lsn, .. } => return Ok(WalEvent::Begin { final_lsn }),
-                WalRecord::Commit { lsn, .. } => return Ok(WalEvent::Commit { lsn }),
+                WalRecord::Commit { lsn, end_lsn, .. } => {
+                    return Ok(WalEvent::Commit { lsn, end_lsn })
+                }
                 WalRecord::Relation(mapping) => {
                     // Store the relation in the hash map for future use
                     let id = mapping.id;


### PR DESCRIPTION
The `lsn` field in COMMIT XLogData messages matches the LSN of the last
event in the transaction, meaning the event before a given COMMIT and
the COMMIT itself will share the same replication offset (specifically,
`(LSN of commit, LSN of commit)`). While it's okay for two non-COMMIT
events to share the same replication offset, if the event before a
COMMIT has the same replication offset as the COMMIT itself, and we
flush the events in our buffer before we process the COMMIT, we'll
ignore the `ReplicationAction::LogPosition` we return when we see the
COMMIT and log a "Skipping schema update for earlier entry" warning.

This commit uses the `end_lsn` field in the COMMIT XLogData message as
the second component of the COMMIT's replication offset to ensure that
the event before a COMMIT and the COMMIT itself share the same offset.

