### PR TITLE
sql: Project columns referenced by GROUP BY above aggs

### DIFF
--- a/logictests/group_by_projected_col.test
+++ b/logictests/group_by_projected_col.test
@@ -1,0 +1,25 @@
+statement ok
+create table events (
+  id int,
+  created_at timestamp
+);
+
+statement ok
+insert into events (id, created_at)
+values
+(1, '2023-09-01 12:22:00'),
+(1, '2023-08-31 12:22:00'),
+(1, '2023-08-18 12:22:00'),
+(1, '2023-06-02 12:22:00');
+
+query II rowsort
+select month(created_at) as grp, count(*) as count
+from events
+group by grp
+----
+6
+1
+8
+2
+9
+1

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -1990,6 +1990,15 @@ impl SqlToMirConverter {
 
             // Project out any columns that need special handling
             for oc in &query_graph.columns {
+                if expressions_above_grouped
+                    .values()
+                    .any(|alias| alias == oc.name())
+                {
+                    // Already projected, nothing to do
+                    already_computed.push(oc.clone());
+                    continue;
+                }
+
                 if let OutputColumn::Expr(ExprColumn {
                     name,
                     table: None,

--- a/readyset-server/src/controller/sql/query_graph.rs
+++ b/readyset-server/src/controller/sql/query_graph.rs
@@ -48,6 +48,26 @@ pub enum OutputColumn {
     Expr(ExprColumn),
 }
 
+impl OutputColumn {
+    /// Returns the final projected name for this [`OutputColumn`]
+    pub fn name(&self) -> &str {
+        match self {
+            OutputColumn::Data { alias, .. } => alias,
+            OutputColumn::Literal(LiteralColumn { name, .. }) => name,
+            OutputColumn::Expr(ExprColumn { name, .. }) => name,
+        }
+    }
+
+    /// Convert this [`OutputColumn`] into an [`Expr`], consuming it
+    pub fn into_expr(self) -> Expr {
+        match self {
+            OutputColumn::Data { column, .. } => Expr::Column(column),
+            OutputColumn::Literal(LiteralColumn { value, .. }) => Expr::Literal(value),
+            OutputColumn::Expr(ExprColumn { expression, .. }) => expression,
+        }
+    }
+}
+
 impl Ord for OutputColumn {
     fn cmp(&self, other: &OutputColumn) -> Ordering {
         match *self {


### PR DESCRIPTION
The SQL GROUP BY clause can reference columns in the SELECT list by name
- in this case, we need to project those columns *above* aggregate
nodes, rather than below like we normally do - then avoid projecting
them later in the leaf project node.

Fixes: REA-3436
