### PR TITLE
metrics: Use forked metrics crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
@@ -2007,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
 dependencies = [
  "ahash 0.8.3",
 ]
@@ -2633,7 +2624,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.13.1",
 ]
 
 [[package]]
@@ -2744,9 +2735,8 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
+version = "0.21.1"
+source = "git+https://github.com/readysettech/metrics.git#9834afdd26f6dea20cd6bc1003fa15bf350cc0f5"
 dependencies = [
  "ahash 0.8.3",
  "metrics-macros",
@@ -2756,8 +2746,7 @@ dependencies = [
 [[package]]
 name = "metrics-exporter-prometheus"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+source = "git+https://github.com/readysettech/metrics.git#9834afdd26f6dea20cd6bc1003fa15bf350cc0f5"
 dependencies = [
  "base64 0.21.0",
  "hyper",
@@ -2774,8 +2763,7 @@ dependencies = [
 [[package]]
 name = "metrics-macros"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+source = "git+https://github.com/readysettech/metrics.git#9834afdd26f6dea20cd6bc1003fa15bf350cc0f5"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.26",
@@ -2784,14 +2772,13 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111cb375987443c3de8d503580b536f77dc8416d32db62d9456db5d93bd7ac47"
+version = "0.15.1"
+source = "git+https://github.com/readysettech/metrics.git#9834afdd26f6dea20cd6bc1003fa15bf350cc0f5"
 dependencies = [
- "aho-corasick 0.7.20",
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.13.2",
+ "hashbrown 0.13.1",
  "indexmap",
  "metrics",
  "num_cpus",
@@ -4279,7 +4266,6 @@ dependencies = [
  "readyset-version",
  "replicators",
  "reqwest",
- "rlimit",
  "tokio",
  "tokio-native-tls",
  "tokio-stream",
@@ -5093,7 +5079,7 @@ version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.2",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.7.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ eui48 = { git = "https://github.com/readysettech/eui48.git", branch = "master" }
 opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust" }
 opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust" }
 opentelemetry-semantic-conventions = { git = "https://github.com/open-telemetry/opentelemetry-rust" }
+metrics-exporter-prometheus = { git = "https://github.com/readysettech/metrics.git" }
+metrics = { git = "https://github.com/readysettech/metrics.git" }
+metrics-util = { git = "https://github.com/readysettech/metrics.git" }
 
 [workspace]
 members = [
@@ -75,6 +78,9 @@ postgres-types = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio-postgres = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio = { version = "1.32",  features = ["full"] }
 rocksdb = { git = "https://github.com/readysettech/rust-rocksdb.git", default-features = false, features = ["lz4", "jemalloc"] }
+metrics-exporter-prometheus = { version = "0.12.1" }
+metrics = { version = "0.21.1" }
+metrics-util = { version = "0.15.1"}
 
 [profile.release]
 debug=true

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -29,9 +29,9 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 serde = "1.0"
 serde_with = "1.12"
-metrics = "0.21"
-metrics-util = "0.15"
-metrics-exporter-prometheus = {version = "0.12.1", features = ["push-gateway", "tokio"]}
+metrics = { workspace = true }
+metrics-util = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 itertools = "0.10"
 num-integer = "0.1.44"
 lazy_static = "1.4.0"

--- a/benchmarks/src/utils/mod.rs
+++ b/benchmarks/src/utils/mod.rs
@@ -108,7 +108,8 @@ macro_rules! benchmark_gauge {
     ($name: expr, $unit: ident, $description: expr, $value: expr $(, $label_key: expr => $label_value: expr)*) => {
         if let Some(recorder) = metrics::try_recorder() {
             let key = $crate::make_key!($name, $unit $(, $label_key => $label_value)*);
-            let g = recorder.register_gauge(&key);
+            let meta = metrics::Metadata::new("", metrics::Level::INFO, None);
+            let g = recorder.register_gauge(&key, &meta);
             recorder.describe_gauge(key.into_parts().0, Some(::metrics::Unit::$unit), $description);
             g.set($value);
         }
@@ -120,7 +121,8 @@ macro_rules! benchmark_counter {
     ($name: expr, $unit: ident, $description: expr, $value: expr $(, $label_key: expr => $label_value: expr)*) => {
         if let Some(recorder) = metrics::try_recorder() {
             let key = $crate::make_key!($name, $unit $(, $label_key => $label_value)*);
-            let c = recorder.register_counter(&key);
+            let meta = metrics::Metadata::new("", metrics::Level::INFO, None);
+            let c = recorder.register_counter(&key, &meta);
             recorder.describe_counter(key.into_parts().0, Some(::metrics::Unit::$unit), $description);
             c.increment($value);
         }
@@ -135,7 +137,8 @@ macro_rules! benchmark_increment_counter {
     ($name: expr, $unit: ident, $value: expr $(, $label_key: expr => $label_value: expr)*) => {
         if let Some(recorder) = metrics::try_recorder() {
             let key = $crate::make_key!($name, $unit $(, $label_key => $label_value)*);
-            let c = recorder.register_counter(&key);
+            let meta = metrics::Metadata::new("", metrics::Level::INFO, None);
+            let c = recorder.register_counter(&key, &meta);
             c.increment($value);
         }
     };
@@ -149,7 +152,8 @@ macro_rules! benchmark_histogram {
     ($name: expr, $unit: ident, $description: expr, $value: expr $(, $label_key: expr => $label_value: expr)*) => {
         if let Some(recorder) = metrics::try_recorder() {
             let key = $crate::make_key!($name, $unit $(, $label_key => $label_value)*);
-            let h = recorder.register_histogram(&key);
+            let meta = metrics::Metadata::new("", metrics::Level::INFO, None);
+            let h = recorder.register_histogram(&key, &meta);
             recorder.describe_histogram(key.into_parts().0, Some(::metrics::Unit::$unit), $description);
             h.record($value);
         }

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -28,8 +28,8 @@ derive_more = "0.99.11"
 async-trait = "0.1.58"
 thiserror = "1.0.26"
 readyset-util = { path = "../readyset-util" }
-metrics = "0.21"
-metrics-exporter-prometheus = "0.12.1"
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 futures = "0.3"
 serde = "1.0.130"
 serde_json = "1.0.67"

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -107,7 +107,7 @@ use crate::query_handler::SetBehavior;
 use crate::query_status_cache::QueryStatusCache;
 pub use crate::upstream_database::UpstreamPrepare;
 use crate::utils::create_dummy_column;
-use crate::{rewrite, QueryHandler, UpstreamDatabase, UpstreamDestination};
+use crate::{create_dummy_schema, rewrite, QueryHandler, UpstreamDatabase, UpstreamDestination};
 
 pub mod noria_connector;
 
@@ -1731,19 +1731,7 @@ where
             queries.retain(|q| q.status.migration_state.is_supported());
         }
 
-        let select_schema = SelectSchema {
-            schema: Cow::Owned(vec![
-                create_dummy_column("query id"),
-                create_dummy_column("proxied query"),
-                create_dummy_column("readyset supported"),
-            ]),
-
-            columns: Cow::Owned(vec![
-                "query id".into(),
-                "proxied query".into(),
-                "readyset supported".into(),
-            ]),
-        };
+        let select_schema = create_dummy_schema!("query id", "proxied query", "readyset supported");
 
         let mut data = queries
             .into_iter()
@@ -1816,21 +1804,8 @@ where
             ]);
         }
 
-        let select_schema = SelectSchema {
-            schema: Cow::Owned(vec![
-                create_dummy_column("query id"),
-                create_dummy_column("cache name"),
-                create_dummy_column("query text"),
-                create_dummy_column("fallback behavior"),
-            ]),
-
-            columns: Cow::Owned(vec![
-                "query id".into(),
-                "cache name".into(),
-                "query text".into(),
-                "fallback behavior".into(),
-            ]),
-        };
+        let select_schema =
+            create_dummy_schema!("query id", "cache name", "query text", "fallback behavior");
 
         Ok(noria_connector::QueryResult::from_owned(
             select_schema,
@@ -2552,10 +2527,7 @@ where
             .map(|s| vec![DfValue::from(s)])
             .collect();
 
-        let select_schema = SelectSchema {
-            schema: Cow::Owned(vec![create_dummy_column("query text")]),
-            columns: Cow::Owned(vec!["query text".into()]),
-        };
+        let select_schema = create_dummy_schema!("query text");
 
         Ok(noria_connector::QueryResult::from_owned(
             select_schema,

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -607,6 +607,25 @@ pub(crate) fn create_dummy_column(name: &str) -> ColumnSchema {
     }
 }
 
+#[macro_export]
+macro_rules! create_dummy_schema {
+    ($($n:expr),+) => {
+        SelectSchema {
+            schema: Cow::Owned(vec![
+                $(
+                    create_dummy_column($n),
+                )*
+            ]),
+
+            columns: Cow::Owned(vec![
+                $(
+                    $n.into(),
+                )*
+            ]),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use nom_sql::{self, parse_create_table, Dialect, SqlQuery};

--- a/readyset-client-metrics/Cargo.toml
+++ b/readyset-client-metrics/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["ReadySet Technology, Inc. <info@readyset.io>"]
 edition = "2021"
 
 [dependencies]
-metrics = "0.21"
+metrics = { workspace = true }
 serde = "1.0.130"
 serde_json = "1.0.67"
 

--- a/readyset-client/Cargo.toml
+++ b/readyset-client/Cargo.toml
@@ -55,8 +55,8 @@ smallvec = "1.8"
 rocksdb.workspace = true
 
 tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-eui48-1", "with-uuid-0_8", "with-serde_json-1", "with-bit-vec-0_6"] }
-metrics = "0.21"
-metrics-util = "0.15"
+metrics = { workspace = true }
+metrics-util = { workspace = true }
 itertools = "0.10"
 bytes = "1.0.1"
 rust_decimal = { version = "1.26", features = ["db-tokio-postgres", "serde-str"] }

--- a/readyset-dataflow/Cargo.toml
+++ b/readyset-dataflow/Cargo.toml
@@ -16,7 +16,7 @@ ahash = "0.7"
 futures-util = "0.3.13"
 lazy_static = "1.0.0"
 itertools = "0.10"
-metrics = "0.21"
+metrics = { workspace = true }
 nom-sql = { path = "../nom-sql" }
 indexmap = "1.9.2"
 rand = "0.7"

--- a/readyset-server/Cargo.toml
+++ b/readyset-server/Cargo.toml
@@ -36,9 +36,9 @@ pin-project = "1.0"
 hyper = { version = "0.14.10", features = [ "stream", "server" ] }
 querystring = "1.1.0"
 itertools = "0.10"
-metrics = "0.21"
-metrics-util = "0.15"
-metrics-exporter-prometheus = "0.12.1"
+metrics = { workspace = true }
+metrics-util = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 nom = "7.1"
 petgraph = { version = "0.5", features = ["serde-1"] }
 rand = "0.7.0"

--- a/readyset-server/src/metrics/composite_recorder.rs
+++ b/readyset-server/src/metrics/composite_recorder.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::option_map_unit_fn)]
 use std::sync::Arc;
 
-use metrics::{Counter, Gauge, Histogram, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, KeyName, Metadata, Recorder, SharedString, Unit};
 use metrics_exporter_prometheus::PrometheusRecorder;
 use readyset_client::metrics::Key;
 
@@ -110,40 +110,40 @@ impl Clear for CompositeMetricsRecorder {
 }
 
 impl Recorder for CompositeMetricsRecorder {
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, metadata: &Metadata<'_>) -> Counter {
         match (&self.prom_recorder, &self.noria_recorder) {
-            (Some(p), None) => p.register_counter(key),
-            (None, Some(n)) => n.register_counter(key),
+            (Some(p), None) => p.register_counter(key, metadata),
+            (None, Some(n)) => n.register_counter(key, metadata),
             (None, None) => Counter::noop(),
             (Some(p), Some(n)) => Arc::new(CompositeCounter {
-                noria: n.register_counter(key),
-                prom: p.register_counter(key),
+                noria: n.register_counter(key, metadata),
+                prom: p.register_counter(key, metadata),
             })
             .into(),
         }
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, metadata: &Metadata<'_>) -> Gauge {
         match (&self.prom_recorder, &self.noria_recorder) {
-            (Some(p), None) => p.register_gauge(key),
-            (None, Some(n)) => n.register_gauge(key),
+            (Some(p), None) => p.register_gauge(key, metadata),
+            (None, Some(n)) => n.register_gauge(key, metadata),
             (None, None) => Gauge::noop(),
             (Some(p), Some(n)) => Arc::new(CompositeGauge {
-                noria: n.register_gauge(key),
-                prom: p.register_gauge(key),
+                noria: n.register_gauge(key, metadata),
+                prom: p.register_gauge(key, metadata),
             })
             .into(),
         }
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, metadata: &Metadata<'_>) -> Histogram {
         match (&self.prom_recorder, &self.noria_recorder) {
-            (Some(p), None) => p.register_histogram(key),
-            (None, Some(n)) => n.register_histogram(key),
+            (Some(p), None) => p.register_histogram(key, metadata),
+            (None, Some(n)) => n.register_histogram(key, metadata),
             (None, None) => Histogram::noop(),
             (Some(p), Some(n)) => Arc::new(CompositeHistogram {
-                noria: n.register_histogram(key),
-                prom: p.register_histogram(key),
+                noria: n.register_histogram(key, metadata),
+                prom: p.register_histogram(key, metadata),
             })
             .into(),
         }

--- a/readyset-server/src/metrics/noria_recorder.rs
+++ b/readyset-server/src/metrics/noria_recorder.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
 
-use metrics::{Counter, Gauge, Histogram, KeyName, Recorder, SharedString, Unit};
+use metrics::{Counter, Gauge, Histogram, KeyName, Metadata, Recorder, SharedString, Unit};
 use parking_lot::Mutex;
 use readyset_client::metrics::{Key, MetricsDump};
 
@@ -47,7 +47,7 @@ impl metrics::HistogramFn for NoriaHistogram {
 }
 
 impl Recorder for NoriaMetricsRecorder {
-    fn register_counter(&self, key: &Key) -> Counter {
+    fn register_counter(&self, key: &Key, _metadata: &Metadata<'_>) -> Counter {
         let mut counters = self.counters.lock();
         counters
             .raw_entry_mut()
@@ -58,7 +58,7 @@ impl Recorder for NoriaMetricsRecorder {
             .into()
     }
 
-    fn register_gauge(&self, key: &Key) -> Gauge {
+    fn register_gauge(&self, key: &Key, _metadata: &Metadata<'_>) -> Gauge {
         let mut gauges = self.gauges.lock();
         gauges
             .raw_entry_mut()
@@ -69,7 +69,7 @@ impl Recorder for NoriaMetricsRecorder {
             .into()
     }
 
-    fn register_histogram(&self, key: &Key) -> Histogram {
+    fn register_histogram(&self, key: &Key, _metadata: &Metadata<'_>) -> Histogram {
         let mut histograms = self.histograms.lock();
         histograms
             .raw_entry_mut()

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -13,9 +13,8 @@ clap = { workspace = true, features = ["derive","env"] }
 futures-util = "0.3.0"
 fail = "0.5.0"
 failpoint-macros = { path = "../failpoint-macros" }
-metrics = "0.21"
-metrics-exporter-prometheus = "0.12.1"
-rlimit = "0.10.1"
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-native-tls = "0.3.1"
 tokio-stream = { version = "0.1.5", features = ["net"] }

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -266,7 +266,7 @@ pub struct Options {
         long,
         env = "QUERY_LOG",
         requires = "metrics",
-        default_value_if("promethues-metrics", "true", Some("true"))
+        default_value_if("prometheus_metrics", "true", Some("true"))
     )]
     query_log: bool,
 

--- a/replicators/Cargo.toml
+++ b/replicators/Cargo.toml
@@ -16,7 +16,7 @@ fail = "0.5.0"
 bytes = "1.0"
 chrono = "0.4"
 itertools = "0.10"
-metrics = "0.21"
+metrics = { workspace = true }
 tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tracing-futures = "0.2.5"
 serde_json = { version = "1", features = ["arbitrary_precision"] }


### PR DESCRIPTION
Switches our metries dependencies to a readysettech/metrics fork instead
of relying on the upstream crate. This is done temporarily to make use
of a patch to provide an expanded interface to PrometheusHandle.

