### PR TITLE
server: Un-hide, document, and add env vars for HA flags

### DIFF
--- a/readyset-server/src/controller/replication.rs
+++ b/readyset-server/src/controller/replication.rs
@@ -7,8 +7,11 @@ use tracing::warn;
 #[allow(missing_docs)] // Allows us to exclude docs (from doc comments) from --help text
 #[derive(Debug, Parser, Clone)]
 pub struct ReplicationOptions {
-    /// Number of times to replicate domains that contain readers
-    #[clap(long, hide = true, conflicts_with = "non_base_replicas")]
+    /// Number of times to replicate domains that contain readers.
+    ///
+    /// This flag should be set to the number of adapter instances in the ReadySet deployment when
+    /// running in embbedded readers mode (eg for high availability)
+    #[clap(long, conflicts_with = "non_base_replicas", env = "READER_REPLICAS")]
     reader_replicas: Option<usize>,
 
     /// Number of times to replicate domains that don't contain base nodes

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -111,11 +111,14 @@ struct Options {
     authority_address: String,
 
     /// Whether this server should only run reader domains
-    #[clap(long, conflicts_with = "no_readers")]
+    #[clap(long, conflicts_with = "no_readers", env = "READER_ONLY")]
     reader_only: bool,
 
     /// If set, this server will never run domains containing reader nodes
-    #[clap(long, conflicts_with = "reader_only")]
+    ///
+    /// Pass this flag to the server instance when running a ReadySet deployment in embedded
+    /// readers mode (eg for high availability)
+    #[clap(long, conflicts_with = "reader_only", env = "NO_READERS")]
     no_readers: bool,
 
     /// Prevent this instance from ever being elected as the leader


### PR DESCRIPTION
Un-hide the `reader_replicas` flag, add new docs to it and the
`no_readers` flag, and add env vars to those two and the `no_readers`
flag, since they're required to run ReadySet in warm-read HA mode.

Refs: REA-3442
