### PR TITLE
build: Move cargo-deny image creation to fix dependency graph

### DIFF
--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -23,18 +23,6 @@ steps:
           login: true
           retries: 3
 
-  - label: ':docker: Build cargo-deny image'
-    key: cargo-deny-image
-    commands:
-      - '[ -d public ] && cd public'
-      - '.buildkite/build-image.sh build/Dockerfile.cargo-deny cargo-deny .'
-    env:
-      VERSION: "${BUILDKITE_COMMIT}"
-    plugins:
-      ecr#v2.5.0:
-        login: true
-        retries: 3
-
   - label: ':rust: :lock: Check cargo-deny'
     commands:
       - '[ -d public ] && cd public'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,17 @@ steps:
         login: true
         retries: 3
 
+  - label: ':docker: Build cargo-deny image'
+    key: cargo-deny-image
+    commands:
+      - '.buildkite/build-image.sh build/Dockerfile.cargo-deny cargo-deny .'
+    env:
+      VERSION: "${BUILDKITE_COMMIT}"
+    plugins:
+      ecr#v2.5.0:
+        login: true
+        retries: 3
+
   - label: ':pipeline: Upload public-common pipeline'
     commands:
       - buildkite-agent pipeline upload .buildkite/pipeline.public-common.yml


### PR DESCRIPTION
The cargo-deny image was being created if `public` was changed, but not
if `crates` was changed without `public`.  However, the `crates`
pipeline requires the cargo-deny image.  This update adds the cargo-deny
image build to the monorepo pipeline so that it will be in scope for the
`crates` pipeline even if `public` wasn't changed.

