### PR TITLE
adapter: Mark queries unsupported after max dry run time elapses

### DIFF
--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -315,12 +315,15 @@ impl MigrationHandler {
             .or_insert_with(Instant::now);
         if Instant::now() - *start_time > self.max_retry {
             // We've exceeded the max amount of times we'll try running dry runs with this query.
-            // It's probably unsupported, but we'll allow a proper migration determine that.
+            // We can't be certain its unsupported without attempting an actual migration, but
+            // mark it unsupported anyway to avoid confusion.
             debug!(
                 "Max retry time of {:?} exceeded for dry run migration. {:?} is probably unsupported",
                 self.max_retry,
                 view_request.to_anonymized_string()
             );
+            self.query_status_cache
+                .update_query_migration_state(view_request, MigrationState::Unsupported);
             return;
         }
         let qname =

--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -22,7 +22,7 @@ use tracing::error;
 #[derive(Debug)]
 pub struct QueryStatusCache {
     /// A thread-safe hash map that holds the query status of each successfully parsed query that
-    /// is cached.
+    /// has been sent to this adapter.
     statuses: DashMap<Arc<ViewCreateRequest>, QueryStatus, ahash::RandomState>,
 
     // A thread-safe hash map that holds the query status of each query that has failed to parse.


### PR DESCRIPTION
In explicit migration mode, mark pending queries as unsupported if their
dry-run fails for longer than MAX_PROCESSING_MINUTES (default 15).

It was already impossible for pending queries to become supported beyond
that duration (as we give up on dry-running them), but we would leave
them pending indefinitely. This allowed the user to try to cache them
explicitly; a failure here would indeed mark the query unsupported.

Refs: REA-3383
