### PR TITLE
client: Use request timeout for migration_status RPC

### DIFF
--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -684,15 +684,7 @@ impl ReadySetHandle {
             {
                 ExtendRecipeResult::Done => Ok(()),
                 ExtendRecipeResult::Pending(migration_id) => {
-                    while self
-                        .rpc::<_, MigrationStatus>(
-                            "migration_status",
-                            migration_id,
-                            self.migration_timeout,
-                        )
-                        .await?
-                        .is_pending()
-                    {
+                    while self.migration_status(migration_id).await?.is_pending() {
                         tokio::time::sleep(EXTEND_RECIPE_POLL_INTERVAL).await;
                     }
                     Ok(())
@@ -706,7 +698,7 @@ impl ReadySetHandle {
         &mut self,
         migration_id: u64,
     ) -> impl Future<Output = ReadySetResult<MigrationStatus>> + '_ {
-        self.rpc::<_, MigrationStatus>("migration_status", migration_id, self.migration_timeout)
+        self.rpc::<_, MigrationStatus>("migration_status", migration_id, self.request_timeout)
     }
 
     /// Asynchronous version of extend_recipe(). The Controller should immediately return an ID that


### PR DESCRIPTION
Use the request timeout (default 5s) for the migration_status RPC
instead of the migration timeout (default 30m), as that RPC doesn't
perform migrations.

Also, replace a direct call to rpc("migration_status") with the
migration_status method.

