### PR TITLE
jepsen: Fix test crash on first-time startup during upstream teardown

### DIFF
--- a/jepsen/src/jepsen/readyset.clj
+++ b/jepsen/src/jepsen/readyset.clj
@@ -126,6 +126,7 @@
                (c/sudo "postgres" (c/exec "psql"
                                           :-c (str "drop database " rs/pgdatabase)))
                (catch #(re-find #"psql: command not found" (:err %)) _)
+               (catch #(re-find #"unknown user postgres" (:err %)) _)
                (catch #(re-find #"database \".*?\" does not exist" (:err %)) _)
                (catch
                    #(re-find #"database \".*?\" is used by an active logical"


### PR DESCRIPTION
The first time we try to run the teardown step on an upstream DB node,
we will fail because Postgres hasn't been set up yet, and so we end up
hitting an "unknown user postgres" error which is not caught in the
catches that currently exist.

This prevented me from making it through the README instructions when I
tried to follow them last week, and adding this line fixed the problem.

