### PR TITLE
nom-sql: Add support for DROP SNAPSHOT FROM table

### DIFF
--- a/nom-sql/src/analysis/visit.rs
+++ b/nom-sql/src/analysis/visit.rs
@@ -19,12 +19,13 @@ use crate::{
     AlterColumnOperation, AlterTableDefinition, AlterTableStatement, CacheInner, CaseWhenBranch,
     Column, ColumnConstraint, ColumnSpecification, CommentStatement, CommonTableExpr,
     CompoundSelectStatement, CreateCacheStatement, CreateTableStatement, CreateViewStatement,
-    DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropTableStatement,
-    DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr,
-    GroupByClause, InValue, InsertStatement, JoinClause, JoinConstraint, JoinRightSide, Literal,
-    OrderClause, Relation, SelectSpecification, SelectStatement, SetNames, SetPostgresParameter,
-    SetStatement, SetVariables, ShowStatement, SqlIdentifier, SqlQuery, SqlType, TableExpr,
-    TableExprInner, TableKey, UpdateStatement, UseStatement,
+    DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropSnapshotStatement,
+    DropTableStatement, DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr,
+    FieldReference, FunctionExpr, GroupByClause, InValue, InsertStatement, JoinClause,
+    JoinConstraint, JoinRightSide, Literal, OrderClause, Relation, SelectSpecification,
+    SelectStatement, SetNames, SetPostgresParameter, SetStatement, SetVariables, ShowStatement,
+    SqlIdentifier, SqlQuery, SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement,
+    UseStatement,
 };
 
 /// Each method of the `Visitor` trait is a hook to be potentially overridden when recursively
@@ -368,6 +369,12 @@ pub trait Visitor<'ast>: Sized {
         Ok(())
     }
 
+    fn visit_drop_snapshot_statement(
+        &mut self,
+        drop_snapshot_statement: &'ast DropSnapshotStatement,
+    ) -> Result<(), Self::Error> {
+        walk_relation(self, &drop_snapshot_statement.name)
+    }
     fn visit_drop_view_statement(
         &mut self,
         drop_view_statement: &'ast DropViewStatement,
@@ -1120,6 +1127,7 @@ pub fn walk_sql_query<'a, V: Visitor<'a>>(
         SqlQuery::CreateCache(statement) => visitor.visit_create_cache_statement(statement),
         SqlQuery::DropCache(statement) => visitor.visit_drop_cache_statement(statement),
         SqlQuery::DropAllCaches(statement) => visitor.visit_drop_all_caches_statement(statement),
+        SqlQuery::DropSnapshot(statement) => visitor.visit_drop_snapshot_statement(statement),
         SqlQuery::DropView(statement) => visitor.visit_drop_view_statement(statement),
         SqlQuery::Use(statement) => visitor.visit_use_statement(statement),
         SqlQuery::Show(statement) => visitor.visit_show_statement(statement),

--- a/nom-sql/src/analysis/visit_mut.rs
+++ b/nom-sql/src/analysis/visit_mut.rs
@@ -19,12 +19,13 @@ use crate::{
     AlterColumnOperation, AlterTableDefinition, AlterTableStatement, CacheInner, CaseWhenBranch,
     Column, ColumnConstraint, ColumnSpecification, CommentStatement, CommonTableExpr,
     CompoundSelectStatement, CreateCacheStatement, CreateTableStatement, CreateViewStatement,
-    DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropTableStatement,
-    DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr,
-    GroupByClause, InValue, InsertStatement, JoinClause, JoinConstraint, JoinRightSide, Literal,
-    OrderClause, Relation, SelectSpecification, SelectStatement, SetNames, SetPostgresParameter,
-    SetStatement, SetVariables, ShowStatement, SqlIdentifier, SqlQuery, SqlType, TableExpr,
-    TableExprInner, TableKey, UpdateStatement, UseStatement,
+    DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropSnapshotStatement,
+    DropTableStatement, DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr,
+    FieldReference, FunctionExpr, GroupByClause, InValue, InsertStatement, JoinClause,
+    JoinConstraint, JoinRightSide, Literal, OrderClause, Relation, SelectSpecification,
+    SelectStatement, SetNames, SetPostgresParameter, SetStatement, SetVariables, ShowStatement,
+    SqlIdentifier, SqlQuery, SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement,
+    UseStatement,
 };
 
 /// Each method of the `VisitorMut` trait is a hook to be potentially overridden when recursively
@@ -381,6 +382,13 @@ pub trait VisitorMut<'ast>: Sized {
         _drop_all_caches_statement: &'ast mut DropAllCachesStatement,
     ) -> Result<(), Self::Error> {
         Ok(())
+    }
+
+    fn visit_drop_snapshot_statement(
+        &mut self,
+        drop_snapshot_statement: &'ast mut DropSnapshotStatement,
+    ) -> Result<(), Self::Error> {
+        walk_relation(self, &mut drop_snapshot_statement.name)
     }
 
     fn visit_drop_view_statement(
@@ -1137,6 +1145,7 @@ pub fn walk_sql_query<'a, V: VisitorMut<'a>>(
         SqlQuery::CreateCache(statement) => visitor.visit_create_cache_statement(statement),
         SqlQuery::DropCache(statement) => visitor.visit_drop_cache_statement(statement),
         SqlQuery::DropAllCaches(statement) => visitor.visit_drop_all_caches_statement(statement),
+        SqlQuery::DropSnapshot(statement) => visitor.visit_drop_snapshot_statement(statement),
         SqlQuery::DropView(statement) => visitor.visit_drop_view_statement(statement),
         SqlQuery::Use(statement) => visitor.visit_use_statement(statement),
         SqlQuery::Show(statement) => visitor.visit_show_statement(statement),

--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -27,7 +27,8 @@ pub use self::create_table_options::CreateTableOption;
 pub use self::delete::DeleteStatement;
 pub use self::dialect::Dialect;
 pub use self::drop::{
-    DropAllCachesStatement, DropCacheStatement, DropTableStatement, DropViewStatement,
+    DropAllCachesStatement, DropCacheStatement, DropSnapshotStatement, DropTableStatement,
+    DropViewStatement,
 };
 pub use self::explain::ExplainStatement;
 pub use self::expression::{

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -240,6 +240,10 @@ impl ChangeList {
                                 name: dcs.name,
                                 if_exists: false,
                             }),
+                            SqlQuery::DropSnapshot(dss) => changes.push(Change::Drop {
+                                name: dss.name,
+                                if_exists: false,
+                            }),
                             _ => unsupported!(
                                 "Only DDL statements supported in ChangeList (got {})",
                                 parsed.query_type()

--- a/readyset-logictest/src/from_query_log.rs
+++ b/readyset-logictest/src/from_query_log.rs
@@ -110,7 +110,8 @@ fn is_ddl(query: &SqlQuery) -> bool {
         | SqlQuery::Use(_)
         | SqlQuery::CreateCache(_)
         | SqlQuery::DropCache(_)
-        | SqlQuery::DropAllCaches(_) => true,
+        | SqlQuery::DropAllCaches(_)
+        | SqlQuery::DropSnapshot(_) => true,
     }
 }
 


### PR DESCRIPTION
Add support for DROP SNAPSHOT query.
The underlining adaptor code is not yet implemented.

Relates #456 