### PR TITLE
sql: Properly mark subqueries for projected IN as dependent

### DIFF
--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -17,7 +17,6 @@ values
 (1, 1),
 (1, 1);
 
-
 query I nosort
 select count(*) from t1 where x in (select x from t2);
 ----
@@ -74,4 +73,24 @@ from t1
 query I nosort
 select x from t1 where y in (select y from t2 where t2.x = t1.x)
 ----
+1
+
+query I rowsort
+select x from t1 where y not in (select y from t2 where t2.x = t1.x)
+----
+2
+3
+
+query I nosort
+select y in (select y from t2 where t2.x = t1.x) from t1 order by x asc
+----
+1
+0
+0
+
+query I nosort
+select y not in (select y from t2 where t2.x = t1.x) from t1 order by x asc
+----
+0
+1
 1

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -1138,6 +1138,7 @@ impl SqlToMirConverter {
             }
         };
 
+        let is_correlated = is_correlated(&subquery);
         let query_graph = to_query_graph(subquery)?;
         let subquery_leaf = self.named_query_to_mir(
             query_name,
@@ -1185,7 +1186,11 @@ impl SqlToMirConverter {
             }],
             parent,
             right_mark,
-            JoinKind::Left,
+            if is_correlated {
+                JoinKind::DependentLeft
+            } else {
+                JoinKind::Left
+            },
         )?;
 
         Ok(self.make_project_node(


### PR DESCRIPTION
When making JOIN nodes for IN and NOT IN exprs in the column list, do
the same thing we do for other joins to subqueries and mark them
dependent if the subquery is correlated, so that the decorrelation pass
can pick up on them and decorrelate them later.

Release-Note-Core: Support correlated subqueries on the right-hand side
  of IN and NOT IN in the column list
