### PR TITLE
sql: Remove from view_schemas when removing views

### DIFF
--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -1157,6 +1157,7 @@ impl SqlIncorporator {
         }
         let mut mir_removal_result = self.mir_converter.remove_query(query_name)?;
         self.process_removal(&mut mir_removal_result, mig);
+        self.view_schemas.remove(query_name);
         Ok(mir_removal_result)
     }
 
@@ -1186,6 +1187,7 @@ impl SqlIncorporator {
         for query in removal_result.relations_removed.iter() {
             self.leaf_addresses.remove(query);
             self.registry.remove_expression(query);
+            self.view_schemas.remove(query);
         }
         // Sadly, we don't use `DfNodeIndex` for migrations/df state, so we need to map them
         // to `NodeIndex`.


### PR DESCRIPTION
Since we use the contents of `SqlIncorporator::view_schemas` to desugar
queries referencing views (eg to populate column lists in
`star_expansion` for queries which run `SELECT * FROM v`), it's
important that when SQL VIEWs are removed we also remove from that map -
otherwise queries referencing another view with the same name but
different column names would get the column names in the other view for
its `*`.

This commit does that removal in two places - first, when explicitly
dropping views eg as a result of a replicated `DROP VIEW` statement, and
second when views are dropped because they referenced tables that were
dropped. Note that in the second case we don't actually care about
`CASCADE` - the semantics of ReadySet have *all* drops imply `CASCADE`
and we just trust the upstream db to have already checked referential
integrity for us.

Fixes: REA-3284
