### PR TITLE
psql-srv: Use passthrough when decoding unsupported text format params

### DIFF
--- a/psql-srv/src/codec/decoder.rs
+++ b/psql-srv/src/codec/decoder.rs
@@ -470,7 +470,11 @@ fn get_text_value(src: &mut Bytes, t: &Type) -> Result<PsqlValue, Error> {
         Type::BIT => get_bitvec_from_str(text_str).map(PsqlValue::Bit),
         Type::VARBIT => get_bitvec_from_str(text_str).map(PsqlValue::VarBit),
         ref t if t.name() == "citext" => Ok(PsqlValue::Text(text_str.into())),
-        _ => Err(Error::UnsupportedType(t.clone())),
+        _ => Ok(PsqlValue::PassThrough(readyset_data::PassThrough {
+            ty: t.clone(),
+            format: PassThroughFormat::Text,
+            data: text.as_bytes().to_vec().into_boxed_slice(),
+        })),
     }
 }
 


### PR DESCRIPTION
This ties together the last couple of commits that add support for
sending text passthrough parameters, and actually starts using it so
that we can proxy unsupported types for parameters in text mode.

Fixes: #266
Fixes: REA-3183
Release-Note-Core: Fix proxying of Postgres queries that use the
  Postgres text protocol to send query parameters when those parameters
  use types that aren't natively supported by ReadySet.
