### PR TITLE
jepsen: Disable color in log output

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -186,7 +186,7 @@
      opts
      {:name "ReadySet"
       :os ubuntu/os
-      :db (db "92e5b6b70a3a4da3f7f33c4401be443c728afa77"  ; Needs at least this commit
+      :db (db "d7232218f74d9af117046fa1101b107d0d5f848d"  ; Needs at least this commit
               #_"refs/tags/beta-2023-07-26")
       :client (rs/new-client
                {:retry-queries 2

--- a/jepsen/src/jepsen/readyset/automation.clj
+++ b/jepsen/src/jepsen/readyset/automation.clj
@@ -69,6 +69,7 @@
      :chdir "/"}
     "/usr/local/bin/readyset"
     :--log-level (:log-level test "info")
+    :--no-color
     :--deployment "jepsen"
     :-a "0.0.0.0:5432"
     :--controller-address "0.0.0.0"
@@ -94,6 +95,7 @@
      :chdir "/"}
     "/usr/local/bin/readyset-server"
     :--log-level (:log-level test "info")
+    :--no-color
     :--deployment "jepsen"
     :--db-dir "/opt/readyset/data"
     :-a "0.0.0.0"


### PR DESCRIPTION
Pass the newly supported (as of the bumped commit) --no-color flag to
both readyset binaries, so that when the Jepsen UI renders the logs in
the browser they're actually readable.

