### PR TITLE
jepsen: Introduce partitions

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -196,11 +196,13 @@
                               (map (fn [[k {:keys [query]}]] [k query]))
                               (into {}))})
       :nemesis (nemesis/compose
-                {{:kill-adapter :start
-                  :start-adapter :stop} (rs.nemesis/kill-adapters)
-                 {:kill-server :start
-                  :start-server :stop} (rs.nemesis/kill-server)
-                 #{:bitflip} (rs.nemesis/bitflip-rocksdb)})
+                [(nemesis/compose
+                  {{:kill-adapter :start
+                    :start-adapter :stop} (rs.nemesis/kill-adapters)
+                   {:kill-server :start
+                    :start-server :stop} (rs.nemesis/kill-server)
+                   #{:bitflip} (rs.nemesis/bitflip-rocksdb)})
+                 rs.nemesis/all-partitioners])
       :checker (checker/compose
                 {:liveness (rs.checker/liveness)
                  :eventually-consistent
@@ -227,7 +229,9 @@
                              {:type :info :f :start-server}])
 
                            (repeat
-                            {:type :info :f :bitflip})])
+                            {:type :info :f :bitflip})
+
+                           rs.nemesis/gen-partitions])
                          (gen/stagger 2)))
                    (gen/time-limit (:time-limit opts)))
 

--- a/jepsen/src/jepsen/readyset/nemesis.clj
+++ b/jepsen/src/jepsen/readyset/nemesis.clj
@@ -4,7 +4,8 @@
    [jepsen.control.util :as cu]
    [jepsen.nemesis :as nemesis]
    [jepsen.readyset.automation :as rs.auto]
-   [jepsen.readyset.nodes :as nodes]))
+   [jepsen.readyset.nodes :as nodes]
+   [jepsen.generator :as gen]))
 
 (defn- wrap-reflection [fs nemesis]
   (reify
@@ -64,3 +65,57 @@
   database files on the ReadySet server"
   []
   (BitflipRocksdb. (nemesis/bitflip)))
+
+(def adapter->server
+  "A grudge which causes the adapter to not be able to talk to the server"
+  (nodes/grudge {:node-role/readyset-server [:node-role/readyset-adapter]}))
+
+(def server->adapter
+  "A grudge which causes the server to not be able to talk to the adapter"
+  (nodes/grudge {:node-role/readyset-adapter [:node-role/readyset-server]}))
+
+(def adapter<->server
+  "A grudge which causes the adapter and server to not be able to talk to each
+  other symmetrically"
+  (nodes/grudge {:node-role/readyset-server [:node-role/readyset-adapter]
+                 :node-role/readyset-adapter [:node-role/readyset-server]}))
+
+(def server<->upstream
+  "A grudge which causes the server and upstream to not be able to talk to each
+  other symmetrically"
+  (nodes/grudge {:node-role/readyset-server [:node-role/upstream]
+                 :node-role/upstream [:node-role/readyset-server]}))
+
+(def role-grudges
+  {:adapter->server {:node-role/readyset-server [:node-role/readyset-adapter]}
+   :server->adapter {:node-role/readyset-adapter [:node-role/readyset-server]}
+   :adapter<->server {:node-role/readyset-server [:node-role/readyset-adapter]
+                      :node-role/readyset-adapter [:node-role/readyset-server]}
+   :server<->upstream {:node-role/readyset-server [:node-role/upstream]
+                       :node-role/upstream [:node-role/readyset-server]}})
+
+(def all-partitioners
+  "All partitioner nemeses composed together"
+  (nemesis/compose
+   (into
+    {}
+    (map (fn [[n role-grudge]]
+           (let [start (keyword (str "partition-" (name n)))
+                 stop (keyword (str "heal-" (name n)))]
+             [{start :start stop :stop}
+              (nemesis/partitioner (nodes/grudge role-grudge))])))
+    role-grudges)))
+
+(def gen-partitions
+  "Gen nemesis ops to partition according to `all-partitioners`.
+
+  Must be wrapped at the call site in `gen/nemesis`"
+  (->> all-partitioners
+       :nemeses
+       keys
+       (map (fn [ops]
+              (->> ops
+                   keys
+                   (map (fn [f] {:type :info, :f f}))
+                   cycle)))
+       (gen/mix)))


### PR DESCRIPTION
Add a bunch of new nemeses to introduce partitions, including between
the adapter and the server both symmetrically and asymmetrically, and
between the server and the upstream symmetrically.

