### PR TITLE
adapter: Prettify query text in SHOW CACHES / PROXIED QUERIES

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4337,6 +4337,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "sqlformat",
  "test-strategy",
  "thiserror",
  "time 0.3.9",
@@ -5770,6 +5771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
+dependencies = [
+ "itertools",
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6642,8 +6654,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
- "rand 0.7.3",
+ "cfg-if 1.0.0",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -6706,6 +6718,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -44,6 +44,7 @@ dashmap = "4.0.2"
 mysql_common = "0.29"
 bincode = "1.3.3"
 parking_lot = "0.11.2"
+sqlformat = "0.2.1"
 
 readyset-alloc = { path = "../readyset-alloc/" }
 readyset-client = { path = "../readyset-client/" }


### PR DESCRIPTION
Use the sqlformat crate to prettify query text returned by the `SHOW
CACHES` and `SHOW PROXIED QUERIES` ReadySet commands.

In addition to looking nice, this partially mitigates the issue of
jumbled output when the results wrap around the terminal. Such wrapping
will still happen if any one prettified line is too long, however.

This is only done for Postgres deployments, as the MySQL terminal client
doesn't handle newlines within cells.

Refs: REA-3382
