### PR TITLE
worker: Dedicated runtime for domains with persistent state

### DIFF
--- a/dataflow-state/src/persistent_state.rs
+++ b/dataflow-state/src/persistent_state.rs
@@ -214,6 +214,13 @@ pub enum DurabilityMode {
     Permanent,
 }
 
+impl DurabilityMode {
+    /// Returns true if `self` persists state to disk
+    pub fn persists_to_disk(&self) -> bool {
+        matches!(self, Self::DeleteOnExit | Self::Permanent)
+    }
+}
+
 #[derive(Debug, Error)]
 #[error("Invalid durability mode; expected one of persistent, ephemeral, or memory")]
 pub struct InvalidDurabilityMode;

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -388,6 +388,12 @@ impl DomainBuilder {
         }
     }
 
+    /// Returns true if the domain built by this [`DomainBuilder`] will have state persisted to disk
+    pub fn has_persistent_state(&self) -> bool {
+        self.persistence_parameters.mode.persists_to_disk()
+            && self.nodes.values().any(|n| n.borrow().is_base())
+    }
+
     /// Starts up the domain represented by this `DomainBuilder`.
     pub fn build(
         self,


### PR DESCRIPTION
Domains which contain persistent state can perform blocking IO to
interact with that persistent state if it's backed by RocksDB, which is
the case if DurabilityMode is set to anything other than Memory. At
least in theory, this happening in a lot of different tasks at the same
time can cause worker pool starvation and system-global latency spikes
due to inefficient use of resources.

In a perfect world, we'd fix this by using `spawn_blocking` to execute
all of RocksDB's blocking IO operations, but actually implementing that
requires threading `async fn` *very* deep into domain code, and
also (I'm assuming) likely dealing with some remarkably annoying
Send/Sync issues. As a bit of a workaround, instead, this commit just
spawns any domains containing persistent state onto their own tokio
runtime, so that ideally domains only containing internal nodes or
reader nodes can continue to work even if all worker threads are
blocking on IO.

In the future, this *might* want to also go along with a change to
always assign base tables to their own domains, but for now the memory
tradeoffs of having stateful ingresses downstream of those domains for
joins are unclear. Down the road if we make ingresses backed by
read-only persistent state handles things might get even better here.

Note that none of the potential issues that this commit tries to fix
have been seen in the wild yet - this is all still just addressing
things in theory.

Refs: REA-2961
