### PR TITLE
readyset-data: Implement encode_format for DfValue ToSql impl

### DIFF
--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -19,6 +19,7 @@ use eui48::{MacAddress, MacAddressFormat};
 use itertools::Itertools;
 use mysql_time::MySqlTime;
 use nom_sql::{Double, Float, Literal, SqlType};
+use postgres_types::Format;
 use readyset_errors::{internal, invalid_query_err, unsupported, ReadySetError, ReadySetResult};
 use readyset_util::arbitrary::{arbitrary_decimal, arbitrary_duration};
 use readyset_util::redacted::Sensitive;
@@ -1801,6 +1802,13 @@ impl ToSql for DfValue {
 
     fn accepts(_: &Type) -> bool {
         true
+    }
+
+    fn encode_format(&self, _ty: &Type) -> Format {
+        match self {
+            Self::PassThrough(p) if p.format == PassThroughFormat::Text => Format::Text,
+            _ => Format::Binary,
+        }
     }
 
     to_sql_checked!();


### PR DESCRIPTION
The default implementation of this trait method is to use binary format
for everything, and we still do that for almost all cases, but the new
passthrough text format is the one exception.

By implementing this, tokio-postgres will automatically send the right
flags in the Execute message to signify that we're sending text encoding
for any passthrough parameter that has the `format` parameter set to
Text. Since the ToSql impl already just encodes whatever raw data is
held in a DfValue::PassThrough, no further changes are needed to support
passing through text parameters.

Refs: #266
Refs: REA-3183
