### PR TITLE
adapter: Remove `url` and `schema_dump` from UpstreamDatabase

### DIFF
--- a/readyset-adapter/src/upstream_database.rs
+++ b/readyset-adapter/src/upstream_database.rs
@@ -103,10 +103,6 @@ pub trait UpstreamDatabase: Sized + Send {
     /// Test the connection with the upstream database
     async fn is_connected(&mut self) -> bool;
 
-    /// Return a reference to the URL used when originally constructing this database via
-    /// [`connect`]
-    fn url(&self) -> &str;
-
     /// Returns a database name if it was included in the original connection string, or None if no
     /// database name was included in the original connection string.
     fn database(&self) -> Option<&str> {
@@ -173,9 +169,6 @@ pub trait UpstreamDatabase: Sized + Send {
 
     /// Handle rolling back the ongoing transaction for this connection to the upstream db.
     async fn rollback<'a>(&'a mut self) -> Result<Self::QueryResult<'a>, Self::Error>;
-
-    /// Return schema dump from the upstream database, for inclusion in a query analysis bundle.
-    async fn schema_dump(&mut self) -> Result<Vec<u8>, anyhow::Error>;
 
     /// Query the upstream database for the currently configured schema search path.
     ///

--- a/readyset-mysql/src/upstream.rs
+++ b/readyset-mysql/src/upstream.rs
@@ -249,10 +249,6 @@ impl UpstreamDatabase for MySqlUpstream {
         })
     }
 
-    fn url(&self) -> &str {
-        self.upstream_config.upstream_db_url.as_deref().unwrap()
-    }
-
     fn database(&self) -> Option<&str> {
         self.conn.opts().db_name()
     }
@@ -393,23 +389,6 @@ impl UpstreamDatabase for MySqlUpstream {
         Ok(QueryResult::Command {
             status_flags: self.conn.status(),
         })
-    }
-
-    async fn schema_dump(&mut self) -> Result<Vec<u8>, anyhow::Error> {
-        let tables: Vec<String> = self.conn.query_iter("SHOW TABLES").await?.collect().await?;
-        let mut dump = String::with_capacity(tables.len());
-        for table in &tables {
-            if let Some(create) = self
-                .conn
-                .query_first(format!("SHOW CREATE TABLE `{}`", &table))
-                .await?
-                .map(|row: (String, String)| row.1)
-            {
-                dump.push_str(&create);
-                dump.push('\n');
-            }
-        }
-        Ok(dump.into_bytes())
     }
 
     async fn schema_search_path(&mut self) -> Result<Vec<SqlIdentifier>, Self::Error> {


### PR DESCRIPTION
Neither of these are used, and maintaining them with lazy connections to
the upstream is going to be hard, so let's just remove them.

