### PR TITLE
jepsen: Add a nemesis to bitflip rocksdb databases

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -148,7 +148,7 @@
                (c/exec :rm :-rf
                        "/var/run/readyset-server.pid"
                        "/var/log/readyset-server.log"
-                       "/opt/readyset/data"))))
+                       rs.auto/db-dir))))
           (error node "unknown role")))
 
       db/LogFiles
@@ -199,7 +199,8 @@
                 {{:kill-adapter :start
                   :start-adapter :stop} (rs.nemesis/kill-adapters)
                  {:kill-server :start
-                  :start-server :stop} (rs.nemesis/kill-server)})
+                  :start-server :stop} (rs.nemesis/kill-server)
+                 #{:bitflip} (rs.nemesis/bitflip-rocksdb)})
       :checker (checker/compose
                 {:liveness (rs.checker/liveness)
                  :eventually-consistent
@@ -223,7 +224,10 @@
 
                            (cycle
                             [{:type :info :f :kill-server}
-                             {:type :info :f :start-server}])])
+                             {:type :info :f :start-server}])
+
+                           (repeat
+                            {:type :info :f :bitflip})])
                          (gen/stagger 2)))
                    (gen/time-limit (:time-limit opts)))
 

--- a/jepsen/src/jepsen/readyset/automation.clj
+++ b/jepsen/src/jepsen/readyset/automation.clj
@@ -7,6 +7,18 @@
             [jepsen.readyset.client :as rs]
             [jepsen.readyset.nodes :as nodes]))
 
+(def db-dir
+  "The database directory used when running the readyset server"
+  "/opt/readyset/data")
+
+(def deployment
+  "The name of the ReadySet deployment"
+  "jepsen")
+
+(def deployment-dir
+  "The directory that will be used to store deployment data"
+  (str db-dir "/" deployment))
+
 (defn ensure-git-cloned
   "Ensure that a git repository `repo` is cloned at ref `ref` in dir `dir`"
   [repo ref dir]
@@ -70,7 +82,7 @@
     "/usr/local/bin/readyset"
     :--log-level (:log-level test "info")
     :--no-color
-    :--deployment "jepsen"
+    :--deployment deployment
     :-a "0.0.0.0:5432"
     :--controller-address "0.0.0.0"
     :--external-address (net/ip (name node))
@@ -88,7 +100,7 @@
 
 (defn start-readyset-server! [test node]
   (c/su
-   (c/exec :mkdir :-p "/opt/readyset/data")
+   (c/exec :mkdir :-p db-dir)
    (cu/start-daemon!
     {:logfile "/var/log/readyset-server.log"
      :pidfile "/var/run/readyset-server.pid"
@@ -96,8 +108,8 @@
     "/usr/local/bin/readyset-server"
     :--log-level (:log-level test "info")
     :--no-color
-    :--deployment "jepsen"
-    :--db-dir "/opt/readyset/data"
+    :--deployment deployment
+    :--db-dir db-dir
     :-a "0.0.0.0"
     :--external-address (net/ip (name node))
     :--authority-address (authority-address test)


### PR DESCRIPTION
Add a new nemesis to the jepsen test which picks a random file in a
random rocksdb database on the server node and flips bits in it at
random. This *ought* to trigger rocksdb's checksumming eventually, at
which point the table should fail and either resnapshot, or all queries
should go upstream.

Refs: REA-3369
Refs: #355
