### PR TITLE
mir/rewrite: Decorrelate LEFT JOINs

### DIFF
--- a/logictests/exists.test
+++ b/logictests/exists.test
@@ -98,3 +98,12 @@ AND author_id = ?;
 ? = 1
 ----
 1
+
+statement ok
+insert into users (id) values (3);
+
+query I nosort
+select id from users
+where not exists (select * from posts where author_id = users.id);
+----
+3

--- a/readyset-mir/src/graph.rs
+++ b/readyset-mir/src/graph.rs
@@ -208,6 +208,15 @@ impl MirGraph {
                 }
                 columns
             }
+            MirNodeInner::Join { on, project } | MirNodeInner::LeftJoin { on, project } => {
+                let mut columns = project.clone();
+                for c in on.iter().flat_map(|(lc, rc)| [lc, rc]) {
+                    if !columns.iter().any(|col| col == c) {
+                        columns.push(c.clone())
+                    }
+                }
+                columns
+            }
             _ => self.columns(node),
         }
     }

--- a/readyset-mir/src/node/node_inner.rs
+++ b/readyset-mir/src/node/node_inner.rs
@@ -350,7 +350,8 @@ impl MirNodeInner {
             }
             MirNodeInner::Join { project, .. }
             | MirNodeInner::LeftJoin { project, .. }
-            | MirNodeInner::DependentJoin { project, .. } => {
+            | MirNodeInner::DependentJoin { project, .. }
+            | MirNodeInner::DependentLeftJoin { project, .. } => {
                 if !project.contains(&c) {
                     project.push(c);
                 }
@@ -382,11 +383,15 @@ impl MirNodeInner {
         }
     }
 
-    /// Returns `true` if self is a [`DependentJoin`].
+    /// Returns `true` if self is a [`DependentJoin`] or [`DependentLeftJoin`].
     ///
     /// [`DependentJoin`]: MirNodeInner::DependentJoin
+    /// [`DependentLeftJoin`]: MirNodeInner::DependentLeftJoin
     pub fn is_dependent_join(&self) -> bool {
-        matches!(self, Self::DependentJoin { .. })
+        matches!(
+            self,
+            Self::DependentJoin { .. } | Self::DependentLeftJoin { .. }
+        )
     }
 
     /// Returns `true` if self is a [`ViewKey`].


### PR DESCRIPTION
Add support for decorrelating correlated LEFT JOINs to the decorrelate
MIR rewrite pass. This basically works the same as decorrelation for
INNER JOINs - we just push all dependent filters down to the join until
we can turn them into equi-join keys.

This allows us to support correlated NOT EXISTS in the WHERE clause of
queries, and gets us *close* to supporting correlated NOT IN everywhere
in queries.

Release-Note-Core: Add support for correlated and uncorrelated NOT
  EXISTS in the WHERE clause of queries.
Fixes: #461
Fixes: REA-3417
