### PR TITLE
treewide: Update rust-postgres dependency sha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,12 +321,6 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -3695,8 +3689,8 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#9732087d0eea968d1393709432c291449f9695f8"
+version = "0.19.7"
+source = "git+https://github.com/readysettech/rust-postgres.git#d4f90aa530783a0c7aaa6c5dba3841561061a0fe"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3708,18 +3702,19 @@ dependencies = [
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.3"
-source = "git+https://github.com/readysettech/rust-postgres.git#9732087d0eea968d1393709432c291449f9695f8"
+version = "0.4.5"
+source = "git+https://github.com/readysettech/rust-postgres.git#d4f90aa530783a0c7aaa6c5dba3841561061a0fe"
 dependencies = [
+ "heck 0.4.1",
  "proc-macro2 1.0.63",
  "quote 1.0.26",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/readysettech/rust-postgres.git#9732087d0eea968d1393709432c291449f9695f8"
+source = "git+https://github.com/readysettech/rust-postgres.git#d4f90aa530783a0c7aaa6c5dba3841561061a0fe"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3729,10 +3724,10 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#9732087d0eea968d1393709432c291449f9695f8"
+version = "0.6.6"
+source = "git+https://github.com/readysettech/rust-postgres.git#d4f90aa530783a0c7aaa6c5dba3841561061a0fe"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -3746,8 +3741,8 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.4"
-source = "git+https://github.com/readysettech/rust-postgres.git#9732087d0eea968d1393709432c291449f9695f8"
+version = "0.2.6"
+source = "git+https://github.com/readysettech/rust-postgres.git#d4f90aa530783a0c7aaa6c5dba3841561061a0fe"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -3930,7 +3925,7 @@ dependencies = [
  "hmac",
  "nom",
  "nom-sql",
- "postgres 0.19.4",
+ "postgres 0.19.7",
  "postgres-native-tls",
  "postgres-protocol",
  "postgres-types",
@@ -6310,8 +6305,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.7"
-source = "git+https://github.com/readysettech/rust-postgres.git#9732087d0eea968d1393709432c291449f9695f8"
+version = "0.7.10"
+source = "git+https://github.com/readysettech/rust-postgres.git#d4f90aa530783a0c7aaa6c5dba3841561061a0fe"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6326,9 +6321,11 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
+ "rand 0.8.5",
  "socket2 0.5.3",
  "tokio",
  "tokio-util 0.7.2",
+ "whoami",
 ]
 
 [[package]]
@@ -6654,8 +6651,8 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
- "rand 0.8.5",
+ "cfg-if 0.1.10",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -6917,6 +6914,16 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
This updates our rust-postgres dependencies in our Cargo.ock to the
latest version by running `cargo update` on them.

