### PR TITLE
readyset-adapter: Add count to show metrics

### DIFF
--- a/readyset-clustertest/src/readyset_mysql.rs
+++ b/readyset-clustertest/src/readyset_mysql.rs
@@ -1813,7 +1813,7 @@ async fn show_query_metrics() {
     }
 
     // Check `SHOW PROXIED QUERIES`
-    let proxied_result: Vec<(String, String, String, String, String, String)> = adapter
+    let proxied_result: Vec<(String, String, String, String, String, String, String)> = adapter
         .as_mysql_conn()
         .unwrap()
         .query(r"SHOW PROXIED QUERIES")
@@ -1821,12 +1821,23 @@ async fn show_query_metrics() {
         .unwrap();
 
     // Assert that we get a non-zero value for the metrics
-    assert!(&proxied_result[0].3 != "0.0");
+    assert!(&proxied_result[0].3 != "0");
     assert!(&proxied_result[0].4 != "0.0");
     assert!(&proxied_result[0].5 != "0.0");
+    assert!(&proxied_result[0].6 != "0.0");
 
     // Check `SHOW CACHES`
-    let caches_result: Vec<(String, String, String, String, String, String, String)> = adapter
+    #[allow(clippy::type_complexity)]
+    let caches_result: Vec<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )> = adapter
         .as_mysql_conn()
         .unwrap()
         .query(r"SHOW CACHES")
@@ -1834,6 +1845,7 @@ async fn show_query_metrics() {
         .unwrap();
 
     // Assert that we get a non-zero value for the metrics
+    assert!(&caches_result[0].3 != "0");
     assert!(&caches_result[0].4 != "0.0");
     assert!(&caches_result[0].5 != "0.0");
     assert!(&caches_result[0].6 != "0.0");


### PR DESCRIPTION
This adds a count column to the `show caches` and `show proxied queries`
output that displays the number of samples that are included in the
percentiles that are already reported.

