### PR TITLE
build: Move public build down into public dir

### DIFF
--- a/.buildkite/build-image.sh
+++ b/.buildkite/build-image.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script is used by Buildkite to standardize a few things about how we
+# build Docker containers that are used for other steps in Buildkite.
+# The script ensures the following things:
+# Docker Buildkit is used for better performance and caching
+# Builds are uploaded to our private AWS Elastic Container Registry
+# When builds are done on main, they are tagged as latest to help with caching.
+#
+# To optimize rebuilds of images that rarely change, set the SKIP_IF_UNCHANGED
+# environment variable to a comma-separated lists of repository-relative paths
+# to files - if none of these files have changed, the image won't actually be
+# built, it'll just be re-tagged with the current commit via the AWS API.
+
+
+dockerfile="$1"
+image_name="$2"
+context="$3"
+
+if [ -z "$dockerfile" ] || [ -z "$image_name" ]; then
+    echo "Usage: $0 <dockerfile> <image_name> <context> [<docker-build-args>...]" >&2
+    exit 1
+fi
+shift 3
+
+AWS_ACCOUNT=${AWS_ACCOUNT:-305232526136} # build
+AWS_REGION=${AWS_REGION:-us-east-2}
+VERSION=${VERSION:-$BUILDKITE_COMMIT}
+
+docker_repo="$AWS_ACCOUNT.dkr.ecr.$AWS_REGION.amazonaws.com"
+image="$docker_repo/$image_name"
+
+if [ -n "${SKIP_IF_UNCHANGED+1}" ]; then
+    do_skip="1"
+    changed_files="$(git diff --name-only HEAD~ HEAD)"
+    IFS=',' read -ra files <<< "$SKIP_IF_UNCHANGED,$dockerfile"
+    for fname in "${files[@]}"; do
+        if grep "$fname" <<< "$changed_files" > /dev/null; then
+            do_skip=""
+        fi
+    done
+
+    if [ -n "$do_skip" ]; then
+        echo "+++ :docker: Dockerfile unchanged, retagging latest image as ${BUILDKITE_COMMIT}"
+        set +eo pipefail
+
+        manifest=$(
+            aws ecr batch-get-image \
+                --repository-name "$image_name" \
+                --image-ids imageTag=latest \
+                --output json \
+                | jq -r '.images[0].imageManifest')
+
+        # This might fail if the image already exists (eg if we're
+        # rebuilding the same commit), and we don't want to fail if that's
+        # the case - if the operation fails for *another* reason, we'll just
+        # fail in a later build because the image doesn't exist
+        aws ecr put-image \
+            --repository-name "$image_name" \
+            --image-tag "$BUILDKITE_COMMIT" \
+            --image-manifest "$manifest" || true \
+            > /dev/null
+        exit 0
+    fi
+fi
+
+echo "--- :docker: Pulling $image:latest"
+if docker pull "$image:latest"; then
+    cache_from="--cache-from=$image:latest"
+else
+    echo "Failed to pull previous build of image"
+    cache_from=""
+fi
+
+build_cmd_prefix=(
+    "docker" "build" \
+    "-f" "$dockerfile" \
+    "-t" "$image:$VERSION" \
+    "--build-arg" "BUILDKIT_INLINE_CACHE=1" \
+)
+build_cmd_suffix=(
+    "$@" \
+    "$context"
+)
+if [ -n "$cache_from" ]; then
+    build_cmd=("${build_cmd_prefix[@]}" "$cache_from" "${build_cmd_suffix[@]}")
+else
+    build_cmd=("${build_cmd_prefix[@]}" "${build_cmd_suffix[@]}")
+fi
+
+echo "+++ :docker: Building $image:$VERSION"
+DOCKER_BUILDKIT=1 "${build_cmd[@]}"
+tags_to_push=("$image:$VERSION")
+
+if [ "$BUILDKITE_BRANCH" = "refs/heads/main" ]; then
+    docker tag "$image:$VERSION" "$image:latest"
+    tags_to_push+=("$image:latest")
+    docker tag "$image:$VERSION" "$image:release-${BUILDKITE_COMMIT}"
+    tags_to_push+=("$image:release-${BUILDKITE_COMMIT}")
+fi
+
+for tag in "${tags_to_push[@]}"; do
+    echo "--- :docker: Pushing $tag"
+    docker push "$tag"
+done

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+if [ -v READYSET_SUBPROJECT_ROOT ]; then
+  cd "$READYSET_SUBPROJECT_ROOT"
+fi
+
+if [ "$BUILDKITE_AGENT_META_DATA_QUEUE" = "apple" ]; then
+  exit 0
+fi
+
+# Ensure that the `target` and `cargo-registry` volumes exist, so that steps
+# that expect them to already exist (the ones that use docker-compose) can run
+# even if they're the first steps to run on an agent
+docker volume create target || true
+docker volume create cargo-registry || true
+
+## Setup for framework testing
+mkdir -pv .buildkite/gen .buildkite/image
+buildkite-agent artifact download '.buildkite/gen/*' ./ || true
+buildkite-agent artifact download '.buildkite/image/**/*.tar.gz' ./ || true
+find .buildkite/image -type f | while read -r tarball; do
+	docker load < "$tarball"
+done

--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -1,0 +1,39 @@
+steps:
+  - label: ':clojure: Run jepsen test with --help'
+    key: lein-run-test-help
+    command:
+      - '[ -d public ] && cd public'
+      - cd jepsen
+      - lein run test --help
+    plugins:
+      docker#v3.8.0:
+        image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
+      ecr#v2.5.0:
+        login: true
+        retries: 3
+
+  - label: ':clojure: Run clojure tests'
+    key: lein-test
+    command:
+      - '[ -d public ] && cd public'
+      - cd jepsen
+      - lein test
+    plugins:
+      docker#v3.8.0:
+        image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
+      ecr#v2.5.0:
+        login: true
+        retries: 3
+
+  - label: ':clojure: Run clj-kondo'
+    key: lein-clj-kondo
+    command:
+      - '[ -d public ] && cd public'
+      - cd jepsen
+      - lein clj-kondo
+    plugins:
+      docker#v3.8.0:
+        image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
+      ecr#v2.5.0:
+        login: true
+        retries: 3

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,211 @@
+steps:
+  # TODO: ronh: decide what kind of linting we want in the OSS pipeline
+  # - label: ':git: Lint commits'
+  #   key: lint-commits
+  #   branches: '!refs/heads/main'
+  #   commands:
+  #     - ./scripts/commit_lint.sh
+  #   agents:
+  #     queue: t3a-small
+
+  - label: ':docker: Build build image'
+    key: build-image
+    commands:
+      - '[ -d public ] && cd public'
+      - '.buildkite/build-image.sh build/Dockerfile readyset-build .'
+    plugins:
+      ecr#v2.5.0:
+        login: true
+        retries: 3
+
+  - label: ':rust: Check rustfmt'
+    key: check-rustfmt
+    commands:
+      - '[ -d public ] && cd public'
+      - "cargo --locked fmt -- --check"
+    depends_on:
+    - build-image
+    plugins:
+      - docker#v3.8.0:
+          image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
+          volumes:
+          - 'target:/workdir/target'
+          environment:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+      - ecr#v2.5.0:
+          login: true
+          retries: 3
+
+  - label: ':docker: Build cargo-deny image'
+    key: cargo-deny-image
+    commands:
+      - '[ -d public ] && cd public'
+      - '.buildkite/build-image.sh build/Dockerfile.cargo-deny cargo-deny .'
+    env:
+      VERSION: "${BUILDKITE_COMMIT}"
+    plugins:
+      ecr#v2.5.0:
+        login: true
+        retries: 3
+
+  - label: ':rust: :lock: Check cargo-deny'
+    commands:
+      - '[ -d public ] && cd public'
+      - export RUST_BACKTRACE=full
+      - cargo --locked deny check
+    depends_on:
+    - cargo-deny-image
+    plugins:
+      - docker#v3.8.0:
+          image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/cargo-deny:${BUILDKITE_COMMIT}'
+          environment:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+      - ecr#v2.5.0:
+          login: true
+          retries: 3
+
+  - label: ':clippy: Check clippy'
+    key: check-clippy
+    commands:
+      - '[ -d public ] && cd public'
+      - export RUST_BACKTRACE=full
+      - cargo --locked clippy --workspace --all-targets --features bench -- -W clippy::disallowed_methods -D warnings
+    depends_on:
+    - build-image
+    plugins:
+      - docker#v3.8.0:
+          image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
+          volumes:
+          - 'target:/workdir/target'
+          environment:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+      - ecr#v2.5.0:
+          login: true
+          retries: 3
+
+  - label: ':rust: Run tests'
+    key: rust-tests
+    commands:
+      - '[ -d public ] && cd public'
+      - '.buildkite/run-tests.sh'
+    timeout_in_minutes: 60
+    depends_on:
+    - build-image
+    plugins:
+      - docker-compose#v3.7.0:
+          run: app
+          env:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+          - MYSQL_HOST=mysql
+          - MYSQL_PWD=noria
+          - MYSQL_DB=noria
+          volumes:
+            - 'target:/workdir/target'
+          config:
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
+          mount-buildkite-agent: true
+          pull-retries: 3
+      - ecr#v2.5.0:
+          login: true
+          retries: 3
+    agents:
+      queue: c6a-4xlarge
+
+  - label: 'Run logictest'
+    key: logictest
+    command:
+      - 'echo +++ Running readyset-logictest'
+      - '[ -d public ] && cd public'
+      - export RUST_BACKTRACE=full
+      - cargo --locked run --bin readyset-logictest -- verify logictests
+      - cargo --locked run --bin readyset-logictest -- verify logictests/psql --database-type postgresql
+    timeout_in_minutes: 60
+    depends_on:
+    - build-image
+    plugins:
+      - docker-compose#v3.7.0:
+          run: app
+          env:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+          config:
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
+          pull-retries: 3
+      - ecr#v2.5.0:
+          login: true
+          retries: 3
+
+  - label: 'Run clustertests'
+    key: readyset-clustertest
+    command:
+      - '[ -d public ] && cd public'
+      - 'echo +++ Building binaries for clustertest'
+      - cargo --locked build --bin readyset-server --bin readyset --features failure_injection
+      - 'echo +++ Running Clustertests'
+      - cargo --locked test -p readyset-clustertest
+    timeout_in_minutes: 60
+    depends_on:
+    - build-image
+    plugins:
+      - docker-compose#v3.7.0:
+          run: app
+          env:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+          - DISABLE_TELEMETRY=true
+          - BINARY_PATH=/workdir/${GIT_PUBLIC_ROOT}target/debug/
+          - MYSQL_ROOT_PASSWORD=noria
+          volumes:
+          - 'target:/workdir/target'
+          config:
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
+          mount-buildkite-agent: true
+      - ecr#v2.2.0:
+          login: true
+
+  - label: 'Test benchmark framework'
+    key: test-benchmark
+    command:
+      - '[ -d public ] && cd public'
+      - 'echo +++ Running benchmarks'
+      - export RUST_BACKTRACE=full
+      - cargo --locked run --bin benchmarks -- --local --database-type mysql --benchmark benchmarks/src/yaml/benchmarks/test/benchmark_test.yaml
+      - cargo --locked run --bin benchmarks -- --local-with-upstream mysql://root:noria@mysql/noria --database-type mysql --benchmark benchmarks/src/yaml/benchmarks/test/benchmark_test.yaml
+    timeout_in_minutes: 60
+    depends_on:
+    - build-image
+    plugins:
+      - docker-compose#v3.7.0:
+          image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
+          run: app
+          environment:
+          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
+          - CACHEPOT_REGION=us-east-2
+          - CARGO_INCREMENTAL=0
+          - RUST_BACKTRACE=full
+          config:
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
+            - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
+          pull-retries: 3
+      - ecr#v2.5.0:
+          login: true
+          retries: 3

