### PR TITLE
readyset-data: Add format field to PassThrough struct

### DIFF
--- a/psql-srv/src/codec/decoder.rs
+++ b/psql-srv/src/codec/decoder.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use cidr::IpInet;
 use eui48::MacAddress;
 use postgres_types::{FromSql, Kind, Type};
-use readyset_data::{Array, Collation};
+use readyset_data::{Array, Collation, PassThroughFormat};
 use rust_decimal::prelude::FromStr;
 use rust_decimal::Decimal;
 use tokio_util::codec::Decoder;
@@ -389,6 +389,7 @@ fn get_binary_value(src: &mut Bytes, t: &Type) -> Result<PsqlValue, Error> {
             )),
             _ => Ok(PsqlValue::PassThrough(readyset_data::PassThrough {
                 ty: t.clone(),
+                format: PassThroughFormat::Binary,
                 data: buf.to_vec().into_boxed_slice(),
             })),
         },

--- a/psql-srv/src/value.rs
+++ b/psql-srv/src/value.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime};
 use cidr::IpInet;
 use eui48::MacAddress;
 use postgres_types::{FromSql, Kind, Type};
-use readyset_data::{Array, Text};
+use readyset_data::{Array, PassThroughFormat, Text};
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
@@ -107,6 +107,7 @@ impl<'a> FromSql<'a> for PsqlValue {
                 Type::VARBIT => BitVec::from_sql(ty, raw).map(PsqlValue::VarBit),
                 _ => Ok(PsqlValue::PassThrough(readyset_data::PassThrough {
                     ty: ty.clone(),
+                    format: PassThroughFormat::Binary,
                     data: Box::from(raw),
                 })),
             },

--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -63,7 +63,14 @@ const MAX_SECONDS_DATETIME_OFFSET: i32 = 85_940;
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PassThrough {
     pub ty: Type,
+    pub format: PassThroughFormat,
     pub data: Box<[u8]>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum PassThroughFormat {
+    Binary,
+    Text,
 }
 
 /// The main type used for user data throughout the codebase.
@@ -220,6 +227,7 @@ impl DfValue {
             DfValue::Array(_) => DfValue::empty_array(),
             DfValue::PassThrough(p) => DfValue::PassThrough(Arc::new(PassThrough {
                 ty: p.ty.clone(),
+                format: PassThroughFormat::Binary,
                 data: [].into(),
             })),
             DfValue::Max => DfValue::None,
@@ -1914,6 +1922,7 @@ impl<'a> FromSql<'a> for DfValue {
                 )),
                 ref ty => Ok(DfValue::PassThrough(Arc::new(PassThrough {
                     ty: ty.clone(),
+                    format: PassThroughFormat::Binary,
                     data: Box::from(raw),
                 }))),
             },
@@ -2142,6 +2151,7 @@ impl Arbitrary for DfValue {
                             Kind::Simple,
                             "Test Schema".to_string(),
                         ),
+                        format: PassThroughFormat::Binary,
                         data: data.into_boxed_slice(),
                     }))
                 })


### PR DESCRIPTION
This commit adds the new field, but doesn't do anything interesting with
it yet. The plan is to use this to support passthrough of text-formatted
parameters of unsupported types when we proxy queries, but for now we
just hardcode the format to Binary everywhere so as to maintain the
existing behavior.

Followup commits will add support for encoding parameters as text in
proxied queries when the format flag is set to do so, and once that's
done we can actually set the format flag to Text and use the PassThrough
type in the `get_text_value` function in the psql-srv decoder.

Refs: #266
Refs: REA-3183
