### PR TITLE
adapter: Use LazyUpstream for both PG and MySQL

### DIFF
--- a/readyset-client-test-helpers/src/mysql_helpers.rs
+++ b/readyset-client-test-helpers/src/mysql_helpers.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use mysql_async::prelude::Queryable;
 use mysql_srv::MySqlIntermediary;
 use readyset_adapter::backend::QueryInfo;
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_mysql::{Backend, MySqlQueryHandler, MySqlUpstream};
 use tokio::net::TcpStream;
 
@@ -63,7 +64,7 @@ impl MySQLAdapter {
 #[async_trait]
 impl Adapter for MySQLAdapter {
     type ConnectionOpts = mysql_async::Opts;
-    type Upstream = MySqlUpstream;
+    type Upstream = LazyUpstream<MySqlUpstream>;
     type Handler = MySqlQueryHandler;
 
     const DIALECT: nom_sql::Dialect = nom_sql::Dialect::MySQL;

--- a/readyset-client-test-helpers/src/psql_helpers.rs
+++ b/readyset-client-test-helpers/src/psql_helpers.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use async_trait::async_trait;
 use readyset_adapter::backend::{QueryDestination, QueryInfo};
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_adapter::Backend;
 use readyset_psql::{PostgreSqlQueryHandler, PostgreSqlUpstream};
 use tokio::net::TcpStream;
@@ -33,7 +34,7 @@ pub struct PostgreSQLAdapter;
 #[async_trait]
 impl Adapter for PostgreSQLAdapter {
     type ConnectionOpts = tokio_postgres::Config;
-    type Upstream = PostgreSqlUpstream;
+    type Upstream = LazyUpstream<PostgreSqlUpstream>;
     type Handler = PostgreSqlQueryHandler;
 
     const DIALECT: nom_sql::Dialect = nom_sql::Dialect::PostgreSQL;

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -18,6 +18,7 @@ use nom_sql::{Dialect, Relation};
 use readyset_adapter::backend::noria_connector::ReadBehavior;
 use readyset_adapter::backend::{BackendBuilder, NoriaConnector};
 use readyset_adapter::query_status_cache::QueryStatusCache;
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_adapter::{UpstreamConfig, UpstreamDatabase};
 use readyset_client::consensus::{Authority, LocalAuthorityStore};
 use readyset_client::{ReadySetHandle, ViewCreateRequest};
@@ -576,9 +577,11 @@ impl TestScript {
                     #[allow(clippy::manual_map)]
                     let upstream = match &replication_url {
                         Some(url) => Some(
-                            <$upstream as UpstreamDatabase>::connect(UpstreamConfig::from_url(url))
-                                .await
-                                .unwrap(),
+                            <LazyUpstream<$upstream> as UpstreamDatabase>::connect(
+                                UpstreamConfig::from_url(url),
+                            )
+                            .await
+                            .unwrap(),
                         ),
                         None => None,
                     };

--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -20,6 +20,7 @@ use readyset_adapter::backend::noria_connector::{
 use readyset_adapter::backend::{
     noria_connector, QueryResult, SinglePrepareResult, UpstreamPrepare,
 };
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_data::{DfType, DfValue, DfValueKind};
 use readyset_errors::{internal, ReadySetError};
 use readyset_util::redacted::Sensitive;
@@ -277,14 +278,14 @@ async fn write_meta_with_header<W: AsyncWrite + Unpin>(
 
 pub struct Backend {
     /// Handle to the backing noria client
-    pub noria: readyset_adapter::Backend<MySqlUpstream, MySqlQueryHandler>,
+    pub noria: readyset_adapter::Backend<LazyUpstream<MySqlUpstream>, MySqlQueryHandler>,
     /// Enables logging of statements received from the client. The `Backend` only logs Query,
     /// Prepare and Execute statements.
     pub enable_statement_logging: bool,
 }
 
 impl Deref for Backend {
-    type Target = readyset_adapter::Backend<MySqlUpstream, MySqlQueryHandler>;
+    type Target = readyset_adapter::Backend<LazyUpstream<MySqlUpstream>, MySqlQueryHandler>;
 
     fn deref(&self) -> &Self::Target {
         &self.noria
@@ -478,7 +479,7 @@ where
 }
 
 async fn handle_query_result<'a, W>(
-    result: Result<QueryResult<'a, MySqlUpstream>, Error>,
+    result: Result<QueryResult<'a, LazyUpstream<MySqlUpstream>>, Error>,
     writer: QueryResultWriter<'_, W>,
 ) -> io::Result<()>
 where

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -10,6 +10,7 @@ use postgres_types::Type;
 use ps::{PsqlValue, TransferFormat};
 use psql_srv as ps;
 use readyset_adapter::backend as cl;
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_data::DfValue;
 use thiserror::Error;
 
@@ -49,12 +50,14 @@ impl FromStr for AuthenticationMethod {
 /// wrapped `noria_client` `Backend`. All request parameters and response results are forwarded
 /// using type conversion.
 pub struct Backend {
-    inner: cl::Backend<PostgreSqlUpstream, PostgreSqlQueryHandler>,
+    inner: cl::Backend<LazyUpstream<PostgreSqlUpstream>, PostgreSqlQueryHandler>,
     authentication_method: AuthenticationMethod,
 }
 
 impl Backend {
-    pub fn new(inner: cl::Backend<PostgreSqlUpstream, PostgreSqlQueryHandler>) -> Self {
+    pub fn new(
+        inner: cl::Backend<LazyUpstream<PostgreSqlUpstream>, PostgreSqlQueryHandler>,
+    ) -> Self {
         Self {
             inner,
             authentication_method: Default::default(),
@@ -70,7 +73,7 @@ impl Backend {
 }
 
 impl Deref for Backend {
-    type Target = cl::Backend<PostgreSqlUpstream, PostgreSqlQueryHandler>;
+    type Target = cl::Backend<LazyUpstream<PostgreSqlUpstream>, PostgreSqlQueryHandler>;
 
     fn deref(&self) -> &Self::Target {
         &self.inner

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -6,6 +6,7 @@ use psql_srv as ps;
 use readyset_adapter::backend::{
     self as cl, noria_connector, SinglePrepareResult, UpstreamPrepare,
 };
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_client::results::{ResultIterator, Results};
 use readyset_client::ColumnSchema;
 use readyset_data::DfType;
@@ -17,7 +18,7 @@ use crate::{upstream, PostgreSqlUpstream};
 
 /// A simple wrapper around `noria_client`'s `PrepareResult`, facilitating conversion to
 /// `psql_srv::PrepareResponse`.
-pub struct PrepareResponse<'a>(pub &'a cl::PrepareResult<PostgreSqlUpstream>);
+pub struct PrepareResponse<'a>(pub &'a cl::PrepareResult<LazyUpstream<PostgreSqlUpstream>>);
 
 impl<'a> PrepareResponse<'a> {
     pub fn try_into_ps(self, prepared_statement_id: u32) -> Result<ps::PrepareResponse, ps::Error> {
@@ -63,7 +64,7 @@ impl<'a> PrepareResponse<'a> {
 
 /// A simple wrapper around `noria_client`'s `QueryResult`, facilitating conversion to
 /// `psql_srv::QueryResponse`.
-pub struct QueryResponse<'a>(pub cl::QueryResult<'a, PostgreSqlUpstream>);
+pub struct QueryResponse<'a>(pub cl::QueryResult<'a, LazyUpstream<PostgreSqlUpstream>>);
 
 impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
     type Error = ps::Error;

--- a/readyset/src/mysql.rs
+++ b/readyset/src/mysql.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use mysql_srv::MySqlIntermediary;
+use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_mysql::{MySqlQueryHandler, MySqlUpstream};
 use tokio::net::TcpStream;
 use tracing::{error, instrument};
@@ -14,14 +15,14 @@ pub struct MySqlHandler {
 
 #[async_trait]
 impl ConnectionHandler for MySqlHandler {
-    type UpstreamDatabase = MySqlUpstream;
+    type UpstreamDatabase = LazyUpstream<MySqlUpstream>;
     type Handler = MySqlQueryHandler;
 
     #[instrument(level = "debug", "connection", skip_all, fields(addr = ?stream.peer_addr().unwrap()))]
     async fn process_connection(
         &mut self,
         stream: TcpStream,
-        backend: readyset_adapter::Backend<MySqlUpstream, MySqlQueryHandler>,
+        backend: readyset_adapter::Backend<LazyUpstream<MySqlUpstream>, MySqlQueryHandler>,
     ) {
         if let Err(e) = MySqlIntermediary::run_on_tcp(
             readyset_mysql::Backend {


### PR DESCRIPTION
Wrap the upstream DB for both the PostgreSQL and MySQL adapters in
LazyUpstream, so that they wait to establish a connection with the
upstream DB until they know they're going to need to proxy a query
upstream. This is generally a decent seeming idea, but is going to
become especially important in hosted environments that query things
like `SHOW PROXIED QUERIES` or `SHOW CACHES` frequently, to avoid that
placing additional load on the upstream database.

Fixes: REA-3432
Fixes: #496