--- a/.buildkite/run-tests.sh
+++ b/.buildkite/run-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+upload_artifacts() {
+    echo "--- Uploading proptest-regressions to buildkite artifacts"
+    buildkite-agent artifact upload '**/proptest-regressions/*.txt'
+    buildkite-agent artifact upload '**/*.proptest-regressions'
+    exit 1
+}
+
+echo "+++ :rust: Run tests"
+export DISABLE_TELEMETRY=true
+cargo --locked test --all --features failure_injection --exclude readyset-clustertest || upload_artifacts

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,40 @@
+FROM 305232526136.dkr.ecr.us-east-2.amazonaws.com/mirror/rustlang/rust:nightly
+
+WORKDIR /tmp
+
+COPY rust-toolchain .
+
+RUN rustup default "$(cat public/rust-toolchain)"; rm rust-toolchain
+
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        docker.io \
+        ca-certificates \
+        build-essential \
+        llvm \
+        clang \
+        libclang-dev \
+        lld \
+        cmake \
+        libssl-dev \
+        liblz4-dev \
+        curl \
+        protobuf-compiler \
+        rsync; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-`uname -m` -o /usr/local/bin/docker-compose; \
+    chmod a+x /usr/local/bin/docker-compose
+
+RUN set -eux; \
+    cargo install cargo-cache --version 0.6.3; \
+    cargo install --git https://github.com/paritytech/cachepot --rev 2c4b14f4164ae954a1e6241e14c13feada0f1758; \
+    cargo install detect_flake; \
+    cargo install critcmp; \
+    cargo cache --remove-dir all,git-db; \
+    mkdir -p ~/.config/cachepot; touch ~/.config/cachepot/config # To clean up cachepot logs
+
+# CARGO_HOME is set by the nightly container to be /usr/local/cargo.
+# This is where it reads configs from for cargo and where cargo installs binaries.
+RUN printf '[build]\nrustc-wrapper="/usr/local/cargo/bin/cachepot"\nrustflags = ["-C", "link-arg=-fuse-ld=lld"]' > ${CARGO_HOME}/config

--- a/build/Dockerfile.cargo-deny
+++ b/build/Dockerfile.cargo-deny
@@ -1,0 +1,3 @@
+FROM 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/rust:1.70
+
+RUN cargo install cargo-deny --version 0.13.7 && cargo deny --version

--- a/build/docker-compose.ci-test.yml
+++ b/build/docker-compose.ci-test.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+# Depends on `docker-compose.yml` from the root of the repository.
+# As such, context is now at root.
+
+services:
+  consul-server:
+    image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/consul:1.15
+    expose:
+      - '8500'
+      - '8600'
+  mysql:
+    image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/mysql:8.0
+    expose:
+      - '3306'
+  postgres:
+    image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/postgres:15
+    expose:
+      - '5432'
+  postgres13:
+    image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/postgres:13
+    expose:
+      - '5433'
+  redis:
+    image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/redis:6.2
+    expose:
+      - '6379'
+  app:
+    image: "305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}"
+    working_dir: /workdir
+    volumes:
+    - 'target:/workdir/target'
+    - 'cargo-registry:/usr/local/cargo/registry'
+    - '/tmp/orchestrator-state:/tmp/orchestrator-state'
+    - "${BUILDKITE_BUILD_CHECKOUT_PATH}:/workdir"
+      # Needed for the installer to send commands to the host when run via expect_test.rs:
+    - '/var/run/docker.sock:/var/run/docker.sock'
+    environment:
+    - AUTHORITY_ADDRESS=consul-server:8500
+    - AUTHORITY=consul
+    - REDIS_URL=redis://redis:6379/
+    - MYSQL_HOST=mysql
+    - POSTGRESQL_HOST=postgres
+    - PGHOST=postgres
+    - PGHOST13=postgres13
+    - ALLOW_UNAUTHENTICATED_CONNECTIONS=true
+    depends_on:
+    - redis
+    - mysql
+    - postgres
+    - postgres13
+    - consul-server
+
+volumes:
+  target:
+    external: true
+  cargo-registry:
+    external: true

--- a/build/docker-compose.override.yml.example
+++ b/build/docker-compose.override.yml.example
@@ -1,0 +1,19 @@
+# Docker-compose override to open up each images ports to the local
+# machine. To use, copy this file to docker-compose.override.yml and
+# use docker-compose as usual to start the dev docker containers.
+version: "3.8"
+services:
+  consul-server:
+    ports:
+      - '8500:8500'
+      - '8600:8600/tcp'
+      - '8600:8600/udp'
+  mysql:
+    ports:
+      - '3306:3306'
+  postgres:
+    ports:
+      - '5432:5432'
+  postgres13:
+    ports:
+      - '5433:5433'

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.8"
+services:
+  consul-server:
+    image: hashicorp/consul:1.15
+    restart: always
+    volumes:
+      - ./docker/consul/server.json:/consul/config/server.json:ro
+    command: 'agent -bootstrap-expect=1'
+  mysql:
+    image: mysql:8.0
+    environment:
+      - MYSQL_ROOT_PASSWORD=noria
+      - MYSQL_DATABASE=noria
+  postgres:
+    image: postgres:14
+    environment:
+      - POSTGRES_PASSWORD=noria
+      - POSTGRES_DB=noria
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+  postgres13:
+    image: postgres:13
+    environment:
+      - POSTGRES_PASSWORD=noria
+      - POSTGRES_DB=noria
+    command:
+      - "postgres"
+      - "-c"
+      - "wal_level=logical"
+      - "-p"
+      - "5433"

--- a/build/docker/consul/server.json
+++ b/build/docker/consul/server.json
@@ -1,0 +1,11 @@
+{
+  "node_name": "consul-server1",
+  "server": true,
+  "ui_config": {
+    "enabled": true
+  },
+  "data_dir": "/consul/data",
+  "addresses": {
+    "http": "0.0.0.0"
+  }
+}

