### PR TITLE
jepsen: Retry queries twice, with a slight sleep

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -189,7 +189,7 @@
       :db (db "92e5b6b70a3a4da3f7f33c4401be443c728afa77"  ; Needs at least this commit
               #_"refs/tags/beta-2023-07-26")
       :client (rs/new-client
-               {:retry-queries? true
+               {:retry-queries 2
                 :tables (:tables workload)
                 :queries (->> workload
                               :queries


### PR DESCRIPTION
With the way we're killing the adapter currently, it's just too likely
that both retries of a query happen to get routed to an adapter that is
actively being killed. Bumping up to retrying twice (in addition to the
first try) with a slight sleep in between seems to avoid that case.

