### PR TITLE
mir: Add a DependentLeftJoin node type

### DIFF
--- a/readyset-mir/src/graph.rs
+++ b/readyset-mir/src/graph.rs
@@ -254,7 +254,8 @@ impl MirGraph {
                 .collect(),
             MirNodeInner::Join { project, .. }
             | MirNodeInner::LeftJoin { project, .. }
-            | MirNodeInner::DependentJoin { project, .. } => project.clone(),
+            | MirNodeInner::DependentJoin { project, .. }
+            | MirNodeInner::DependentLeftJoin { project, .. } => project.clone(),
             MirNodeInner::JoinAggregates => {
                 let cols = self
                     // see note [edge-ordering]

--- a/readyset-mir/src/rewrite/filters_to_join_keys.rs
+++ b/readyset-mir/src/rewrite/filters_to_join_keys.rs
@@ -146,6 +146,7 @@ pub(crate) fn convert_filters_to_join_keys(query: &mut MirQuery<'_>) -> ReadySet
                 | MirNodeInner::Identity
                 | MirNodeInner::JoinAggregates
                 | MirNodeInner::DependentJoin { .. }
+                | MirNodeInner::DependentLeftJoin { .. }
                 | MirNodeInner::ViewKey { .. }
                 | MirNodeInner::Project { .. }
                 | MirNodeInner::Leaf { .. } => {}

--- a/readyset-mir/src/rewrite/pull_keys.rs
+++ b/readyset-mir/src/rewrite/pull_keys.rs
@@ -65,6 +65,7 @@ fn push_view_key(query: &mut MirQuery<'_>, node_idx: NodeIndex) -> ReadySetResul
         | MirNodeInner::AliasTable { .. }
         | MirNodeInner::Join { .. }
         | MirNodeInner::DependentJoin { .. }
+        | MirNodeInner::DependentLeftJoin { .. }
         | MirNodeInner::Filter { .. }
         | MirNodeInner::Identity => {
             trace!(

--- a/readyset-mir/src/visualize.rs
+++ b/readyset-mir/src/visualize.rs
@@ -298,6 +298,13 @@ impl GraphViz for MirNodeInner {
                     on.iter().map(|(l, r)| format!("{}:{}", l, r)).join(", ")
                 )
             }
+            MirNodeInner::DependentLeftJoin { ref on, .. } => {
+                write!(
+                    f,
+                    "⟕D | on: {}",
+                    on.iter().map(|(l, r)| format!("{}:{}", l, r)).join(", ")
+                )
+            }
             MirNodeInner::Project { ref emit } => {
                 write!(f, "π: {}", emit.iter().join(", "))
             }

--- a/readyset-server/src/controller/mir_to_flow.rs
+++ b/readyset-server/src/controller/mir_to_flow.rs
@@ -194,7 +194,7 @@ pub(super) fn mir_node_to_flow_parts(
                         mig,
                     )?)
                 }
-                MirNodeInner::DependentJoin { .. } => {
+                MirNodeInner::DependentJoin { .. } | MirNodeInner::DependentLeftJoin { .. } => {
                     // See the docstring for MirNodeInner::DependentJoin
                     internal!("Encountered dependent join when lowering to dataflow")
                 }


### PR DESCRIPTION
Add a DependentLeftJoin MIR node type - like the DependentJoin node type
except it's for LEFT JOINs instead of INNER JOINs. Currently this is
unused - it's never compiled to, and there's no decorrelation support
for it yet.

Refs: REA-3417
Refs: #461
