### PR TITLE
treewide: Replace obsolete ticket names ENG-2499/2500

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -984,7 +984,7 @@ where
             }
             Err(e) => {
                 warn!(
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     statement = %Sensitive(&stmt.display(nom_sql::Dialect::MySQL)),
                     "This statement could not be rewritten by ReadySet"
                 );
@@ -1033,7 +1033,7 @@ where
             ) => PrepareMeta::Write { stmt: query },
             Ok(pq) => {
                 warn!(
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     statement = %Sensitive(&pq.display(nom_sql::Dialect::MySQL)),
                     "Statement cannot be prepared by ReadySet"
                 );
@@ -1629,7 +1629,7 @@ where
         if let Some(name) = name {
             if let Some(view_request) = self.noria.view_create_request_from_name(name).await {
                 warn!(
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     statement = %Sensitive(&view_request.statement.display(nom_sql::Dialect::MySQL)),
                     name = %name.display(nom_sql::Dialect::MySQL),
                     "Dropping previously cached query",
@@ -2109,7 +2109,7 @@ where
                 should_try
             } else {
                 warn!(
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     statement = %Sensitive(&q.statement.display(nom_sql::Dialect::MySQL)),
                     "This statement could not be rewritten by ReadySet"
                 );
@@ -2139,7 +2139,7 @@ where
         match Handler::handle_set_statement(set) {
             SetBehavior::Unsupported => {
                 warn!(
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     set = %set.display(nom_sql::Dialect::MySQL),
                     "received unsupported SET statement"
                 );
@@ -2162,7 +2162,7 @@ where
             SetBehavior::Proxy => { /* Do nothing (the caller will proxy for us) */ }
             SetBehavior::SetAutocommit(on) => {
                 warn!(
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     set = %set.display(nom_sql::Dialect::MySQL),
                     "received unsupported SET statement"
                 );
@@ -2587,7 +2587,7 @@ fn log_query(
     {
         if let Some(query) = &event.query {
             warn!(
-                // FIXME(ENG-2499): Use correct dialect.
+                // FIXME(REA-2168): Use correct dialect.
                 query = %Sensitive(&query.display(nom_sql::Dialect::MySQL)),
                 readyset_time = ?event.readyset_duration,
                 upstream_time = ?event.upstream_duration,

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -55,7 +55,7 @@ pub(crate) struct PreparedSelectStatement {
 
 impl fmt::Debug for PreparedStatement {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        // FIXME(ENG-2499): Use correct dialect.
+        // FIXME(REA-2168): Use correct dialect.
         match self {
             PreparedStatement::Select(PreparedSelectStatement { name, .. }) => {
                 write!(f, "{}", name.display(nom_sql::Dialect::MySQL),)

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -135,7 +135,7 @@ impl MigrationHandler {
                     Err(e) if e.caused_by_unsupported() => {
                         debug!(
                             error = %e,
-                            // FIXME(ENG-2500): Use correct dialect.
+                            // FIXME(REA-2169): Use correct dialect.
                             query = %Sensitive(&query.query().statement.display(nom_sql::Dialect::MySQL)),
                             "Select query is unsupported in ReadySet"
                         );
@@ -148,7 +148,7 @@ impl MigrationHandler {
                     Err(e) => {
                         debug!(
                             error = %e,
-                            // FIXME(ENG-2500): Use correct dialect.
+                            // FIXME(REA-2169): Use correct dialect.
                             query = %Sensitive(&query.query().statement.display(nom_sql::Dialect::MySQL)),
                             "Select query may have transiently failed"
                         );
@@ -238,7 +238,7 @@ impl MigrationHandler {
             Err(e) if e.caused_by_unsupported() => {
                 debug!(
                     error = %e,
-                    // FIXME(ENG-2499 + ENG-2500): Use correct dialect.
+                    // FIXME(REA-2168 + REA-2169): Use correct dialect.
                     query = %Sensitive(&view_request.statement.display(nom_sql::Dialect::MySQL)),
                     "Select query is unsupported in ReadySet"
                 );
@@ -252,7 +252,7 @@ impl MigrationHandler {
             Err(e) => {
                 debug!(
                     error = %e,
-                    // FIXME(ENG-2499 + ENG-2500): Use correct dialect.
+                    // FIXME(REA-2168 + REA-2169): Use correct dialect.
                     query = %Sensitive(&view_request.statement.display(nom_sql::Dialect::MySQL)),
                     "Select query may have transiently failed"
                 );

--- a/readyset-adapter/src/rewrite.rs
+++ b/readyset-adapter/src/rewrite.rs
@@ -256,7 +256,7 @@ fn where_in_to_placeholders(
             Expr::Literal(Literal::Placeholder(ph)) => Ok(ph),
             _ => unsupported!(
                 "IN only supported on placeholders, got: {}",
-                // FIXME(ENG-2499): Use correct dialect.
+                // FIXME(REA-2168): Use correct dialect.
                 e.display(nom_sql::Dialect::MySQL)
             ),
         })

--- a/readyset-adapter/src/views_synchronizer.rs
+++ b/readyset-adapter/src/views_synchronizer.rs
@@ -82,7 +82,7 @@ impl ViewsSynchronizer {
             Ok(statuses) => {
                 for (query, migrated) in queries.into_iter().zip(statuses) {
                     trace!(
-                        // FIXME(ENG-2499): Use correct dialect.
+                        // FIXME(REA-2168): Use correct dialect.
                         query = %query.statement.display(nom_sql::Dialect::MySQL),
                         migrated,
                         "Loaded query status from controller"

--- a/readyset-logictest/src/from_query_log.rs
+++ b/readyset-logictest/src/from_query_log.rs
@@ -171,7 +171,7 @@ impl FromQueryLog {
             .map(Value::try_from)
             .collect::<Result<Vec<_>, _>>()?;
 
-        // FIXME(ENG-2499): Use correct dialect.
+        // FIXME(REA-2168): Use correct dialect.
         let stmt_string = stmt.display(nom_sql::Dialect::MySQL).to_string();
 
         let rows = conn.execute(&stmt_string, &params).await?;

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -713,7 +713,7 @@ impl SqlToMirConverter {
     ) -> NodeIndex {
         trace!(
             name = %name.display_unquoted(),
-            // FIXME(ENG-2499+2502): Use correct dialect.
+            // FIXME(REA-2168+2502): Use correct dialect.
             conditions = %conditions.display(nom_sql::Dialect::MySQL),
             "Added filter node"
         );
@@ -1255,7 +1255,7 @@ impl SqlToMirConverter {
                             Expr::Column(col) => Column::from(col),
                             expr => {
                                 let col = Column::named(
-                                    // FIXME(ENG-2499+2502): Use correct dialect.
+                                    // FIXME(REA-2168+2502): Use correct dialect.
                                     expr.display(nom_sql::Dialect::MySQL).to_string(),
                                 );
                                 if self

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -1009,7 +1009,7 @@ impl SqlIncorporator {
         leaf_behavior: LeafBehavior,
         mig: &mut Migration<'_>,
     ) -> ReadySetResult<MirNodeIndex> {
-        // FIXME(ENG-2499): Use correct dialect.
+        // FIXME(REA-2168): Use correct dialect.
         trace!(stmt = %stmt.display(nom_sql::Dialect::MySQL), "Adding select query");
         *stmt = self.rewrite(stmt.clone(), search_path, mig.dialect, invalidating_tables)?;
 
@@ -1060,7 +1060,7 @@ impl SqlIncorporator {
             }
         }
 
-        // FIXME(ENG-2499): Use correct dialect.
+        // FIXME(REA-2168): Use correct dialect.
         trace!(rewritten_query = %stmt.display(nom_sql::Dialect::MySQL));
 
         let query_graph = to_query_graph(stmt.clone())?;

--- a/readyset-server/src/controller/sql/query_graph.rs
+++ b/readyset-server/src/controller/sql/query_graph.rs
@@ -731,7 +731,7 @@ fn extract_having_aggregates(
 
         fn visit_expr(&mut self, expr: &'ast mut Expr) -> Result<(), Self::Error> {
             if matches!(expr, Expr::Call(fun) if is_aggregate(fun)) {
-                // FIXME(ENG-2499): Use correct dialect.
+                // FIXME(REA-2168): Use correct dialect.
                 let name: SqlIdentifier = expr.display(nom_sql::Dialect::MySQL).to_string().into();
                 let col_expr = Expr::Column(nom_sql::Column {
                     name: name.clone(),
@@ -1169,7 +1169,7 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
             FieldDefinitionExpr::Expr { expr, alias } => {
                 let name: SqlIdentifier = alias
                     .clone()
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     .unwrap_or_else(|| expr.display(nom_sql::Dialect::MySQL).to_string().into());
                 match expr {
                     Expr::Literal(l) => columns.push(OutputColumn::Literal(LiteralColumn {
@@ -1266,14 +1266,14 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
                     // the pull_columns pass will make sure the topk/paginate node gets the
                     // aggregate result column
                     aggregates.entry(func.clone()).or_insert_with(|| {
-                        // FIXME(ENG-2499): Use correct dialect.
+                        // FIXME(REA-2168): Use correct dialect.
                         func.display(nom_sql::Dialect::MySQL).to_string().into()
                     });
                 }
                 FieldReference::Expr(expr) => {
                     // This is an expression that we need to add to the list of projected columns
                     columns.push(OutputColumn::Expr(ExprColumn {
-                        // FIXME(ENG-2499): Use correct dialect.
+                        // FIXME(REA-2168): Use correct dialect.
                         name: expr.display(nom_sql::Dialect::MySQL).to_string().into(),
                         table: None,
                         expression: expr.clone(),
@@ -1297,7 +1297,7 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
                         match expr {
                             FieldReference::Expr(Expr::Column(col)) => col,
                             FieldReference::Expr(expr) => Column {
-                                // FIXME(ENG-2499): Use correct dialect.
+                                // FIXME(REA-2168): Use correct dialect.
                                 name: expr.display(nom_sql::Dialect::MySQL).to_string().into(),
                                 table: None,
                             },

--- a/readyset-sql-passes/src/alias_removal.rs
+++ b/readyset-sql-passes/src/alias_removal.rs
@@ -240,7 +240,7 @@ mod tests {
                  to rewrite to: {} \n\
                        but got: {}",
                 $before,
-                // FIXME(ENG-2499): Use correct dialect.
+                // FIXME(REA-2168): Use correct dialect.
                 expected.display(nom_sql::Dialect::MySQL),
                 res.display(nom_sql::Dialect::MySQL),
             );
@@ -533,7 +533,7 @@ mod tests {
             res,
             expected,
             "\n\n   {}\n!= {}",
-            // FIXME(ENG-2499): Use correct dialect.
+            // FIXME(REA-2168): Use correct dialect.
             res.display(nom_sql::Dialect::MySQL),
             expected.display(nom_sql::Dialect::MySQL)
         );

--- a/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
+++ b/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
@@ -58,7 +58,7 @@ impl NormalizeTopKWithAggregate for SelectStatement {
 
                             if !in_group_by_clause && !references_aggregate {
                                 return Err(ReadySetError::ExprNotInGroupBy {
-                                    // FIXME(ENG-2499): Use correct dialect.
+                                    // FIXME(REA-2168): Use correct dialect.
                                     expression: order_field
                                         .display(nom_sql::Dialect::MySQL)
                                         .to_string(),

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -105,7 +105,7 @@ impl QueryLogger {
                 let mut stmt = stmt.clone();
                 if readyset_adapter::rewrite::process_query(&mut stmt, true).is_ok() {
                     anonymize_literals(&mut stmt);
-                    // FIXME(ENG-2499): Use correct dialect.
+                    // FIXME(REA-2168): Use correct dialect.
                     stmt.display(nom_sql::Dialect::MySQL).to_string()
                 } else {
                     "".to_string()


### PR DESCRIPTION
Replace old Jira ticket names ENG-2499 and ENG-2500 by their Linear
counterparts REA-2168 and REA-2169, respectively, in various FIXME
comments.

