### PR TITLE
jepsen: Allow specifying workload on the command line

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -259,7 +259,17 @@
 (def opt-spec
   (let [validate-pos-number [#(and (number? %) (pos? %))
                              "Must be a positive number"]]
-    [[nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
+    [["-w" "--workload WORKLOAD" "Workload to test"
+      :default :grouped-count
+      :parse-fn keyword
+      :validate [#(contains? workloads/all-workloads %)
+                 (str "Must be a known workload (known workloads: "
+                      (->> workloads/all-workloads
+                           keys
+                           (map name)
+                           (str/join ", "))
+                      ")")]]
+     [nil "--log-level LOG_LEVEL" "Log level for ReadySet processes"
       :default "info"]
      [nil "--force-install" "Force install readyset binaries"]
      ["-r" "--rate HZ" "Approximate number of requests per second, per thread"

--- a/jepsen/src/jepsen/readyset/workloads.clj
+++ b/jepsen/src/jepsen/readyset/workloads.clj
@@ -209,6 +209,10 @@
                      [:= :story-id (:votes/story-id vote-to-delete)]
                      [:= :user-id (:votes/user-id vote-to-delete)]]})))))})
 
+(def all-workloads
+  {:grouped-count grouped-count
+   :votes votes})
+
 (comment
   (def sample-rows
     {:stories [#:stories{:id 1 :title "a"}


### PR DESCRIPTION
Allow specifying the workload to test on the command line as a parameter