--- a/build/docker/entrypoints/readyset-server.sh
+++ b/build/docker/entrypoints/readyset-server.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euf -x -o pipefail
+shopt -s nullglob # have globs expand to nothing when they don't match
+
+SERVER_ARGS="${*:---help}"
+#
+# Consul Opts
+CONSUL_ADDR="${AUTHORITY_ADDRESS:-127.0.0.1:8500}"
+CONSUL_PROTO="${CONSUL_PROTO:-http}"
+CONSUL_MAX_RETRY="${CONSUL_HEALTH_MAX_RETRY:-60}"
+CONSUL_SLEEP="${CONSUL_HEALTH_SLEEP:-2}"
+
+# Url to Consul cluster's leader status endpoint
+_CONSUL_LEADER_URL="${CONSUL_PROTO}://${CONSUL_ADDR}/v1/status/leader"
+
+# Ensure Consul has elected a leader before launching ReadySet.
+# Avoids CrashLoopBackoff while Consul cannot be reached.
+INIT_REQUIRE_LEADER="${INIT_REQUIRE_LEADER:-0}"
+
+await_consul_leader_election () {
+  local i=1
+  result=1
+  while [[ $i -le $CONSUL_MAX_RETRY ]]; do
+    echo "Checking whether Consul leader elected [Attempt $i / $CONSUL_MAX_RETRY]"
+    if curl --fail $_CONSUL_LEADER_URL; then
+      # Leader has been elected.
+      result=0
+      break
+    fi
+    echo "Consul leader not elected. Sleeping $CONSUL_SLEEP seconds."
+    i=$((i+1))
+    sleep $CONSUL_SLEEP
+  done
+
+  if [ $result -gt 0 ]; then
+    echo "No consul leader established after ${CONSUL_MAX_RETRY} retries. Exiting with error."
+    exit 1
+  fi
+}
+
+if [ "${INIT_REQUIRE_LEADER}" == "1" ]; then
+  echo "[INFO] Checking status of Consul cluster leader election ..."
+  await_consul_leader_election
+fi
+
+echo "[INFO] Starting ReadySet-Server ..."
+
+/usr/local/bin/readyset-server ${SERVER_ARGS}

--- a/build/docker/grafana/Dockerfile
+++ b/build/docker/grafana/Dockerfile
@@ -1,0 +1,11 @@
+FROM grafana/grafana:8.0.6
+COPY dashboards /var/lib/grafana/dashboards/
+COPY provisioning /etc/grafana/provisioning/
+COPY --chmod=666 provisioning/datasources/default.yml /etc/grafana/provisioning/datasources/
+COPY config /etc/grafana/
+COPY --chmod=666 config/grafana.ini /etc/grafana/
+COPY config-then-run.sh /
+
+# Run our script
+# It does things, then calls the Grafana entrypoint
+ENTRYPOINT /config-then-run.sh

