### PR TITLE
nom-sql: Parse PG INTERVAL type

### DIFF
--- a/data-generator/src/lib.rs
+++ b/data-generator/src/lib.rs
@@ -465,6 +465,7 @@ pub fn value_of_type(typ: &SqlType) -> DfValue {
             DfValue::from(BitVec::with_capacity(size_opt.unwrap_or(1) as usize))
         }
         SqlType::VarBit(_) => DfValue::from(BitVec::new()),
+        SqlType::Interval { .. } => unimplemented!(),
         SqlType::Array(_) => unimplemented!(),
         SqlType::Other(_) => unimplemented!(),
     }
@@ -596,6 +597,7 @@ where
         }
         SqlType::Serial => ((rng.gen::<u32>() + 1) as i32).into(),
         SqlType::BigSerial => ((rng.gen::<u64>() + 1) as i64).into(),
+        SqlType::Interval { .. } => unimplemented!(),
         SqlType::Array(_) => unimplemented!(),
         SqlType::Other(_) => unimplemented!(),
     }
@@ -720,6 +722,7 @@ pub fn unique_value_of_type(typ: &SqlType, idx: u32) -> DfValue {
         }
         SqlType::Serial => ((idx + 1) as i32).into(),
         SqlType::BigSerial => ((idx + 1) as i64).into(),
+        SqlType::Interval { .. } => unimplemented!(),
         SqlType::Array(_) => unimplemented!(),
         SqlType::Other(_) => unimplemented!(),
     }

--- a/nom-sql/src/literal.rs
+++ b/nom-sql/src/literal.rs
@@ -335,6 +335,7 @@ impl Literal {
             SqlType::Time => arbitrary_naive_time()
                 .prop_map(|nt| Self::String(nt.format("%H:%M:%S").to_string()))
                 .boxed(),
+            SqlType::Interval { .. } => unimplemented!("Intervals aren't implemented yet"),
             SqlType::Enum(_) => unimplemented!("Enums aren't implemented yet"),
             SqlType::Json | SqlType::Jsonb => arbitrary_json()
                 .prop_map(|v| Self::String(v.to_string()))

--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -461,6 +461,7 @@ mod tests {
 
         use super::*;
         use crate::table::Relation;
+        use crate::{FieldDefinitionExpr, TableExpr, TableExprInner};
 
         #[test]
         fn trim_query() {
@@ -726,6 +727,31 @@ mod tests {
                 expected1,
                 res1.unwrap().display(Dialect::PostgreSQL).to_string()
             );
+        }
+
+        #[test]
+        fn cast_to_interval() {
+            assert_eq!(
+                parse_query(Dialect::PostgreSQL, "SELECT '23'::interval as foo from t1").unwrap(),
+                SqlQuery::Select(SelectStatement {
+                    fields: vec![FieldDefinitionExpr::Expr {
+                        expr: Expr::Cast {
+                            expr: Box::new(Expr::Literal("23".into())),
+                            ty: SqlType::Interval {
+                                fields: None,
+                                precision: None
+                            },
+                            postgres_style: true
+                        },
+                        alias: Some("foo".into())
+                    }],
+                    tables: vec![TableExpr {
+                        inner: TableExprInner::Table("t1".into()),
+                        alias: None
+                    }],
+                    ..Default::default()
+                })
+            )
         }
     }
 }

--- a/readyset-data/src/type.rs
+++ b/readyset-data/src/type.rs
@@ -6,7 +6,7 @@ use nom_sql::{EnumVariants, Relation, SqlIdentifier, SqlType};
 use proptest::arbitrary::{any, any_with, Arbitrary};
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Just};
-use readyset_errors::{unsupported_err, ReadySetResult};
+use readyset_errors::{unsupported, unsupported_err, ReadySetResult};
 use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 
@@ -301,7 +301,7 @@ impl DfType {
             TimestampTz => Self::TimestampTz {
                 subsecond_digits: dialect.default_subsecond_digits(),
             },
-
+            Interval { .. } => unsupported!("Unsupported type: INTERVAL"),
             Uuid => Self::Uuid,
             MacAddr => Self::MacAddr,
             Inet => Self::Inet,


### PR DESCRIPTION
Add support for parsing the PostgreSQL INTERVAL type to nom-sql,
including the optional `fields` argument and precision. Everywhere else
this is seen, it panics (if appropriate) or returns an unsupported
error.

Fixes: REA-3474
