### PR TITLE
dataflow-state: Update insert methods to return duplicate row count

### DIFF
--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -475,12 +475,12 @@ impl MemoryState {
             };
             self.mem_size += r.deep_size_of();
             // SAFETY: row remains inside the same state
-            self.state[i].insert_row(unsafe { r.clone() })
+            self.state[i].insert_row(unsafe { r.clone() }).is_some()
         } else {
             let mut hit_any = false;
             for i in 0..self.state.len() {
                 // SAFETY: row remains inside the same state
-                hit_any |= self.state[i].insert_row(unsafe { r.clone() });
+                hit_any |= self.state[i].insert_row(unsafe { r.clone() }).is_some();
             }
             if hit_any {
                 self.mem_size += r.deep_size_of();


### PR DESCRIPTION
Instead of just returning `true`/`false` based on whether the row was
inserted, this changes some insert-related code to now return `Some(n)`
or `None`, where `Some(n)` means the row was inserted and gives the
number of duplicates of that row that now exist in the state.

This doesn't make any user-visible changes, since the only code that
used the return values to these functions is also updated by this commit
to just call `.is_some()` on the return value. But, this lays the
groundwork for followup commits that will fix some bugs relating to weak
indexes.

Refs: REA-3336
Refs: #286