--- a/build/docker/grafana/README.md
+++ b/build/docker/grafana/README.md
@@ -1,0 +1,45 @@
+# readyset-grafana
+
+This is the Dockerfile and build context for the `readyset-grafana` image, which is used by the Docker Compose quickstart in `readyset/public-docs/docs/assets/compose[.mysql|.postgres].yml`
+
+Public ECR Gallery:
+https://gallery.ecr.aws/readyset/readyset-grafana
+
+Private ECR Repo:
+https://us-east-2.console.aws.amazon.com/ecr/repositories/public/888984949675/readyset-grafana?region=us-east-2
+
+## Deployment Steps
+
+1. Obtain the terminal credentials for the `deploy` (888984949675) AWS account (see https://readysettech.atlassian.net/wiki/spaces/ENG/pages/27197446/AWS+CLI+Access):
+    ```
+    export AWS_PROFILE=deploy-AdministratorAccess
+    aws sso login
+    ```
+1. Log into the ECR:
+    ```
+    aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 888984949675.dkr.ecr.us-east-2.amazonaws.com
+    ```
+1. Build, tag, and push the individual images, then generate the multi-arch manifest:
+    ```
+    docker build --platform=linux/arm64 -t public.ecr.aws/readyset/readyset-grafana:latest_linux_arm64 .
+
+    docker build --platform=linux/amd64 -t public.ecr.aws/readyset/readyset-grafana:latest_linux_amd64 .
+
+    docker push public.ecr.aws/readyset/readyset-grafana:latest_linux_arm64
+
+    docker push public.ecr.aws/readyset/readyset-grafana:latest_linux_amd64
+    ```
+1. Delete the existing manifest from the ECR repo via the AWS console:
+    > Pushing a new manifest with the same tag (`latest`) didn't work for me, ECR kept the old one.
+    > I also couldn't use the AWS CLI to do it, something about it being confused between the private `888984949675` repo and `public.ecr.aws`.
+    ```
+    aws ecr batch-delete-image --repository-name public.ecr.aws/readyset/readyset-grafana --image-ids imageTag=latest
+
+    An error occurred (RepositoryNotFoundException) when calling the BatchDeleteImage operation: The repository with name 'public.ecr.aws/readyset/readyset-grafana' does not exist in the registry with id '888984949675'
+    ```
+1. Generate and push the multi-arch manifest:
+    ```
+    docker manifest create public.ecr.aws/readyset/readyset-grafana:latest public.ecr.aws/readyset/readyset-grafana:latest_linux_arm64 public.ecr.aws/readyset/readyset-grafana:latest_linux_amd64
+
+    docker manifest push --purge public.ecr.aws/readyset/readyset-grafana:latest
+    ```

--- a/build/docker/grafana/config-then-run.sh
+++ b/build/docker/grafana/config-then-run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+# Parse the upstream database URL
+RE='(.+):\/\/(.+):(.+)@([^:\/]+)(:[0-9]+)?(\/(.+))?'
+[[ $UPSTREAM_DB_URL =~ $RE ]]
+RS_DB_TYPE=${BASH_REMATCH[1]}
+RS_USER=${BASH_REMATCH[2]}
+RS_PASS=${BASH_REMATCH[3]}
+RS_HOST=${BASH_REMATCH[4]}
+RS_DB_NAME=${BASH_REMATCH[7]}
+
+if [[ $RS_DB_TYPE = "mysql" ]]; then
+    CONFIG_FILE=/etc/grafana/provisioning/datasources/default.template.mysql.yml
+elif [[ $RS_DB_TYPE = "postgresql" || $RS_DB_TYPE = "postgres" ]]; then
+    CONFIG_FILE=/etc/grafana/provisioning/datasources/default.template.postgres.yml
+else
+    echo "Unrecognized RS_DB_TYPE: $RS_DB_TYPE, exiting"
+    exit 1
+fi
+
+# Fill in the config file templates
+eval "cat <<EOF
+$(</etc/grafana/grafana.template.ini)
+EOF
+" > /etc/grafana/grafana.ini
+eval "cat <<EOF
+$(<$CONFIG_FILE)
+EOF
+" > /etc/grafana/provisioning/datasources/default.yml
+
+# Run the Grafana entrypoint
+exec /run.sh "$@"

--- a/build/docker/grafana/config/grafana.template.ini
+++ b/build/docker/grafana/config/grafana.template.ini
@@ -1,0 +1,14 @@
+[server]
+http_port = ${RS_GRAFANA_PORT:?}
+
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+
+org_name = Main Org.
+org_role = Admin
+
+[dashboards]
+default_home_dashboard_path = /var/lib/grafana/dashboards/query_overview.json

--- a/build/docker/grafana/dashboards/query_overview.json
+++ b/build/docker/grafana/dashboards/query_overview.json
@@ -1,0 +1,986 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "iteration": 1685563875756,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "New link",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "-- Mixed --",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "decimals": 4,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "90p Latency"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "50p Latency"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Duration"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query ID"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Query specific dashboard",
+                    "url": "/d/query/specific-query?Deployment=${Deployment:queryparam}&var-queryfilter=${__value.raw}&__url_time_range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "99p Latency"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cache Hit Rate"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "max",
+                "value": 1
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "mode": "thresholds"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "rgba(19, 196, 46, 0)",
+                      "value": null
+                    },
+                    {
+                      "color": "semi-dark-red",
+                      "value": 0
+                    },
+                    {
+                      "color": "semi-dark-yellow",
+                      "value": 0.6
+                    },
+                    {
+                      "color": "semi-dark-green",
+                      "value": 0.8
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "50p latency"
+          }
+        ]
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "sum by (query,query_id)\n(rate(readyset_query_log_execution_time_count{deployment=\"$deployment\",database_type=\"readyset\",query!=\"\", event_type=~\"query|execute\"}[$__range]))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "ReadySet QPS"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "sum by (query)\n(readyset_query_log_execution_time_sum{deployment=\"$deployment\",database_type=\"readyset\",query!=\"\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "RS Duration"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query) ((readyset_query_log_execution_time{deployment=\"$deployment\",database_type=\"readyset\",query!=\"\", quantile=\"0.5\", event_type=~\"query|execute\"} > 0) * 1000)[$__range:]",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "ReadySet 50p"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query) ((readyset_query_log_execution_time{deployment=\"$deployment\",database_type=\"readyset\",query!=\"\", quantile=\"0.9\", event_type=~\"query|execute\"} > 0) * 1000)[$__range:]",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "ReadySet 90p"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query) ((readyset_query_log_execution_time{deployment=\"$deployment\",database_type=\"readyset\",query!=\"\", quantile=\"0.99\", event_type=~\"query|execute\"} > 0) * 1000)[$__range:]",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "ReadySet 99p"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": false,
+          "expr": "avg by (query) (readyset_query_log_execution_time_count{deployment=\"$deployment\",database_type=\"readyset\",query!=\"\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "Count"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query) ((readyset_query_log_total_keys_read{deployment=\"$deployment\", query!=\"\"} - readyset_query_log_total_cache_misses{deployment=\"$deployment\", query!=\"\"}) / readyset_query_log_total_keys_read{deployment=\"$deployment\", query!=\"\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "Cache Hit Rate"
+        },
+        {
+          "datasource": "ReadySet_DB",
+          "format": "table",
+          "group": [],
+          "hide": false,
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SHOW CACHES;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "action_mailbox_inbound_emails",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeShift": null,
+      "title": "Cached Queries",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "results cached query",
+            "renamePattern": "query"
+          }
+        },
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "query"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "Time 7": true,
+              "Value #ReadySet QPS": true,
+              "fallback behavior results": true,
+              "name results": true
+            },
+            "indexByName": {
+              "Time 1": 4,
+              "Time 2": 5,
+              "Time 3": 6,
+              "Time 4": 8,
+              "Time 5": 10,
+              "Time 6": 15,
+              "Time 7": 16,
+              "Value #Cache Hit Rate": 13,
+              "Value #Count": 3,
+              "Value #RS Duration": 12,
+              "Value #ReadySet 50p": 7,
+              "Value #ReadySet 90p": 9,
+              "Value #ReadySet 99p": 11,
+              "Value #ReadySet QPS": 14,
+              "fallback behavior results": 17,
+              "name results": 1,
+              "query": 2,
+              "query_id": 0
+            },
+            "renameByName": {
+              "Time 4": "",
+              "Time 5": "",
+              "Time 7": "",
+              "Value #Cache Hit Rate": "Cache Hit Rate",
+              "Value #Count": "Count",
+              "Value #RS Duration": "Total Duration",
+              "Value #ReadySet 50p": "50p Latency",
+              "Value #ReadySet 90p": "90p Latency",
+              "Value #ReadySet 99p": "99p Latency",
+              "Value #ReadySet QPS": "ReadySet QPS",
+              "name results": "Query ID",
+              "query": "Query Text",
+              "query_id": "Query ID"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Count"
+              }
+            ]
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "greater",
+                  "options": {
+                    "value": 0
+                  }
+                },
+                "fieldName": "Count"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "-- Mixed --",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "decimals": 4,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query Text"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 284
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "90p Latency"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "50p Latency"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL QPS"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 115
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "noValue",
+                "value": "0"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "99p Latency"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Duration"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query ID"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Query specific dashboard",
+                    "url": "/d/query/specific-query?Deployment=${Deployment:queryparam}&var-queryfilter=${__value.raw}&__url_time_range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet supported?"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "pending": {
+                        "color": "light-red",
+                        "index": 0,
+                        "text": "unsupported"
+                      },
+                      "yes": {
+                        "color": "light-green",
+                        "index": 1,
+                        "text": "yes"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Count"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 5,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "sum by (query_id)\n(rate(readyset_query_log_execution_time_count{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", event_type=~\"query|execute\"}[$__range]))",
+          "format": "table",
+          "hide": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "MySQL QPS"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "sum by (query_id)\n(readyset_query_log_execution_time_sum{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "RS Duration"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "sum by (query_id)\n(readyset_query_log_execution_time_count{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "Count"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query_id) ((readyset_query_log_execution_time{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", quantile=\"0.5\", event_type=~\"query|execute\"} > 0) * 1000)[$__range:]",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "MySQL 50p"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query_id) ((readyset_query_log_execution_time{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", quantile=\"0.9\", event_type=~\"query|execute\"} > 0) * 1000)[$__range:]",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "MySQL 90p"
+        },
+        {
+          "datasource": "DS_PROMETHEUS",
+          "exemplar": true,
+          "expr": "avg by (query_id) ((readyset_query_log_execution_time{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", quantile=\"0.99\", event_type=~\"query|execute\"} > 0) * 1000)[$__range:]",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "MySQL 99p"
+        },
+        {
+          "datasource": "ReadySet_DB",
+          "format": "table",
+          "group": [],
+          "hide": false,
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SHOW PROXIED QUERIES;",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "id"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "table": "action_mailbox_inbound_emails",
+          "timeColumn": "created_at",
+          "timeColumnType": "timestamp",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeShift": null,
+      "title": "Proxied Queries",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Status",
+            "binary": {
+              "left": "Value #ReadySet QPS",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Value #MySQL QPS"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "ReadySet Count",
+                "MySQL Count"
+              ],
+              "reducer": "diff"
+            },
+            "replaceFields": false
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "results proxied query",
+            "renamePattern": "query"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "results query id",
+            "renamePattern": "query_id"
+          }
+        },
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "query_id"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Value #A": false,
+              "Value #B": true,
+              "Value #D": true,
+              "Value #MySQL 50p": false,
+              "Value #MySQL 90p": false,
+              "Value #MySQL 99p": false,
+              "Value #ReadySet 50p": false,
+              "Value #Readyset count": false,
+              "deployment": true,
+              "instance": true,
+              "job": true,
+              "query id results": false
+            },
+            "indexByName": {
+              "Time 1": 7,
+              "Time 2": 8,
+              "Time 3": 9,
+              "Time 4": 10,
+              "Time 5": 11,
+              "Value #Count": 2,
+              "Value #MySQL 50p": 3,
+              "Value #MySQL 90p": 4,
+              "Value #MySQL 99p": 5,
+              "Value #RS Duration": 6,
+              "query": 1,
+              "query_id": 0,
+              "readyset supported results": 12
+            },
+            "renameByName": {
+              "Value #50p Noria": "Noria 50p",
+              "Value #90p Noria": "Noria 90p",
+              "Value #99p Noria": "Noria 99p",
+              "Value #A": "ReadySet 50p",
+              "Value #B": "old rs count",
+              "Value #C": "ReadySet 90p",
+              "Value #Count": "Count",
+              "Value #D": "old msqyl count",
+              "Value #E": "ReadySet 99p",
+              "Value #F": "Total Duration",
+              "Value #MySQL 50p": "50p Latency",
+              "Value #MySQL 90p": "90p Latency",
+              "Value #MySQL 99p": "99p Latency",
+              "Value #MySQL QPS": "MySQL QPS",
+              "Value #MySQL count": "MySQL QPS",
+              "Value #RS Duration": "Total Duration",
+              "Value #RS count": "ReadySet QPS",
+              "Value #ReadySet QPS": "ReadySet QPS",
+              "Value #Readyset Count": "Readyset Count",
+              "Value #Readyset count": "ReadySet Count",
+              "Value #test": "Readyset Count",
+              "proxied query": "Proxied Query",
+              "query": "Query Text",
+              "query id": "Query ID",
+              "query id results": "Query ID",
+              "query_id": "Query ID",
+              "readyset supported": "Supported By ReadySet",
+              "readyset supported results": "Supported By ReadySet",
+              "{query=\"SELECT `column_name` FROM `information_schema`.`statistics` WHERE ((`index_name` = '<anonymized>') AND ((`table_schema` = database()) AND (`table_name` = '<anonymized>'))) ORDER BY `seq_in_index`\"}": "MySQL90p"
+            }
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "(q_+)"
+                  }
+                },
+                "fieldName": "Query ID"
+              }
+            ],
+            "match": "all",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "undefined"
+                  }
+                },
+                "fieldName": "Query Text"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "show databases"
+                  }
+                },
+                "fieldName": "Query Text"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "select @@version_comment limit 1"
+                  }
+                },
+                "fieldName": "Query Text"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "SELECT ((current_setting('server_version_num')::INT) / 100)"
+                  }
+                },
+                "fieldName": "Query Text"
+              },
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": "SELECT \"extversion\" FROM \"pg_extension\" WHERE (\"extname\" = $1)"
+                  }
+                },
+                "fieldName": "Query Text"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "SELECT n\\.nspname as \"Schema\".*"
+                  }
+                },
+                "fieldName": "Query Text"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "Count"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "docker_compose_deployment",
+          "value": "docker_compose_deployment"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": false,
+        "name": "deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Workload Overview",
+  "uid": "workload",
+  "version": 2
+}

