### PR TITLE
jepsen: Make `:grouped-count` writes idempotent

### DIFF
--- a/jepsen/src/jepsen/readyset/workloads.clj
+++ b/jepsen/src/jepsen/readyset/workloads.clj
@@ -39,7 +39,8 @@
 (def grouped-count
   {:tables [{:create-table :t
              :with-columns [[:id :int]
-                            [:grp :int]]}]
+                            [:grp :int]
+                            [[:primary-key :id]]]}]
 
    :queries {:q
              {:query
@@ -66,7 +67,8 @@
                    :insert {:insert-into :t
                             :columns [:id :grp]
                             :values [[(rand-int 100)
-                                      (rand-int 10)]]}
+                                      (rand-int 10)]]
+                            :on-conflict {:do-nothing []}}
 
                    :delete {:delete-from :t
                             :where [:= :id (if (seq (:t rows))


### PR DESCRIPTION
Since we retry writes that report as failed, we can end up
double-applying the same write op if it fails after it's reported as
applied successfully by the upstream. This *might* want to be something
we address in the proxy itself, but for now it's simple enough to just
make writes idempotent by making `id` an actual primary key and running
with `ON CONFLICT DO NOTHING`.

This was incorrectly reported as a double-applied write within ReadySet
itself at #468, but was actually just us applying the same
non-idempotent write twice within the jepsen test.

