### PR TITLE
replicators: MySqlPosition::position overflow fix

### DIFF
--- a/replication-offset/src/mysql.rs
+++ b/replication-offset/src/mysql.rs
@@ -24,7 +24,7 @@ pub struct MySqlPosition {
     /// filename in [`MySqlPosition::binlog_file_name()`].
     binlog_file_suffix_length: usize,
     /// The position within the binlog file represented by this type.
-    pub position: u32,
+    pub position: u64,
 }
 
 impl fmt::Display for MySqlPosition {
@@ -35,7 +35,7 @@ impl fmt::Display for MySqlPosition {
 
 impl MySqlPosition {
     /// Converts a raw binlog file name and a position within that file to a [`MySqlPosition`].
-    pub fn from_file_name_and_position(file_name: String, position: u32) -> ReadySetResult<Self> {
+    pub fn from_file_name_and_position(file_name: String, position: u64) -> ReadySetResult<Self> {
         let (binlog_file_base_name, binlog_file_suffix) =
             file_name.rsplit_once('.').ok_or_else(|| {
                 ReadySetError::ReplicationFailed(format!("Invalid binlog name {}", file_name))

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -350,7 +350,7 @@ impl MySqlReplicator {
         })?;
 
         let file: String = pos.get(0).expect("Binlog file name");
-        let offset: u32 = pos.get(1).expect("Binlog offset");
+        let offset: u64 = pos.get(1).expect("Binlog offset");
 
         MySqlPosition::from_file_name_and_position(file, offset)
             .map_err(|err| mysql_async::Error::Other(Box::new(err)))


### PR DESCRIPTION
This is actually a flaw in MySQL binlog protocol, as Binlog::EventHeader defines end_pos filed as 4 bytes, while binlog might grow beyond that point. When that happens, the end_pos offset delta above u32::MAX will be reported. If the said event is from a table, readyset is replicating from, and the last known position on that table is higher than the reported overflown position, we will skip the event:

2023-08-27T17:48:35.713716Z WARN replicators::noria_adapter: Skipping table action for earlier entry table=test.user pos=binlog.000003:384346131 cur=binlog.000003:4289370691

This causes readyset copy of the table(s) to be out of sync with the source database.

This patch fixes the issue by using u64 for the position field in MySqlPosition.

MySQL does not have an API that allows us to register a replication stream to start streaming binlog from the overflow position. We will have to re-snapshot all tables if such a situation happens. The current patch does not address this issue. We will panic in case unwrap() fails.