--- a/build/docker/grafana/dashboards/query_specific.json
+++ b/build/docker/grafana/dashboards/query_specific.json
@@ -1,0 +1,964 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Stats to examine a specific query",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "iteration": 1690391529262,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "links",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 1,
+          "values": true
+        },
+        "text": {
+          "valueSize": 12
+        },
+        "textMode": "name"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "readyset_query_log_execution_time{deployment=\"$deployment\",query_id=\"${queryfilter:raw}\"}",
+          "interval": "",
+          "legendFormat": "{{query}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Text",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "is this query running in RS or not",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": -99999999,
+                "result": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "Proxied"
+                },
+                "to": 0
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Cached"
+                },
+                "to": 10000000000000000
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "match": "null+nan",
+                "result": {
+                  "color": "yellow",
+                  "index": 2,
+                  "text": "Proxied"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(readyset_query_log_execution_time_count{deployment=\"$deployment\", database_type=\"readyset\", query_id=\"${queryfilter:raw}\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "Readyset Count"
+        },
+        {
+          "exemplar": true,
+          "expr": "(readyset_query_log_execution_time_count{deployment=\"$deployment\", database_type=\"mysql\", query_id=\"${queryFilter:raw}\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "MySQL Count"
+        }
+      ],
+      "title": "Query Status",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Readyset Status",
+            "binary": {
+              "left": "Value #Readyset Count",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Value #MySQL Count"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "This measures the query end-to-end latency from the time the request is received by ReadySet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 0,
+        "y": 3
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.5\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "ReadySet 50p",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.5\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{upstream_db_type}} 50p",
+          "refId": "B"
+        }
+      ],
+      "title": "50p Query Latency",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "psql",
+            "renamePattern": "PostgreSQL"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mysql",
+            "renamePattern": "MySQL"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "This measures the query end-to-end latency from the time the request is received by ReadySet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 7,
+        "x": 7,
+        "y": 3
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.9\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "ReadySet 90p",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.9\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{upstream_db_type}} 90p",
+          "refId": "B"
+        }
+      ],
+      "title": "90p Query Latency",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "psql",
+            "renamePattern": "PostgreSQL"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mysql",
+            "renamePattern": "MySQL"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "This measures the query end-to-end latency from the time the request is received by ReadySet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 14,
+        "y": 3
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.99\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "ReadySet 99p",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.99\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{upstream_db_type}} 99p",
+          "refId": "B"
+        }
+      ],
+      "title": "99p Query Latency",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "psql",
+            "renamePattern": "PostgreSQL"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mysql",
+            "renamePattern": "MySQL"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Total Queries",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 1,
+          "mappings": [
+            {
+              "options": {
+                "noria": {
+                  "index": 0,
+                  "text": "ReadySet"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 20,
+        "x": 0,
+        "y": 11
+      },
+      "id": 25,
+      "interval": null,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": false,
+          "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"mysql\"}",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{upstream_db_type}}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"readyset\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "ReadySet",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "title": "Total Query Count",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "psql",
+            "renamePattern": "PostgreSQL"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mysql",
+            "renamePattern": "MySQL"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 26,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 20,
+        "x": 0,
+        "y": 20
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(readyset_query_log_total_keys_read{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\"} - readyset_query_log_total_cache_misses{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\"}) / readyset_query_log_total_keys_read{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "title": "Cache hit rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 20,
+        "x": 0,
+        "y": 29
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"mysql\"}[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "Queries Per Second ({{upstream_db_type}})",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"readyset\"}[$__rate_interval])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Queries Per Second (ReadySet)",
+          "refId": "B"
+        }
+      ],
+      "title": "Queries Per Second",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "psql",
+            "renamePattern": "PostgreSQL"
+          }
+        },
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "mysql",
+            "renamePattern": "MySQL"
+          }
+        }
+      ],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": false,
+        "name": "deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(query_id)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Query Filter",
+        "multi": false,
+        "name": "queryfilter",
+        "options": [],
+        "query": {
+          "query": "label_values(query_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Specific Query",
+  "uid": "query",
+  "version": 1
+}

--- a/build/docker/grafana/provisioning/dashboards/default.yml
+++ b/build/docker/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: Query Overview
+    type: file
+    options:
+      allowUiUpdates: true
+      path: /var/lib/grafana/dashboards/query_overview.json
+
+  - name: Specific Query
+    type: file
+    options:
+      allowUiUpdates: true
+      path: /var/lib/grafana/dashboards/query_specific.json

--- a/build/docker/grafana/provisioning/datasources/default.template.mysql.yml
+++ b/build/docker/grafana/provisioning/datasources/default.template.mysql.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+datasources:
+  - name: DS_PROMETHEUS
+    type: prometheus
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    access: proxy
+    url: http://prometheus:9090
+    jsonData:
+      httpMethod: POST
+
+  - name: ReadySet_DB
+    type: mysql
+    access: proxy
+    url: cache:${RS_PORT:?}
+    user: ${RS_USER:?}
+    jsonData:
+      tlsAuth: true
+    secureJsonData:
+      password: ${RS_PASS:?}
+    editable: true

--- a/build/docker/grafana/provisioning/datasources/default.template.postgres.yml
+++ b/build/docker/grafana/provisioning/datasources/default.template.postgres.yml
@@ -1,0 +1,23 @@
+apiVersion: 1
+
+datasources:
+  - name: DS_PROMETHEUS
+    type: prometheus
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    access: proxy
+    url: http://prometheus:9090
+    jsonData:
+      httpMethod: POST
+
+  - name: ReadySet_DB
+    type: postgres
+    url: cache:${RS_PORT:?}
+    database: ${RS_DB_NAME:?}
+    user: ${RS_USER:?}
+    secureJsonData:
+      password: ${RS_PASS:?}
+    jsonData:
+      sslmode: 'disable'
+      postgresVersion: 903
+      timescaledb: false
+    editable: true

--- a/build/docker/monitoring/README.md
+++ b/build/docker/monitoring/README.md
@@ -1,0 +1,24 @@
+# Overview
+This docker stack spins up ReadySet's monitoring services locally. It can be used to test Grafana and Prometheus integrations.
+
+This docker stack is provided in order to facilitate testing the experiments with Grafana integration.
+
+## Components
+The following components are present in this stack
+
+| Service | Port | User | Password | Tools configured |
+|------|---------|------|---------|---------|
+| Grafana | 4000 | -- | -- | <ul><li>'Experiments' dashboard</li></ul> |
+| Prometheus | 9090 | | | |
+
+## Configurations
+### Grafana
+If you want to extend the current Grafana configurations, check:
+- `grafana/dashboards`: This folder is where all the dashboard definitions are stored, as separate json files.
+- `grafana/provisioning/dashboards/default.yaml`: This file configures which dashboards should be pre-loaded by Grafana.
+- `grafana/provisioning/datasources/default.yaml`: This file configures which datasources should be pre-loaded by Grafana.
+
+### Prometheus
+Prometheus's config lives in `prometheus/prometheus.yml`.
+By default, prometheus only pulls metrics from "localhost:6033/metrics", the default prometheus endpoint
+for noria-server.

--- a/build/docker/monitoring/docker-compose.yml
+++ b/build/docker/monitoring/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.8"
+services:
+  prometheus:
+    image: prom/prometheus
+    # Required to access a local noria-server.
+    network_mode: "host"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    healthcheck:
+      test: ["CMD", "nc", "-vz", "localhost", "9090"]
+      interval: 10s
+      timeout: 2s
+      retries: 5
+      start_period: 5s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  pushgateway:
+    image: prom/pushgateway
+    network_mode: "host"
+  grafana:
+    image: grafana/grafana:8.0.6
+    network_mode: "host"
+    volumes:
+      - ./grafana/dashboards:/var/lib/grafana/dashboards
+      - ./grafana/provisioning:/etc/grafana/provisioning
+      - ./grafana/config/grafana.ini:/etc/grafana/grafana.ini
+  vector:
+    image: timberio/vector:0.16.1-debian
+    network_mode: "host"
+    volumes:
+      - ./vector/aggregator.toml:/etc/vector/vector.toml
+  node_exporter:
+    image: quay.io/prometheus/node-exporter:latest
+    container_name: node_exporter
+    command:
+      - '--path.rootfs=/host'
+    network_mode: host
+    pid: host
+    restart: unless-stopped
+    volumes:
+      - '/:/host:ro,rslave'
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    network_mode: "host"
+    environment:
+      SPAN_STORAGE_TYPE: "badger"
+      BADGER_EPHEMERAL: "false"

--- a/build/docker/monitoring/grafana/config/grafana.ini
+++ b/build/docker/monitoring/grafana/config/grafana.ini
@@ -1,0 +1,17 @@
+[server]
+http_port = 4000
+
+[auth]
+# Set to true to disable (hide) the login form, useful if you use OAuth
+#disable_login_form = false 
+disable_login_form = true
+
+[auth.anonymous]
+# enable anonymous access 
+enabled = true
+
+# specify organization name that should be used for unauthenticated users
+org_name = Main Org.
+
+# specify role for unauthenticated users
+org_role = Editor

