### PR TITLE
nom-sql: impl Ord for most of the AST

### DIFF
--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -268,7 +268,7 @@ impl TableKey {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)] // NOTE(aspen): do we actually care about this?
 #[derive(Default)]
 pub enum FieldDefinitionExpr {
@@ -330,7 +330,7 @@ pub enum Sign {
 
 /// A reference to a field in a query, usable in either the `GROUP BY` or `ORDER BY` clauses of the
 /// query
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum FieldReference {
     /// A reference to a field in the `SELECT` list by its (1-based) index.
     Numeric(u64),

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -28,7 +28,7 @@ use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Column, Dialect, Literal, NomSqlResult, SelectStatement, SqlIdentifier, SqlType};
 
 /// Function call expressions
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum FunctionExpr {
     /// `AVG` aggregation. The boolean argument is `true` if `DISTINCT`
     Avg { expr: Box<Expr>, distinct: bool },
@@ -165,7 +165,7 @@ impl FunctionExpr {
 /// Note that because all binary operators have expressions on both sides, SQL `IN` is not a binary
 /// operator - since it must have either a subquery or a list of expressions on its right-hand side
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Arbitrary,
+    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
 )]
 pub enum BinaryOperator {
     /// `AND`
@@ -334,7 +334,7 @@ impl Display for BinaryOperator {
 }
 
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Arbitrary,
+    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
 )]
 pub enum UnaryOperator {
     Neg,
@@ -351,7 +351,7 @@ impl Display for UnaryOperator {
 }
 
 /// Right-hand side of IN
-#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Clone, Serialize, Deserialize, From)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From)]
 pub enum InValue {
     Subquery(Box<SelectStatement>),
     List(Vec<Expr>),
@@ -371,7 +371,7 @@ impl InValue {
 }
 
 /// A single branch of a `CASE WHEN` statement
-#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Clone, Serialize, Deserialize, From)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From)]
 pub struct CaseWhenBranch {
     pub condition: Expr,
     pub body: Expr,
@@ -391,7 +391,7 @@ impl CaseWhenBranch {
 }
 
 /// SQL Expression AST
-#[derive(Debug, PartialEq, Eq, PartialOrd, Hash, Clone, Serialize, Deserialize, From)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From)]
 pub enum Expr {
     /// Function call expressions
     ///

--- a/nom-sql/src/join.rs
+++ b/nom-sql/src/join.rs
@@ -12,7 +12,7 @@ use test_strategy::Arbitrary;
 use crate::column::Column;
 use crate::{Dialect, Expr, NomSqlResult, TableExpr};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum JoinRightSide {
     /// A single table expression.
     Table(TableExpr),
@@ -40,7 +40,7 @@ impl JoinRightSide {
 }
 
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Arbitrary,
+    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
 )]
 pub enum JoinOperator {
     Join,
@@ -77,7 +77,7 @@ impl fmt::Display for JoinOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum JoinConstraint {
     On(Expr),
     Using(Vec<Column>),

--- a/nom-sql/src/order.rs
+++ b/nom-sql/src/order.rs
@@ -17,7 +17,7 @@ use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, FieldReference, NomSqlResult};
 
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Arbitrary,
+    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
 )]
 pub enum OrderType {
     OrderAscending,
@@ -45,7 +45,7 @@ impl fmt::Display for OrderType {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct OrderClause {
     pub order_by: Vec<(FieldReference, Option<OrderType>)>,
 }

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -26,7 +26,7 @@ use crate::{
     TableExpr,
 };
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Default, Serialize, Deserialize)]
 pub struct GroupByClause {
     pub fields: Vec<FieldReference>,
 }
@@ -46,7 +46,7 @@ impl GroupByClause {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct JoinClause {
     pub operator: JoinOperator,
     pub right: JoinRightSide,
@@ -67,7 +67,7 @@ impl JoinClause {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CommonTableExpr {
     pub name: SqlIdentifier,
     pub statement: SelectStatement,
@@ -87,7 +87,7 @@ impl CommonTableExpr {
 }
 
 /// AST representation of the SQL limit and offset clauses.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum LimitClause {
     /// The standard limit and offset syntax: `LIMIT <limit> OFFSET <offset>`.
     LimitOffset {
@@ -174,7 +174,7 @@ impl LimitClause {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct SelectStatement {
     pub ctes: Vec<CommonTableExpr>,
     pub distinct: bool,

--- a/nom-sql/src/set.rs
+++ b/nom-sql/src/set.rs
@@ -204,7 +204,7 @@ fn postgres_parameter_value(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], Postgr
 
 /// Scope for a [`Variable`]
 #[derive(
-    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Arbitrary,
+    Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
 )]
 pub enum VariableScope {
     User,
@@ -234,7 +234,7 @@ pub(crate) fn variable_scope_prefix(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8]
     ))(i)
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize, Arbitrary)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub struct Variable {
     pub scope: VariableScope,
     pub name: SqlIdentifier,

--- a/nom-sql/src/sql_type.rs
+++ b/nom-sql/src/sql_type.rs
@@ -26,7 +26,7 @@ use crate::table::relation;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, NomSqlResult, Relation};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum SqlType {
     Bool,
     Char(Option<u16>),
@@ -412,6 +412,13 @@ impl PartialOrd for EnumVariants {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         <[String]>::partial_cmp(self, other)
+    }
+}
+
+impl Ord for EnumVariants {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        <[String]>::cmp(self, other)
     }
 }
 

--- a/nom-sql/src/table.rs
+++ b/nom-sql/src/table.rs
@@ -96,7 +96,7 @@ impl Relation {
 }
 
 /// An expression for a table in a query
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum TableExprInner {
     Table(Relation),
     Subquery(Box<SelectStatement>),
@@ -128,7 +128,7 @@ impl TableExprInner {
 }
 
 /// An expression for a table in the `FROM` clause of a query, with optional alias
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct TableExpr {
     pub inner: TableExprInner,
     pub alias: Option<SqlIdentifier>,


### PR DESCRIPTION
I'm about to do something that requires sorting a list of Exprs - to
prepare for this, this commit impls Ord for all of the bits of the
nom-sql AST that are reachable from Expr (including SelectStatement).

