### PR TITLE
replicators: Fix "until" condition

### DIFF
--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -569,7 +569,6 @@ impl NoriaAdapter {
             set_failpoint!(failpoints::POSTGRES_SNAPSHOT_START);
 
             let snapshot_start = Instant::now();
-            // If snapshot name exists, it means we need to make a snapshot to noria
 
             let (mut client, connection) = pgsql_opts.connect(tls_connector.clone()).await?;
 


### PR DESCRIPTION
`PostgresWalConnector::next_action` takes an `until` parameter that
allows the method to return early if the we've reached the position
referenced by `until`. We were checking this condition after the point
at which we pulled the next event from the WAL stream, so if the
condition was triggered, we'd lose the event. To avoid this, this commit
moves the `until` check to be *before* we pull another position from the
WAL.

