### PR TITLE
mir: Use the right symbol for LeftJoin nodes

### DIFF
--- a/readyset-mir/src/node/node_inner.rs
+++ b/readyset-mir/src/node/node_inner.rs
@@ -486,7 +486,7 @@ impl MirNodeInner {
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!(
-                    "⋉ [{} on {}]",
+                    "⟕ [{} on {}]",
                     project
                         .iter()
                         .map(|c| c.name.as_str())

--- a/readyset-mir/src/visualize.rs
+++ b/readyset-mir/src/visualize.rs
@@ -289,7 +289,7 @@ impl GraphViz for MirNodeInner {
             }
             MirNodeInner::LeftJoin { ref on, .. } => {
                 let jc = on.iter().map(|(l, r)| format!("{}:{}", l, r)).join(", ");
-                write!(f, "⋉  | on: {}", jc)
+                write!(f, "⟕ | on: {}", jc)
             }
             MirNodeInner::DependentJoin { ref on, .. } => {
                 write!(


### PR DESCRIPTION
The symbol we had previously been using for LeftJoin MIR nodes was the
symbol for left semijoin - our left join is just a left outer join, so
we should use the proper relational algebra symbol for a left outer join
to visualize it.