--- a/build/docker/monitoring/grafana/dashboards/connected.json
+++ b/build/docker/monitoring/grafana/dashboards/connected.json
@@ -1,0 +1,622 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1643932316699,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "How long Readyset has been up for",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "dateTimeFromNow"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^startup_timestamp\\{deployment=\"solidus\", instance=\"localhost:9000\", job=\"readyset\\-server\"\\}$/",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "startup_timestamp\n\n",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "Timestamp"
+        }
+      ],
+      "title": "Readyset Started",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 8
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "server_external_requests",
+          "format": "table",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Server External Requests",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 9,
+        "y": 8
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "noria_client_external_requests",
+          "format": "table",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Adapter External Requests",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The number of queries per second executed against ReadySet split by the ReadySet and MySQL backends.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 14,
+        "x": 0,
+        "y": 15
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (database_type) (rate(query_log_execution_time_count{deployment=\"$Deployment\"}[1m]))",
+          "interval": "",
+          "legendFormat": "{{database_type}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Queries Per Second (1 minute intervals)",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 14,
+        "y": 15
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(replicator_snapshot_status{deployment=\"$Deployment\", status=\"started\"}) - sum(replicator_snapshot_status{deployment=\"$Deployment\", status=~\"successful|failed\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Snapshot In Progress",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 17,
+        "y": 15
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "controller_migration_in_progress{deployment=\"$Deployment\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Migration in Progress",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 14,
+        "y": 18
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(node_memory_MemTotal_bytes{deployment=\"$Deployment\",job=\"readyset-adapter\"}) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "ReadySet Adapters",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 17,
+        "y": 18
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(node_memory_MemTotal_bytes{deployment=\"$Deployment\",job=\"readyset-adapter\"}) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "ReadySet Adapters",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "solidus",
+          "value": "solidus"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "SELECT `column_name` FROM `information_schema`.`statistics` WHERE ((`index_name` = '<anonymized>') AND ((`table_schema` = database()) AND (`table_name` = '<anonymized>'))) ORDER BY `seq_in_index` ASC",
+          "value": "SELECT `column_name` FROM `information_schema`.`statistics` WHERE ((`index_name` = '<anonymized>') AND ((`table_schema` = database()) AND (`table_name` = '<anonymized>'))) ORDER BY `seq_in_index` ASC"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(query)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Query Filter",
+        "multi": false,
+        "name": "QueryFilter",
+        "options": [],
+        "query": {
+          "query": "label_values(query)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Is Readyset Connected",
+  "uid": "SLlJ0Wank",
+  "version": 1
+}

--- a/build/docker/monitoring/grafana/dashboards/query_overview.json
+++ b/build/docker/monitoring/grafana/dashboards/query_overview.json
@@ -1,0 +1,471 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1644972459093,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The end-to-end read latencies of queries executed against the ReadySet and MySQL backends at the median, 50th and 90th percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "decimals": 4,
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query Text"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": null
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 117
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 50p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "green",
+                        "index": 0,
+                        "text": "Readyset"
+                      }
+                    },
+                    "type": "value"
+                  },
+                  {
+                    "options": {
+                      "match": "null+nan",
+                      "result": {
+                        "color": "green",
+                        "index": 1,
+                        "text": "Readyset"
+                      }
+                    },
+                    "type": "special"
+                  },
+                  {
+                    "options": {
+                      "from": -9999999,
+                      "result": {
+                        "color": "red",
+                        "index": 2,
+                        "text": "MySQL"
+                      },
+                      "to": 0
+                    },
+                    "type": "range"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Duration"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query Text"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Query specific dashboard",
+                    "url": "http://10.0.37.8:4000/d/jAoEkfF7z/specific-query?Deployment=${Deployment:queryparam}&var-QueryFilter=${__value.raw}&__url_time_range"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (query)\n(increase(query_log_execution_time_count{deployment=\"$deployment\",database_type=\"noria\",query!=\"\", event_type=~\"query|execute\"}[$__range]))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "Readyset count"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum by (query)\n(increase(query_log_execution_time_count{deployment=\"$deployment\",database_type=\"mysql\",query!=\"\", event_type=~\"query|execute\"}[$__range]))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "MySQL count"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.5\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.9\", event_type=~\"query|execute\"}) *1000  ",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.99\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum by (query)\n(query_log_execution_time_sum{deployment=\"$deployment\",database_type=\"noria\",query!=\"\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "F"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.5\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "hide": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "G"
+        }
+      ],
+      "timeShift": null,
+      "title": "Query Log",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value #B": true,
+              "Value #D": true,
+              "Value #Readyset count": false,
+              "deployment": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value #A": 4,
+              "Value #C": 5,
+              "Value #E": 6,
+              "Value #F": 7,
+              "Value #MySQL count": 3,
+              "Value #Readyset count": 2,
+              "query": 1
+            },
+            "renameByName": {
+              "Value #50p Noria": "Noria 50p",
+              "Value #90p Noria": "Noria 90p",
+              "Value #99p Noria": "Noria 99p",
+              "Value #A": "ReadySet 50p",
+              "Value #B": "old rs count",
+              "Value #C": "ReadySet 90p",
+              "Value #D": "old msqyl count",
+              "Value #E": "ReadySet 99p",
+              "Value #F": "Total Duration",
+              "Value #MySQL count": "MySQL Count",
+              "Value #Readyset Count": "Readyset Count",
+              "Value #Readyset count": "ReadySet Count",
+              "Value #test": "Readyset Count",
+              "query": "Query Text"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Total Duration"
+              }
+            ]
+          }
+        },
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Status",
+            "binary": {
+              "left": "ReadySet Count",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "MySQL Count"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "ReadySet Count",
+                "MySQL Count"
+              ],
+              "reducer": "diff"
+            },
+            "replaceFields": false
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "solidus",
+          "value": "solidus"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": false,
+        "name": "deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Query Overview",
+  "uid": "38II-qb7z",
+  "version": 3
+}

--- a/build/docker/monitoring/grafana/dashboards/query_specific.json
+++ b/build/docker/monitoring/grafana/dashboards/query_specific.json
@@ -1,0 +1,881 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Stats to examine a specific query",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "iteration": 1646947574824,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "description": "",
+      "gridPos": {
+        "h": 3,
+        "w": 16,
+        "x": 0,
+        "y": 0
+      },
+      "id": 21,
+      "options": {
+        "content": "${queryfilter}",
+        "mode": "markdown"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Text",
+      "type": "text"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "is this query running in RS or not",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": -99999999,
+                "result": {
+                  "color": "yellow",
+                  "index": 0,
+                  "text": "No"
+                },
+                "to": 0
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "Yes"
+                },
+                "to": 10000000000000000
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "(query_log_execution_time_count{deployment=\"$deployment\", database_type=\"noria\", query=\"${queryfilter:raw}\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "Readyset Count"
+        },
+        {
+          "exemplar": true,
+          "expr": "(query_log_execution_time_count{deployment=\"$deployment\", database_type=\"mysql\", query=\"${queryFilter:raw}\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "MySQL Count"
+        }
+      ],
+      "title": "Query Running in Readyset",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "alias": "Readyset Status",
+            "binary": {
+              "left": "Value #Readyset Count",
+              "operator": "-",
+              "reducer": "sum",
+              "right": "Value #MySQL Count"
+            },
+            "mode": "binary",
+            "reduce": {
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "This measures the query end-to-end latency from the time the request is received by ReadySet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 20,
+        "x": 0,
+        "y": 3
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "query_log_execution_time{quantile=~\"0.5|0.9|0.99\",database_type=\"noria\",deployment=\"$deployment\",query=\"${queryfilter:raw}\"} * 1000",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{quantile}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Latency",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 20,
+        "x": 0,
+        "y": 15
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "query_log_total_cache_misses{deployment=\"$deployment\", query=\"${queryfilter:raw}\"}",
+          "interval": "",
+          "legendFormat": "Total misses",
+          "queryType": "randomWalk",
+          "refId": "total query misses"
+        },
+        {
+          "exemplar": true,
+          "expr": "query_log_execution_time_count{deployment=\"$deployment\",database_type=\"noria\",query=\"${queryfilter:raw}\", event_type=~\"query|execute\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "total query count"
+        }
+      ],
+      "title": "Total query cache misses rate",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {
+            "binary": {
+              "left": "Total misses",
+              "operator": "/",
+              "reducer": "sum",
+              "right": "query_log_execution_time_count{database_type=\"noria\", deployment=\"solidus\", event_type=\"query\", instance=\"localhost:9000\", job=\"readyset-server\", query=\"SELECT `active_storage_variant_records`.* FROM `active_storage_variant_records` WHERE ((`active_storage_variant_records`.`blob_id` = '<anonymized>') AND (`active_storage_variant_records`.`variation_digest` = '<anonymized>')) LIMIT '<anonymized>'\", query_type=\"read\", upstream_db_type=\"mysql\"}"
+            },
+            "mode": "binary",
+            "reduce": {
+              "include": [
+                "Total misses",
+                "query_log_execution_time_count{database_type=\"noria\", deployment=\"solidus\", event_type=\"query\", instance=\"localhost:9000\", job=\"readyset-server\", query=\"SELECT `active_storage_variant_records`.* FROM `active_storage_variant_records` WHERE ((`active_storage_variant_records`.`blob_id` = '<anonymized>') AND (`active_storage_variant_records`.`variation_digest` = '<anonymized>')) LIMIT '<anonymized>'\", query_type=\"read\", upstream_db_type=\"mysql\"}"
+              ],
+              "reducer": "sum"
+            },
+            "replaceFields": true
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The number of queries per second executed against ReadySet split by the ReadySet and MySQL backends.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 20,
+        "x": 0,
+        "y": 24
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (database_type) (rate(query_log_execution_time_count{deployment=\"$deployment\", query=\"${queryfilter:raw}\"}[1m]))",
+          "interval": "",
+          "legendFormat": "{{database_type}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Queries Per Second (1 minute intervals)",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The cache hit rate observed at the first layer of ReadySet caches. In the absence of queries this graph shows a cache hit rate of 0%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 2,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 30
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(server_view_query_result{deployment=\"$deployment\", result=\"served_from_cache\"}[1m])) / sum(rate(server_view_query_result{result=~\"served_from_cache|replay\"}[1m]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "Cache eviction runs asynchronously in Noria, but can impact the performance of queries that miss at the first layer of caches. This tracks the percent of the last 30 seconds that we spent performing evictions in the cache, reported as the maximum across all caches.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": -1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 30
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max(increase(domain_eviction_time_us_sum{deployment=\"$deployment\"}[30s])) / 3000000",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Eviction Time",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 8,
+        "y": 30
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "repeat": null,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (instance, job) ((node_memory_MemTotal_bytes{deployment=\"$deployment\"}-node_memory_MemAvailable_bytes)/node_memory_MemTotal_bytes*100)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "title": "System Memory Utilization",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 14,
+        "y": 30
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "100 - (avg by (job, instance) (rate(node_cpu_seconds_total{deployment=\"$deployment\",mode=\"idle\"}[1m])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "title": "System CPU Utilization",
+      "transformations": [],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "solidus",
+          "value": "solidus"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Deployment",
+        "multi": false,
+        "name": "deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "SELECT `active_storage_variant_records`.* FROM `active_storage_variant_records` WHERE ((`active_storage_variant_records`.`blob_id` = '<anonymized>') AND (`active_storage_variant_records`.`variation_digest` = '<anonymized>')) LIMIT '<anonymized>'",
+          "value": "SELECT `active_storage_variant_records`.* FROM `active_storage_variant_records` WHERE ((`active_storage_variant_records`.`blob_id` = '<anonymized>') AND (`active_storage_variant_records`.`variation_digest` = '<anonymized>')) LIMIT '<anonymized>'"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(query)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Query Filter",
+        "multi": false,
+        "name": "queryfilter",
+        "options": [],
+        "query": {
+          "query": "label_values(query)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Specific Query",
+  "uid": "jAoEkfF7z",
+  "version": 2
+}

--- a/build/docker/monitoring/grafana/dashboards/readyset_external.json
+++ b/build/docker/monitoring/grafana/dashboards/readyset_external.json
@@ -1,0 +1,1218 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "iteration": 1637726518924,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The number of queries per second executed against ReadySet split by the ReadySet and MySQL backends.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 14,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (database_type) (rate(query_log_execution_time_count{deployment=\"$Deployment\"}[1m]))",
+          "interval": "",
+          "legendFormat": "{{database_type}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Queries Per Second (1 minute intervals)",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 14,
+        "y": 0
+      },
+      "id": 20,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(replicator_snapshot_status{deployment=\"$Deployment\", status=\"started\"}) - sum(replicator_snapshot_status{deployment=\"$Deployment\", status=~\"successful|failed\"})",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Snapshot In Progress",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "No"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Yes"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 17,
+        "y": 0
+      },
+      "id": 21,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "controller_migration_in_progress{deployment=\"$Deployment\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Migration in Progress",
+      "transformations": [],
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 14,
+        "y": 3
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(node_memory_MemTotal_bytes{deployment=\"$Deployment\",job=\"readyset-adapter\"}) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "ReadySet Adapters",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 17,
+        "y": 3
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(node_memory_MemTotal_bytes{deployment=\"$Deployment\",job=\"readyset-server\"}) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "ReadySet Servers",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The end-to-end read latencies of queries executed against the ReadySet and MySQL backends at the median, 50th and 90th percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "decimals": 4,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Noria 50p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL 50p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Noria 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Noria 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query Text"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": null
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 118
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 124
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 134
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL Count"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 117
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 50p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 109
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.5\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.9\", event_type=~\"query|execute\"}) *1000  ",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg by (query) (query_log_execution_time{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.99\", event_type=~\"query|execute\"}) *1000",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum by (query) (query_log_execution_time_count{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum by (query) (query_log_execution_time_count{deployment=\"$Deployment\",database_type=\"mysql\",query!=\"\", event_type=~\"query|execute\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "D"
+        }
+      ],
+      "title": "Query Log",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "deployment": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value #A": 4,
+              "Value #B": 2,
+              "Value #C": 5,
+              "Value #D": 3,
+              "Value #E": 6,
+              "query": 1
+            },
+            "renameByName": {
+              "Value #50p Noria": "Noria 50p",
+              "Value #90p Noria": "Noria 90p",
+              "Value #99p Noria": "Noria 99p",
+              "Value #A": "ReadySet 50p",
+              "Value #B": "ReadySet Count",
+              "Value #C": "ReadySet 90p",
+              "Value #D": "MySQL Count",
+              "Value #E": "ReadySet 99p",
+              "Value #F": "MySQL 99p",
+              "query": "Query Text"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "ReadySet 50p"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 14,
+        "y": 9
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "100 - (avg by (job, instance) (rate(node_cpu_seconds_total{deployment=\"$Deployment\",mode=\"idle\"}[1m])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "title": "System CPU Utilization",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "This measures the query end-to-end latency from the time the request is received by ReadySet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 13
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "query_log_execution_time{quantile=~\"0.5|0.9|0.99\",database_type=\"noria\",deployment=\"$Deployment\",query=\"${QueryFilter:raw}\"} * 1000",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{quantile}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Latency",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The cache hit rate observed at the first layer of ReadySet caches. In the absence of queries this graph shows a cache hit rate of 0%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 2,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 6,
+        "y": 13
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(server_view_query_result{deployment=\"$Deployment\", result=\"served_from_cache\"}[1m])) / sum(rate(server_view_query_result{result=~\"served_from_cache|replay\"}[1m]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "Cache eviction runs asynchronously in Noria, but can impact the performance of queries that miss at the first layer of caches. This tracks the percent of the last 30 seconds that we spent performing evictions in the cache, reported as the maximum across all caches.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": -1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 10,
+        "y": 13
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max(increase(domain_eviction_time_us_sum{deployment=\"$Deployment\"}[30s])) / 3000000",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Eviction Time",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 14,
+        "y": 16
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "repeat": null,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (instance, job) ((node_memory_MemTotal_bytes{deployment=\"$Deployment\"}-node_memory_MemAvailable_bytes)/node_memory_MemTotal_bytes*100)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "title": "System Memory Utilization",
+      "transformations": [],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(query)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Query Filter",
+        "multi": false,
+        "name": "QueryFilter",
+        "options": [],
+        "query": {
+          "query": "label_values(query)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ReadySet Overview",
+  "uid": "jAoEkfF7z",
+  "version": 1
+}

--- a/build/docker/monitoring/grafana/dashboards/readyset_internal.json
+++ b/build/docker/monitoring/grafana/dashboards/readyset_internal.json
@@ -1,0 +1,982 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "DS_PROMETHEUS",
+        "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "iteration": 1635889126080,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The number of queries per second executed against ReadySet split by the ReadySet and MySQL backends.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 14,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (database_type) (rate(query_log_execution_time_count{deployment=\"$Deployment\"}[1m]))",
+          "interval": "",
+          "legendFormat": "{{database_type}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Queries Per Second (1 minute intervals)",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 14,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(node_memory_MemTotal_bytes{deployment=\"$Deployment\",job=\"readyset-adapter\"}) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "ReadySet Adapters",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 17,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "count(node_memory_MemTotal_bytes{deployment=\"$Deployment\",job=\"readyset-server\"}) or vector(0)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "ReadySet Servers",
+      "type": "stat"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The end-to-end read latencies of queries executed against the ReadySet and MySQL backends at the median, 50th and 90th percentiles.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "decimals": 4,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Noria 50p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL 50p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Noria 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Noria 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MySQL 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 90
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Query Text"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": null
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 90p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 118
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ReadySet 99p"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 124
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 5
+      },
+      "id": 4,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg without (quantile,database_type) (query_log_execution_time{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.5\"}) *1000",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg without (quantile,database_type) (query_log_execution_time{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.9\"}) *1000  ",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "avg without (quantile,database_type) (query_log_execution_time{deployment=\"$Deployment\",database_type=\"noria\",query!=\"\", quantile=\"0.99\"}) *1000",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "E"
+        }
+      ],
+      "title": "Query Log",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "deployment": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #50p Noria": "Noria 50p",
+              "Value #90p Noria": "Noria 90p",
+              "Value #99p Noria": "Noria 99p",
+              "Value #A": "ReadySet 50p",
+              "Value #B": "MySQL 50p",
+              "Value #C": "ReadySet 90p",
+              "Value #D": "MySQL 90p",
+              "Value #E": "ReadySet 99p",
+              "Value #F": "MySQL 99p",
+              "query": "Query Text"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "ReadySet 50p"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 14,
+        "y": 6
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "100 - (avg by (job, instance) (rate(node_cpu_seconds_total{deployment=\"$Deployment\",mode=\"idle\"}[1m])) * 100)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "title": "System CPU Utilization",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "This measures the query end-to-end latency from the time the request is received by ReadySet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 13
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "query_log_execution_time{quantile=~\"0.5|0.9|0.99\",database_type=\"noria\",deployment=\"$Deployment\",query=\"${QueryFilter:raw}\"} * 1000",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{quantile}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Query Latency",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "The cache hit rate observed at the first layer of ReadySet caches. In the absence of queries this graph shows a cache hit rate of 0%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 1,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 2,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 6,
+        "y": 13
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(server_view_query_result{result=\"served_from_cache\"}[1m])) / sum(rate(server_view_query_result{result=~\"served_from_cache|replay\"}[1m]))",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Hit Rate",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "description": "Cache eviction runs asynchronously in Noria, but can impact the performance of queries that miss at the first layer of caches. This tracks the percent of the last 30 seconds that we spent performing evictions in the cache, reported as the maximum across all caches.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": -1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 10,
+        "y": 13
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max(increase(domain_eviction_time_us_sum{deployment=\"$Deployment\"}[30s])) / 3000000",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache Eviction Time",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": "DS_PROMETHEUS",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 14,
+        "y": 13
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "pluginVersion": "8.2.2",
+      "repeat": null,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (instance, job) ((node_memory_MemTotal_bytes{deployment=\"$Deployment\"}-node_memory_MemAvailable_bytes)/node_memory_MemTotal_bytes*100)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{job}} ({{instance}})",
+          "refId": "A"
+        }
+      ],
+      "title": "System Memory Utilization",
+      "transformations": [],
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 30,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": "test_deployment",
+          "value": "test_deployment"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(deployment)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Deployment",
+        "options": [],
+        "query": {
+          "query": "label_values(deployment)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "SELECT * FROM `invites_users` WHERE (`invites_users`.`invite_id` IN ('<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>') AND (`invites_users`.`user_id` = '<anonymized>'))",
+          "value": "SELECT * FROM `invites_users` WHERE (`invites_users`.`invite_id` IN ('<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>', '<anonymized>') AND (`invites_users`.`user_id` = '<anonymized>'))"
+        },
+        "datasource": "DS_PROMETHEUS",
+        "definition": "label_values(query)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Query Filter",
+        "multi": false,
+        "name": "QueryFilter",
+        "options": [],
+        "query": {
+          "query": "label_values(query)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ReadySet Internal",
+  "uid": "jAoEkfF7y",
+  "version": 2
+}

--- a/build/docker/monitoring/grafana/provisioning/dashboards/default.yaml
+++ b/build/docker/monitoring/grafana/provisioning/dashboards/default.yaml
@@ -1,0 +1,27 @@
+apiVersion: 1
+
+providers:
+  - name: Readyset Overview
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/readyset_external.json
+
+  - name: Readyset Internal
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/readyset_internal.json
+
+  - name: Query Overview
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/query_overview.json
+
+  - name: Specific Query
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/query_specific.json
+
+  - name: Connected
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards/connected.json

--- a/build/docker/monitoring/grafana/provisioning/datasources/default.yaml
+++ b/build/docker/monitoring/grafana/provisioning/datasources/default.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: DS_PROMETHEUS
+    type: prometheus
+    # Access mode - proxy (server in the UI) or direct (browser in the UI).
+    access: proxy
+    url: http://localhost:9090
+    jsonData:
+      httpMethod: POST

--- a/build/docker/monitoring/prometheus/prometheus.yml
+++ b/build/docker/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  external_labels:
+    monitor: 'local-noria'
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9092']
+    honor_labels: true
+  - job_name: 'pushgateway'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9091']
+    honor_labels: true

--- a/build/docker/monitoring/vector/agent.toml
+++ b/build/docker/monitoring/vector/agent.toml
@@ -1,0 +1,15 @@
+[sources.in]
+type = "stdin"
+
+[transforms.metadata]
+type = "remap"
+inputs = ["in"]
+source = """
+.hostname = get_hostname!()
+"""
+
+[sinks.out]
+inputs = ["metadata"]
+type = "vector"
+address = "127.0.0.1:8383"
+version = "1"

--- a/build/docker/monitoring/vector/aggregator.toml
+++ b/build/docker/monitoring/vector/aggregator.toml
@@ -1,0 +1,34 @@
+[sources.node-exporter]
+type = "prometheus_scrape"
+endpoints = [ "http://localhost:9100/metrics" ]
+scrape_interval_secs = 2
+
+[sources.prometheus-adapter]
+type = "prometheus_scrape"
+endpoints = [ "http://localhost:6034/metrics" ]
+scrape_interval_secs = 2
+
+[sources.prometheus-server]
+type = "prometheus_scrape"
+endpoints = [ "http://localhost:6033/metrics" ]
+scrape_interval_secs = 2
+
+[transforms.metrics]
+type = "remap"
+inputs = ["node-exporter", "prometheus-server", "prometheus-adapter"]
+source = '''
+  .tags.deployment = "test_deployment"
+  .tags.job = "readyset-server"
+  .tags.instance = "localhost:9000"
+'''
+
+# Print parsed logs to stdout
+[sinks.print]
+type = "console"
+inputs = ["in", "metrics"]
+encoding.codec = "text"
+
+[sinks.prometheus]
+type = "prometheus_exporter"
+inputs = ["metrics"]
+address = "0.0.0.0:9092"

--- a/build/docker/prometheus/Dockerfile
+++ b/build/docker/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:latest
+COPY prometheus.yml /etc/prometheus/

--- a/build/docker/prometheus/README.md
+++ b/build/docker/prometheus/README.md
@@ -1,0 +1,45 @@
+# readyset-prometheus
+
+This is the Dockerfile and build context for the `readyset-prometheus` image, which is used by the Docker Compose quickstart in `readyset/public-docs/docs/assets/compose[.mysql|.postgres].yml`
+
+Public ECR Gallery:
+https://gallery.ecr.aws/readyset/readyset-prometheus
+
+Private ECR Repo:
+https://us-east-2.console.aws.amazon.com/ecr/repositories/public/888984949675/readyset-prometheus?region=us-east-2
+
+## Deployment Steps
+
+1. Obtain the terminal credentials for the `deploy` (888984949675) AWS account (see https://readysettech.atlassian.net/wiki/spaces/ENG/pages/27197446/AWS+CLI+Access):
+    ```
+    export AWS_PROFILE=deploy-AdministratorAccess
+    aws sso login
+    ```
+1. Log into the ECR:
+    ```
+    aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 888984949675.dkr.ecr.us-east-2.amazonaws.com
+    ```
+1. Build, tag, and push the individual images:
+    ```
+    docker build -t public.ecr.aws/readyset/readyset-prometheus:latest_linux_arm64 --platform linux/arm64 .
+
+    docker build -t public.ecr.aws/readyset/readyset-prometheus:latest_linux_amd64 --platform linux/amd64 .
+
+    docker push public.ecr.aws/readyset/readyset-prometheus:latest_linux_arm64
+
+    docker push public.ecr.aws/readyset/readyset-prometheus:latest_linux_amd64
+    ```
+1. Delete the existing manifest from the ECR repo via the AWS console:
+    > Pushing a new manifest with the same tag (`latest`) didn't work for me, ECR kept the old one.
+    > I also couldn't use the AWS CLI to do it, something about it being confused between the private `888984949675` repo and `public.ecr.aws`.
+    ```
+    aws ecr batch-delete-image --repository-name public.ecr.aws/readyset/readyset-prometheus --image-ids imageTag=latest
+
+    An error occurred (RepositoryNotFoundException) when calling the BatchDeleteImage operation: The repository with name 'public.ecr.aws/readyset/readyset-prometheus' does not exist in the registry with id '888984949675'
+    ```
+1. Generate and push the multi-arch manifest:
+    ```
+    docker manifest create public.ecr.aws/readyset/readyset-prometheus public.ecr.aws/readyset/readyset-prometheus:latest_linux_arm64 public.ecr.aws/readyset/readyset-prometheus:latest_linux_amd64
+
+    docker manifest push --purge public.ecr.aws/readyset/readyset-prometheus
+    ```

--- a/build/docker/prometheus/prometheus.yml
+++ b/build/docker/prometheus/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 15s
+  external_labels:
+    monitor: 'readyset'
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets:
+        - 'cache:6033'
+        - 'cache:6034'
+    honor_labels: true
+  - job_name: 'pushgateway'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['pushgateway:9091']
+    honor_labels: true


### PR DESCRIPTION
To support buildkite CI builds out of the github repo, everything
necessary for the CI run needs to live in the github repo.  This update
moves the pipeline and all supporting scripts and files down under the
public/ tree.  The main top-level pipeline is adjusted to run the
public/.buildkite/pipeline.yml on changes to public/.

NOTE: This copies a lot of files from outside public into public, which
means there's a bunch of duplication (build-image.sh, run-tests.sh,
etc.).  To remove that duplication, all references from outside public
would need to be changed to point to the copies in public, and the
non-public files deleted.

