### PR TITLE
adapter: Don't autoparam equi-filters next to param. BETWEEN

### DIFF
--- a/readyset-adapter/src/rewrite.rs
+++ b/readyset-adapter/src/rewrite.rs
@@ -669,6 +669,12 @@ pub fn auto_parametrize_query(query: &mut SelectStatement) -> Vec<(usize, Litera
                             | BinaryOperator::GreaterOrEqual,
                         rhs: box Expr::Literal(Literal::Placeholder(..)),
                         ..
+                    } | Expr::Between {
+                        min: box Expr::Literal(Literal::Placeholder(..)),
+                        ..
+                    } | Expr::Between {
+                        max: box Expr::Literal(Literal::Placeholder(..)),
+                        ..
                     }
                 )
             })
@@ -1179,6 +1185,15 @@ mod tests {
                 "SELECT * FROM posts WHERE id = 1 ORDER BY SCORE ASC LIMIT 3 OFFSET 6",
                 "SELECT * FROM posts WHERE id = ? ORDER BY SCORE ASC LIMIT 3 OFFSET ?",
                 vec![(0, 1_u32.into()), (1, 6_u32.into())],
+            );
+        }
+
+        #[test]
+        fn constant_filter_with_param_betwen() {
+            test_auto_parametrize(
+                "SELECT * FROM posts WHERE id = 1 AND created_at BETWEEN ? and ?",
+                "SELECT * FROM posts WHERE id = 1 AND created_at BETWEEN ? and ?",
+                vec![],
             );
         }
     }

--- a/replication-offset/src/mysql.rs
+++ b/replication-offset/src/mysql.rs
@@ -24,7 +24,7 @@ pub struct MySqlPosition {
     /// filename in [`MySqlPosition::binlog_file_name()`].
     binlog_file_suffix_length: usize,
     /// The position within the binlog file represented by this type.
-    pub position: u32,
+    pub position: u64,
 }
 
 impl fmt::Display for MySqlPosition {
@@ -35,7 +35,7 @@ impl fmt::Display for MySqlPosition {
 
 impl MySqlPosition {
     /// Converts a raw binlog file name and a position within that file to a [`MySqlPosition`].
-    pub fn from_file_name_and_position(file_name: String, position: u32) -> ReadySetResult<Self> {
+    pub fn from_file_name_and_position(file_name: String, position: u64) -> ReadySetResult<Self> {
         let (binlog_file_base_name, binlog_file_suffix) =
             file_name.rsplit_once('.').ok_or_else(|| {
                 ReadySetError::ReplicationFailed(format!("Invalid binlog name {}", file_name))

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -350,7 +350,7 @@ impl MySqlReplicator {
         })?;
 
         let file: String = pos.get(0).expect("Binlog file name");
-        let offset: u32 = pos.get(1).expect("Binlog offset");
+        let offset: u64 = pos.get(1).expect("Binlog offset");
 
         MySqlPosition::from_file_name_and_position(file, offset)
             .map_err(|err| mysql_async::Error::Other(Box::new(err)))


### PR DESCRIPTION
If a query already contains an auto-parametrized BETWEEN filter,
don't *also* parametrize the equi-filters (in the same way we avoid
doing so for queries that already contain direct range comparisons) to
avoid the mixed-comparisons check.

Fixes: REA-3435
