### PR TITLE
adapter: Make SQL_DIALECT a constant, not a function

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1760,7 +1760,7 @@ where
                 vec![
                     DfValue::from(id.to_string()),
                     DfValue::from(Self::format_query_text(
-                        query.display(DB::sql_dialect()).to_string(),
+                        query.display(DB::SQL_DIALECT).to_string(),
                     )),
                     DfValue::from(s),
                 ]
@@ -1806,8 +1806,7 @@ where
                     .display_unquoted()
                     .to_string()
                     .into(),
-                Self::format_query_text(view.statement.display(DB::sql_dialect()).to_string())
-                    .into(),
+                Self::format_query_text(view.statement.display(DB::SQL_DIALECT).to_string()).into(),
                 if status.always {
                     "no fallback".into()
                 } else {
@@ -2566,7 +2565,7 @@ where
     /// Prettify queries above an arbitrary length.
     /// Don't do it for MySQL because the terminal client doesn't handle newlines.
     fn format_query_text(query: String) -> String {
-        if DB::sql_dialect() != nom_sql::Dialect::MySQL && query.len() > 40 {
+        if DB::SQL_DIALECT != nom_sql::Dialect::MySQL && query.len() > 40 {
             sqlformat::format(&query, &Default::default(), Default::default())
         } else {
             query

--- a/readyset-adapter/src/upstream_database.rs
+++ b/readyset-adapter/src/upstream_database.rs
@@ -89,6 +89,9 @@ pub trait UpstreamDatabase: Sized + Send {
     /// is only used for tests
     const DEFAULT_DB_VERSION: &'static str;
 
+    /// Returns the SQL dialect to use for formatting queries
+    const SQL_DIALECT: nom_sql::Dialect;
+
     /// Create a new connection to this upstream database
     ///
     /// Connect will return an error if the upstream database is running an unsupported version.
@@ -99,9 +102,6 @@ pub trait UpstreamDatabase: Sized + Send {
 
     /// Test the connection with the upstream database
     async fn is_connected(&mut self) -> bool;
-
-    /// Returns the SQL dialect for which to format queries.
-    fn sql_dialect() -> nom_sql::Dialect;
 
     /// Return a reference to the URL used when originally constructing this database via
     /// [`connect`]

--- a/readyset-mysql/src/upstream.rs
+++ b/readyset-mysql/src/upstream.rs
@@ -237,6 +237,7 @@ impl UpstreamDatabase for MySqlUpstream {
     type ExecMeta<'a> = ();
     type Error = Error;
     const DEFAULT_DB_VERSION: &'static str = "8.0.26-readyset\0";
+    const SQL_DIALECT: nom_sql::Dialect = nom_sql::Dialect::MySQL;
 
     async fn connect(upstream_config: UpstreamConfig) -> Result<Self, Error> {
         let (conn, prepared_statements, upstream_config) =
@@ -246,10 +247,6 @@ impl UpstreamDatabase for MySqlUpstream {
             prepared_statements,
             upstream_config,
         })
-    }
-
-    fn sql_dialect() -> nom_sql::Dialect {
-        nom_sql::Dialect::MySQL
     }
 
     fn url(&self) -> &str {

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -159,6 +159,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
     type ExecMeta<'a> = &'a [TransferFormat];
     type Error = Error;
     const DEFAULT_DB_VERSION: &'static str = "13.4 (ReadySet)";
+    const SQL_DIALECT: nom_sql::Dialect = nom_sql::Dialect::PostgreSQL;
 
     async fn connect(upstream_config: UpstreamConfig) -> Result<Self, Error> {
         let url = upstream_config
@@ -215,10 +216,6 @@ impl UpstreamDatabase for PostgreSqlUpstream {
             upstream_config,
             version,
         })
-    }
-
-    fn sql_dialect() -> nom_sql::Dialect {
-        nom_sql::Dialect::PostgreSQL
     }
 
     fn url(&self) -> &str {


### PR DESCRIPTION
This function does no computation ever, so it doesn't need to be a
function - instead it can just be an associated constant on the trait

