### PR TITLE
dataflow-state: Rename add_key to add_index

### DIFF
--- a/dataflow-state/benches/persistent_state.rs
+++ b/dataflow-state/benches/persistent_state.rs
@@ -275,11 +275,11 @@ impl PersistentStateBenchArgs {
         // true, we assume that the state already contains the proper data from a previous run of
         // the benchmarks.
         if !self.reuse_persistence {
-            state.add_key(Index::new(IndexType::HashMap, vec![0]), None);
-            state.add_key(Index::new(IndexType::HashMap, vec![1, 2]), None);
-            state.add_key(Index::new(IndexType::HashMap, vec![3]), None);
+            state.add_index(Index::new(IndexType::HashMap, vec![0]), None);
+            state.add_index(Index::new(IndexType::HashMap, vec![1, 2]), None);
+            state.add_index(Index::new(IndexType::HashMap, vec![3]), None);
 
-            state.add_key(Index::new(IndexType::BTreeMap, vec![1]), None);
+            state.add_index(Index::new(IndexType::BTreeMap, vec![1]), None);
 
             state.set_snapshot_mode(SnapshotMode::SnapshotModeEnabled);
 
@@ -330,11 +330,11 @@ impl PersistentStateBenchArgs {
         if !self.reuse_persistence {
             state.set_snapshot_mode(SnapshotMode::SnapshotModeEnabled);
 
-            state.add_key(Index::new(IndexType::HashMap, vec![0]), None);
-            state.add_key(Index::new(IndexType::HashMap, vec![1]), None);
-            state.add_key(Index::new(IndexType::HashMap, vec![3]), None);
+            state.add_index(Index::new(IndexType::HashMap, vec![0]), None);
+            state.add_index(Index::new(IndexType::HashMap, vec![1]), None);
+            state.add_index(Index::new(IndexType::HashMap, vec![3]), None);
 
-            state.add_key(Index::new(IndexType::BTreeMap, vec![1]), None);
+            state.add_index(Index::new(IndexType::BTreeMap, vec![1]), None);
 
             let batches = (0..self.unique_entries)
                 .map(|i| {

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -720,7 +720,7 @@ async fn initialize_state(
         .unwrap()?,
     );
     for idx in indices {
-        s.add_key(idx, None);
+        s.add_index(idx, None);
     }
     if reported_once.load(Ordering::Relaxed) {
         info!(%base_name, %node_idx, "Finished initializing state");
@@ -1590,11 +1590,11 @@ impl Domain {
                                 local = %node,
                                 "told to prepare partial state"
                             );
-                            state.add_key(index, Some(tags));
+                            state.add_index(index, Some(tags));
                         }
 
                         for index in weak_indices {
-                            state.add_weak_key(index);
+                            state.add_weak_index(index);
                         }
                     }
                     PrepareStateKind::Full {
@@ -1614,11 +1614,11 @@ impl Domain {
                                 %node,
                                 "told to prepare full state"
                             );
-                            state.add_key(index, None);
+                            state.add_index(index, None);
                         }
 
                         for index in weak_indices {
-                            state.add_weak_key(index);
+                            state.add_weak_index(index);
                         }
                     }
                     PrepareStateKind::PartialReader {
@@ -2158,7 +2158,7 @@ impl Domain {
                         _ => {
                             let mut s = MaterializedNodeState::Memory(MemoryState::default());
                             for idx in index {
-                                s.add_key(idx, None);
+                                s.add_index(idx, None);
                             }
                             assert!(self.state.insert(node_idx, s).is_none());
                             true
@@ -2326,7 +2326,7 @@ impl Domain {
                 self.state
                     .entry(node)
                     .or_insert_with(|| MaterializedNodeState::Memory(MemoryState::default()))
-                    .add_key(index, Some(vec![tag]));
+                    .add_index(index, Some(vec![tag]));
                 Ok(None)
             }
             DomainRequest::IsReady { node } => {

--- a/readyset-dataflow/src/node/special/base.rs
+++ b/readyset-dataflow/src/node/special/base.rs
@@ -745,8 +745,8 @@ mod tests {
 
             for (_, lookup_index) in graph[global].suggest_indexes(global) {
                 match lookup_index {
-                    LookupIndex::Strict(index) => state.add_key(index, None),
-                    LookupIndex::Weak(index) => state.add_weak_key(index),
+                    LookupIndex::Strict(index) => state.add_index(index, None),
+                    LookupIndex::Weak(index) => state.add_weak_index(index),
                 }
             }
 
@@ -915,7 +915,7 @@ mod tests {
                 .unwrap(),
             );
 
-            state.add_key(Index::hash_map(vec![0]), None);
+            state.add_index(Index::hash_map(vec![0]), None);
 
             let mut recs = vec![Record::Positive(vec![2.into(), 3.into(), 4.into()])].into();
             state.process_records(&mut recs, None, None).unwrap();
@@ -969,7 +969,7 @@ mod tests {
                 .unwrap(),
             );
 
-            state.add_key(Index::hash_map(vec![0]), None);
+            state.add_index(Index::hash_map(vec![0]), None);
 
             let mut recs = vec![Record::Positive(vec![2.into(), 3.into(), 4.into()])].into();
             state.process_records(&mut recs, None, None).unwrap();
@@ -1029,7 +1029,7 @@ mod tests {
                 .unwrap(),
             );
 
-            state.add_key(Index::hash_map(vec![0]), None);
+            state.add_index(Index::hash_map(vec![0]), None);
 
             let mut recs = vec![
                 Record::Positive(vec![1.into(), "a".into()]),
@@ -1086,7 +1086,7 @@ mod tests {
                 .unwrap(),
             );
 
-            state.add_key(Index::hash_map(vec![0]), None);
+            state.add_index(Index::hash_map(vec![0]), None);
             let mut recs = vec![
                 Record::Positive(vec![1.into(), "a".into()]),
                 Record::Positive(vec![1.into(), "b".into()]),

--- a/readyset-dataflow/src/ops/mod.rs
+++ b/readyset-dataflow/src/ops/mod.rs
@@ -345,9 +345,9 @@ pub mod test {
             for (tbl, lookup_index) in idx {
                 if let Some(ref mut s) = self.states.get_mut(self.graph[tbl].local_addr()) {
                     if lookup_index.is_weak() {
-                        s.add_weak_key(lookup_index.index().clone())
+                        s.add_weak_index(lookup_index.index().clone())
                     }
-                    s.add_key(lookup_index.into_index(), None);
+                    s.add_index(lookup_index.into_index(), None);
                 }
             }
             // and get rid of states we don't need
@@ -426,8 +426,8 @@ pub mod test {
             for (tbl, lookup_index) in idx {
                 if tbl == base.as_global() {
                     match lookup_index {
-                        LookupIndex::Strict(index) => state.add_key(index, None),
-                        LookupIndex::Weak(index) => state.add_weak_key(index),
+                        LookupIndex::Strict(index) => state.add_index(index, None),
+                        LookupIndex::Weak(index) => state.add_weak_index(index),
                     }
                 }
             }

--- a/readyset-dataflow/src/ops/project.rs
+++ b/readyset-dataflow/src/ops/project.rs
@@ -414,8 +414,8 @@ mod tests {
 
         let mut states = StateMap::default();
         let row: Record = vec![1.into(), 2.into(), 3.into()].into();
-        state.add_key(Index::hash_map(vec![0]), None);
-        state.add_key(Index::hash_map(vec![1]), None);
+        state.add_index(Index::hash_map(vec![0]), None);
+        state.add_index(Index::hash_map(vec![1]), None);
         state.process_records(&mut row.into(), None, None).unwrap();
         states.insert(local, state);
 


### PR DESCRIPTION
We're generally moving in the direction of more consistently using the
word "key" to refer to a *value* in the key of an index (eg some
non-strict subset of the values in a row) and the word "index" to refer
to the data structure that allows efficient lookups using those keys
into a state. This renames `State::add_key` to `add_index` to go along
with that naming convention

