### PR TITLE
readyset: Make comment on psql::Options not a doc comment

### DIFF
--- a/readyset/src/psql.rs
+++ b/readyset/src/psql.rs
@@ -11,7 +11,7 @@ use tracing::{error, instrument};
 
 use crate::ConnectionHandler;
 
-/// readyset-psql specific options
+// readyset-psql specific options
 #[derive(Clone, Debug, Parser)]
 pub struct Options {
     /// The pkcs12 identity file (certificate and key) used by ReadySet for establishing TLS


### PR DESCRIPTION
If this is a doc comment, it gets put as the overall documentation for
the `readyset` binary, rather than the correct doc comment.

Before this change:

    ❯ cargo run --bin readyset -- --help

        Running `target/debug/readyset --help`
    readyset-psql specific options

    Usage: readyset [OPTIONS]
    ...

After this change:

    ❯ cargo run --bin readyset -- --help

        Running `target/debug/readyset --help`
    Usage: readyset [OPTIONS]
    ...

