### PR TITLE
replicator: Handle PG WAL rotation

### DIFF
--- a/readyset-client/src/failpoints/mod.rs
+++ b/readyset-client/src/failpoints/mod.rs
@@ -18,3 +18,7 @@ pub const REPLICATION_HANDLE_ACTION: &str = "replication-handle-action";
 pub const POSTGRES_REPLICATION_NEXT_ACTION: &str = "postgres-replication-next-action";
 /// Imitates a failure right before we begin snapshotting against a Postgres upstream
 pub const POSTGRES_SNAPSHOT_START: &str = "postgres-snapshot-start";
+/// Imitates a failure right before we invoke `START_REPLICATION` during Postgres replication
+pub const POSTGRES_START_REPLICATION: &str = "postgres-start-replication";
+/// Imitates a failure when we go to pull the next event from the WAL during Postgres replication
+pub const POSTGRES_NEXT_WAL_EVENT: &str = "postgres-next-wal-event";

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -619,8 +619,9 @@ pub enum ReadySetError {
     #[error("Malformed array literal '{}': {}", Sensitive(&input), message)]
     ArrayParseError { input: String, message: String },
 
-    /// A DDL in upstream database requires a partial resnapshot
-    #[error("Change in DDL requires partial resnapshot")]
+    /// An error occured that requires a resnapshot. This error will trigger a *full* resnapshot
+    /// only if the schema or one of the tables is missing a replication offset.
+    #[error("Resnapshot needed")]
     ResnapshotNeeded,
 
     /// An unrecoverable error occurred, requiring a full resnapshot


### PR DESCRIPTION
If the number of WAL files on the upstream Postgres instance exceeds
`max_slot_wal_keep_size`, the database will mark them for deletion,
giving our replication slot a status of "unreserved." When the next
checkpoint happens, these files will be deleted, giving our slot a
status of "lost." This would typically happen if we aren't replicating
changes as quickly as they are being written upstream; the LSN we report
upstream would grow further and further from the current LSN on the
server, forcing it to keep a longer and longer history of WAL.

Previously, when this happened, we'd enter into an infinite retry loop
in the replicator: replication would error out and upon restarting the
replicator, we'd fail to start replication because our slot was
invalidated. This commit fixes this by querying the WAL status of our
slot via `pg_replication_slots` before we invoke `START_REPLICATION`. If
the status of our slot is "lost," a full resnapshot is triggered.

Fixes: REA-3303
