### PR TITLE
nom-sql: Parse integer literals as signed by default

### DIFF
--- a/dataflow-expression/src/lower.rs
+++ b/dataflow-expression/src/lower.rs
@@ -1371,12 +1371,12 @@ pub(crate) mod tests {
                         ty: DfType::Text(Collation::Citext)
                     },
                     Some(Expr::Literal {
-                        val: 1u32.into(),
-                        ty: DfType::UnsignedBigInt
+                        val: 1.into(),
+                        ty: DfType::BigInt
                     }),
                     Some(Expr::Literal {
-                        val: 7u32.into(),
-                        ty: DfType::UnsignedBigInt
+                        val: 7.into(),
+                        ty: DfType::BigInt
                     })
                 )),
                 ty: DfType::Text(Collation::Citext)
@@ -1396,23 +1396,14 @@ pub(crate) mod tests {
                         val: "abcdefghi".into(),
                         ty: DfType::DEFAULT_TEXT
                     },
-                    Some(Expr::Cast {
-                        expr: Box::new(Expr::Literal {
-                            val: 1.into(),
-                            ty: DfType::UnsignedBigInt
-                        }),
-                        ty: DfType::BigInt,
-                        null_on_failure: false
+                    Some(Expr::Literal {
+                        val: 1.into(),
+                        ty: DfType::BigInt
                     }),
-                    Some(Expr::Cast {
-                        expr: Box::new(Expr::Literal {
-                            val: 7.into(),
-                            ty: DfType::UnsignedBigInt
-                        }),
-
-                        ty: DfType::BigInt,
-                        null_on_failure: false
-                    })
+                    Some(Expr::Literal {
+                        val: 7.into(),
+                        ty: DfType::BigInt
+                    }),
                 )),
                 ty: DfType::DEFAULT_TEXT
             }
@@ -1431,23 +1422,14 @@ pub(crate) mod tests {
                         val: "abcdefghi".into(),
                         ty: DfType::DEFAULT_TEXT
                     },
-                    Some(Expr::Cast {
-                        expr: Box::new(Expr::Literal {
-                            val: 1.into(),
-                            ty: DfType::UnsignedBigInt
-                        }),
-                        ty: DfType::BigInt,
-                        null_on_failure: false
+                    Some(Expr::Literal {
+                        val: 1.into(),
+                        ty: DfType::BigInt
                     }),
-                    Some(Expr::Cast {
-                        expr: Box::new(Expr::Literal {
-                            val: 7.into(),
-                            ty: DfType::UnsignedBigInt
-                        }),
-
-                        ty: DfType::BigInt,
-                        null_on_failure: false
-                    })
+                    Some(Expr::Literal {
+                        val: 7.into(),
+                        ty: DfType::BigInt
+                    }),
                 )),
                 ty: DfType::DEFAULT_TEXT
             }
@@ -1653,7 +1635,7 @@ pub(crate) mod tests {
                 elements: vec![
                     Expr::Literal {
                         val: 1u32.into(),
-                        ty: DfType::UnsignedBigInt
+                        ty: DfType::BigInt
                     },
                     Expr::Cast {
                         expr: Box::new(Expr::Literal {
@@ -1665,15 +1647,15 @@ pub(crate) mod tests {
                     },
                     Expr::Literal {
                         val: 3u32.into(),
-                        ty: DfType::UnsignedBigInt
+                        ty: DfType::BigInt
                     },
                     Expr::Literal {
                         val: 4u32.into(),
-                        ty: DfType::UnsignedBigInt
+                        ty: DfType::BigInt
                     }
                 ],
                 shape: vec![2, 2],
-                ty: DfType::Array(Box::new(DfType::Array(Box::new(DfType::UnsignedBigInt))))
+                ty: DfType::Array(Box::new(DfType::Array(Box::new(DfType::BigInt))))
             }
         )
     }
@@ -1688,14 +1670,14 @@ pub(crate) mod tests {
                 op: BinaryOperator::Equal,
                 left: Box::new(Expr::Literal {
                     val: 1u64.into(),
-                    ty: DfType::UnsignedBigInt
+                    ty: DfType::BigInt
                 }),
                 right: Box::new(Expr::Cast {
                     expr: Box::new(Expr::Literal {
                         val: "{1,2}".into(),
                         ty: DfType::Unknown
                     }),
-                    ty: DfType::Array(Box::new(DfType::UnsignedBigInt)),
+                    ty: DfType::Array(Box::new(DfType::BigInt)),
                     null_on_failure: false
                 }),
                 ty: DfType::Bool
@@ -1713,14 +1695,14 @@ pub(crate) mod tests {
                 op: BinaryOperator::Equal,
                 left: Box::new(Expr::Literal {
                     val: 1u64.into(),
-                    ty: DfType::UnsignedBigInt
+                    ty: DfType::BigInt
                 }),
                 right: Box::new(Expr::Cast {
                     expr: Box::new(Expr::Literal {
                         val: "{1,1}".into(),
                         ty: DfType::Unknown
                     }),
-                    ty: DfType::Array(Box::new(DfType::UnsignedBigInt)),
+                    ty: DfType::Array(Box::new(DfType::BigInt)),
                     null_on_failure: false
                 }),
                 ty: DfType::Bool
@@ -1743,10 +1725,10 @@ pub(crate) mod tests {
                     Expr::Array {
                         elements: vec![Expr::Literal {
                             val: 1u64.into(),
-                            ty: DfType::UnsignedBigInt,
+                            ty: DfType::BigInt,
                         }],
                         shape: vec![1],
-                        ty: DfType::Array(Box::new(DfType::UnsignedBigInt))
+                        ty: DfType::Array(Box::new(DfType::BigInt))
                     },
                     Expr::Literal {
                         val: ",".into(),

--- a/nom-sql/src/column.rs
+++ b/nom-sql/src/column.rs
@@ -396,7 +396,7 @@ mod tests {
                     ColumnConstraint::NotNull,
                     ColumnConstraint::DefaultValue(Expr::Call(FunctionExpr::Call {
                         name: "CURRENT_TIMESTAMP".into(),
-                        arguments: vec![Expr::Literal(Literal::UnsignedInteger(6))],
+                        arguments: vec![Expr::Literal(Literal::Integer(6))],
                     })),
                     ColumnConstraint::OnUpdateCurrentTimestamp(None),
                 ],
@@ -431,11 +431,9 @@ mod tests {
                         ColumnConstraint::NotNull,
                         ColumnConstraint::DefaultValue(Expr::Call(FunctionExpr::Call {
                             name: "CURRENT_TIMESTAMP".into(),
-                            arguments: vec![Expr::Literal(Literal::UnsignedInteger(6))],
+                            arguments: vec![Expr::Literal(Literal::Integer(6))],
                         })),
-                        ColumnConstraint::OnUpdateCurrentTimestamp(Some(Literal::UnsignedInteger(
-                            6,
-                        ))),
+                        ColumnConstraint::OnUpdateCurrentTimestamp(Some(Literal::Integer(6))),
                     ],
                 };
                 assert_eq!(res, cspec);

--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -977,7 +977,7 @@ mod tests {
                 name: "ifnull".into(),
                 arguments: vec![
                     Expr::Column(Column::from("x")),
-                    Expr::Literal(Literal::UnsignedInteger(0))
+                    Expr::Literal(Literal::Integer(0))
                 ]
             }
         );
@@ -1017,8 +1017,8 @@ mod tests {
             res,
             FunctionExpr::Substring {
                 string: Box::new(Expr::Column("a".into())),
-                pos: Some(Box::new(Expr::Literal(1u32.into()))),
-                len: Some(Box::new(Expr::Literal(7u32.into())))
+                pos: Some(Box::new(Expr::Literal(1.into()))),
+                len: Some(Box::new(Expr::Literal(7.into())))
             }
         );
     }
@@ -1030,8 +1030,8 @@ mod tests {
             res,
             FunctionExpr::Substring {
                 string: Box::new(Expr::Column("a".into())),
-                pos: Some(Box::new(Expr::Literal(1u32.into()))),
-                len: Some(Box::new(Expr::Literal(7u32.into())))
+                pos: Some(Box::new(Expr::Literal(1.into()))),
+                len: Some(Box::new(Expr::Literal(7.into())))
             }
         );
     }
@@ -1043,7 +1043,7 @@ mod tests {
             res,
             FunctionExpr::Substring {
                 string: Box::new(Expr::Column("a".into())),
-                pos: Some(Box::new(Expr::Literal(1u32.into()))),
+                pos: Some(Box::new(Expr::Literal(1.into()))),
                 len: None,
             }
         );
@@ -1057,7 +1057,7 @@ mod tests {
             FunctionExpr::Substring {
                 string: Box::new(Expr::Column("a".into())),
                 pos: None,
-                len: Some(Box::new(Expr::Literal(7u32.into()))),
+                len: Some(Box::new(Expr::Literal(7.into()))),
             }
         );
     }
@@ -1071,8 +1071,8 @@ mod tests {
                 name: "substring".into(),
                 arguments: vec![
                     Expr::Column("a".into()),
-                    Expr::Literal(1u32.into()),
-                    Expr::Literal(7u32.into()),
+                    Expr::Literal(1.into()),
+                    Expr::Literal(7.into()),
                 ]
             }
         );

--- a/nom-sql/src/compound_select.rs
+++ b/nom-sql/src/compound_select.rs
@@ -172,7 +172,7 @@ mod tests {
             tables: vec![TableExpr::from(Relation::from("Vote"))],
             fields: vec![
                 FieldDefinitionExpr::from(Column::from("id")),
-                FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(1))),
+                FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(1))),
             ],
             ..Default::default()
         };
@@ -252,7 +252,7 @@ mod tests {
             tables: vec![TableExpr::from(Relation::from("Vote"))],
             fields: vec![
                 FieldDefinitionExpr::from(Column::from("id")),
-                FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(1))),
+                FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(1))),
             ],
             ..Default::default()
         };
@@ -267,8 +267,8 @@ mod tests {
         let third_select = SelectStatement {
             tables: vec![TableExpr::from(Relation::from("Vote"))],
             fields: vec![
-                FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(42))),
-                FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(5))),
+                FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(42))),
+                FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(5))),
             ],
             ..Default::default()
         };
@@ -295,7 +295,7 @@ mod tests {
             tables: vec![TableExpr::from(Relation::from("Vote"))],
             fields: vec![
                 FieldDefinitionExpr::from(Column::from("id")),
-                FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(1))),
+                FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(1))),
             ],
             ..Default::default()
         };

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -1309,7 +1309,7 @@ mod tests {
                     expr: Expr::BinaryOp {
                         lhs: Box::new(Expr::Column("x".into())),
                         op: BinaryOperator::Greater,
-                        rhs: Box::new(Expr::Literal(1_u32.into())),
+                        rhs: Box::new(Expr::Literal(1.into())),
                     },
                     enforced: None
                 }
@@ -1328,7 +1328,7 @@ mod tests {
                 expr: Expr::BinaryOp {
                     lhs: Box::new(Expr::Column("x".into())),
                     op: BinaryOperator::Greater,
-                    rhs: Box::new(Expr::Literal(1_u32.into())),
+                    rhs: Box::new(Expr::Literal(1.into())),
                 },
                 enforced: None
             }
@@ -1346,7 +1346,7 @@ mod tests {
                 expr: Expr::BinaryOp {
                     lhs: Box::new(Expr::Column("x".into())),
                     op: BinaryOperator::Greater,
-                    rhs: Box::new(Expr::Literal(1_u32.into())),
+                    rhs: Box::new(Expr::Literal(1.into())),
                 },
                 enforced: Some(false)
             }
@@ -2588,11 +2588,9 @@ PRIMARY KEY (`id`));";
                             ColumnConstraint::NotNull,
                             ColumnConstraint::DefaultValue(Expr::Call(FunctionExpr::Call {
                                 name: "CURRENT_TIMESTAMP".into(),
-                                arguments: vec![Expr::Literal(Literal::UnsignedInteger(6,),),],
+                                arguments: vec![Expr::Literal(Literal::Integer(6,),),],
                             },),),
-                            ColumnConstraint::OnUpdateCurrentTimestamp(Some(
-                                Literal::UnsignedInteger(6)
-                            ),),
+                            ColumnConstraint::OnUpdateCurrentTimestamp(Some(Literal::Integer(6)),),
                         ],
                     ),],
                     keys: None,

--- a/nom-sql/src/delete.rs
+++ b/nom-sql/src/delete.rs
@@ -98,7 +98,7 @@ mod tests {
         let expected_left = Expr::Column(Column::from("id"));
         let expected_where_cond = Some(Expr::BinaryOp {
             lhs: Box::new(expected_left),
-            rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
+            rhs: Box::new(Expr::Literal(Literal::Integer(1))),
             op: BinaryOperator::Equal,
         });
         assert_eq!(

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -1574,9 +1574,9 @@ mod tests {
                 lhs: Box::new(Expr::BinaryOp {
                     lhs: Box::new(Expr::Column("x".into())),
                     op: BinaryOperator::Add,
-                    rhs: Box::new(Expr::Literal(1u32.into()))
+                    rhs: Box::new(Expr::Literal(1.into()))
                 }),
-                rhs: InValue::List(vec![Expr::Literal(2u32.into())]),
+                rhs: InValue::List(vec![Expr::Literal(2.into())]),
                 negated: false
             }
         );
@@ -1635,7 +1635,7 @@ mod tests {
                 Expr::UnaryOp {
                     op: UnaryOperator::Neg,
                     rhs: Box::new(Expr::Cast {
-                        expr: Box::new(Expr::Literal(Literal::UnsignedInteger(128))),
+                        expr: Box::new(Expr::Literal(Literal::Integer(128))),
                         ty: SqlType::Int(None),
                         postgres_style: true
                     }),
@@ -1647,9 +1647,9 @@ mod tests {
                 res.unwrap().1,
                 Expr::BinaryOp {
                     op: BinaryOperator::Multiply,
-                    lhs: Box::new(Expr::Literal(Literal::UnsignedInteger(515))),
+                    lhs: Box::new(Expr::Literal(Literal::Integer(515))),
                     rhs: Box::new(Expr::Cast {
-                        expr: Box::new(Expr::Literal(Literal::UnsignedInteger(128))),
+                        expr: Box::new(Expr::Literal(Literal::Integer(128))),
                         ty: SqlType::Text,
                         postgres_style: true
                     }),
@@ -1662,8 +1662,8 @@ mod tests {
                 Expr::Cast {
                     expr: Box::new(Expr::BinaryOp {
                         op: BinaryOperator::Multiply,
-                        lhs: Box::new(Expr::Literal(Literal::UnsignedInteger(515))),
-                        rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(128)))
+                        lhs: Box::new(Expr::Literal(Literal::Integer(515))),
+                        rhs: Box::new(Expr::Literal(Literal::Integer(128)))
                     }),
                     ty: SqlType::Text,
                     postgres_style: true,
@@ -1677,7 +1677,7 @@ mod tests {
                 res.unwrap().1,
                 Expr::BinaryOp {
                     op: BinaryOperator::Multiply,
-                    lhs: Box::new(Expr::Literal(Literal::UnsignedInteger(200))),
+                    lhs: Box::new(Expr::Literal(Literal::Integer(200))),
                     rhs: Box::new(Expr::Cast {
                         expr: Box::new(Expr::Column(Column::from("postgres.column"))),
                         ty: SqlType::Double,
@@ -1695,7 +1695,7 @@ mod tests {
                 Expr::Cast {
                     expr: Box::new(Expr::UnaryOp {
                         op: UnaryOperator::Neg,
-                        rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(128))),
+                        rhs: Box::new(Expr::Literal(Literal::Integer(128))),
                     }),
                     ty: SqlType::UnsignedBigInt(None),
                     postgres_style: false
@@ -1765,7 +1765,7 @@ mod tests {
             let res = expression(Dialect::MySQL)(LocatedSpan::new(cond.as_bytes()));
             assert_eq!(
                 res.unwrap().1,
-                x_operator_value(BinaryOperator::Add, 3_u32.into())
+                x_operator_value(BinaryOperator::Add, 3.into())
             );
         }
 
@@ -1776,7 +1776,7 @@ mod tests {
             let res = expression(Dialect::MySQL)(LocatedSpan::new(cond.as_bytes()));
             assert_eq!(
                 res.unwrap().1,
-                x_operator_value(BinaryOperator::Subtract, 2_u32.into())
+                x_operator_value(BinaryOperator::Subtract, 2.into())
             );
         }
 
@@ -1787,7 +1787,7 @@ mod tests {
             let res = expression(Dialect::MySQL)(LocatedSpan::new(cond.as_bytes()));
             assert_eq!(
                 res.unwrap().1,
-                x_operator_value(BinaryOperator::Multiply, 5_u32.into())
+                x_operator_value(BinaryOperator::Multiply, 5.into())
             );
         }
 
@@ -1800,8 +1800,8 @@ mod tests {
                 res.unwrap().1,
                 Expr::BinaryOp {
                     op: BinaryOperator::Equal,
-                    lhs: Box::new(x_operator_value(BinaryOperator::Multiply, 3_u32.into())),
-                    rhs: Box::new(Expr::Literal(21_u32.into()))
+                    lhs: Box::new(x_operator_value(BinaryOperator::Multiply, 3.into())),
+                    rhs: Box::new(Expr::Literal(21.into()))
                 }
             );
         }
@@ -1814,8 +1814,8 @@ mod tests {
                 res.unwrap().1,
                 Expr::BinaryOp {
                     op: BinaryOperator::Equal,
-                    lhs: Box::new(x_operator_value(BinaryOperator::Subtract, 7_u32.into())),
-                    rhs: Box::new(Expr::Literal(15_u32.into()))
+                    lhs: Box::new(x_operator_value(BinaryOperator::Subtract, 7.into())),
+                    rhs: Box::new(Expr::Literal(15.into()))
                 }
             );
         }
@@ -1829,8 +1829,8 @@ mod tests {
                 res.unwrap().1,
                 Expr::BinaryOp {
                     op: BinaryOperator::Equal,
-                    lhs: Box::new(x_operator_value(BinaryOperator::Add, 2_u32.into())),
-                    rhs: Box::new(Expr::Literal(15_u32.into()))
+                    lhs: Box::new(x_operator_value(BinaryOperator::Add, 2.into())),
+                    rhs: Box::new(Expr::Literal(15.into()))
                 }
             );
         }
@@ -1844,8 +1844,8 @@ mod tests {
                 res.unwrap().1,
                 Expr::BinaryOp {
                     op: BinaryOperator::Equal,
-                    lhs: Box::new(x_operator_value(BinaryOperator::Add, 2_u32.into())),
-                    rhs: Box::new(x_operator_value(BinaryOperator::Multiply, 3_u32.into()))
+                    lhs: Box::new(x_operator_value(BinaryOperator::Add, 2.into())),
+                    rhs: Box::new(x_operator_value(BinaryOperator::Multiply, 3.into()))
                 }
             );
         }
@@ -1861,7 +1861,7 @@ mod tests {
                 Expr::BinaryOp {
                     lhs: Box::new(Expr::Column(Column::from("foo"))),
                     op: BinaryOperator::GreaterOrEqual,
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(42)))
+                    rhs: Box::new(Expr::Literal(Literal::Integer(42)))
                 }
             );
 
@@ -1871,7 +1871,7 @@ mod tests {
                 Expr::BinaryOp {
                     lhs: Box::new(Expr::Column(Column::from("foo"))),
                     op: BinaryOperator::LessOrEqual,
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(5)))
+                    rhs: Box::new(Expr::Literal(Literal::Integer(5)))
                 }
             );
         }
@@ -1906,7 +1906,7 @@ mod tests {
             let b = Expr::BinaryOp {
                 op: BinaryOperator::Equal,
                 lhs: Box::new(Expr::Column("bar".into())),
-                rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(12))),
+                rhs: Box::new(Expr::Literal(Literal::Integer(12))),
             };
 
             let left = Expr::BinaryOp {
@@ -1946,7 +1946,7 @@ mod tests {
             let b = Expr::BinaryOp {
                 op: BinaryOperator::Equal,
                 lhs: Box::new(Expr::Column("bar".into())),
-                rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(12))),
+                rhs: Box::new(Expr::Literal(Literal::Integer(12))),
             };
 
             let left = Expr::BinaryOp {
@@ -1980,7 +1980,7 @@ mod tests {
                 rhs: Box::new(Expr::BinaryOp {
                     op: BinaryOperator::Equal,
                     lhs: Box::new(Expr::Column("bar".into())),
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(12))),
+                    rhs: Box::new(Expr::Literal(Literal::Integer(12))),
                 }),
             };
 
@@ -2091,7 +2091,7 @@ mod tests {
             let right = Expr::BinaryOp {
                 lhs: Box::new(Expr::Column("size".into())),
                 op: BinaryOperator::Greater,
-                rhs: Box::new(Expr::Literal(0_u32.into())),
+                rhs: Box::new(Expr::Literal(0.into())),
             };
 
             let expected = Expr::BinaryOp {
@@ -2111,10 +2111,7 @@ mod tests {
 
             let expected = Expr::In {
                 lhs: Box::new(Expr::Column("bar".into())),
-                rhs: InValue::List(vec![
-                    Expr::Literal(0_u32.into()),
-                    Expr::Literal(1_u32.into()),
-                ]),
+                rhs: InValue::List(vec![Expr::Literal(0.into()), Expr::Literal(1.into())]),
                 negated: false,
             };
 
@@ -2153,8 +2150,8 @@ mod tests {
             let qs = b"foo between 1 and 2";
             let expected = Expr::Between {
                 operand: Box::new(Expr::Column("foo".into())),
-                min: Box::new(Expr::Literal(1_u32.into())),
-                max: Box::new(Expr::Literal(2_u32.into())),
+                min: Box::new(Expr::Literal(1.into())),
+                max: Box::new(Expr::Literal(2.into())),
                 negated: false,
             };
             let (remaining, result) =
@@ -2168,8 +2165,8 @@ mod tests {
             let qs = b"foo not between 1 and 2";
             let expected = Expr::Between {
                 operand: Box::new(Expr::Column("foo".into())),
-                min: Box::new(Expr::Literal(1_u32.into())),
-                max: Box::new(Expr::Literal(2_u32.into())),
+                min: Box::new(Expr::Literal(1.into())),
+                max: Box::new(Expr::Literal(2.into())),
                 negated: true,
             };
             let (remaining, result) =
@@ -2189,8 +2186,8 @@ mod tests {
                         Expr::Column(Column::from("bar")),
                     ],
                 })),
-                min: Box::new(Expr::Literal(1_u32.into())),
-                max: Box::new(Expr::Literal(2_u32.into())),
+                min: Box::new(Expr::Literal(1.into())),
+                max: Box::new(Expr::Literal(2.into())),
                 negated: false,
             };
             let (remaining, result) =
@@ -2206,13 +2203,13 @@ mod tests {
                 operand: Box::new(Expr::Column("foo".into())),
                 min: Box::new(Expr::BinaryOp {
                     op: BinaryOperator::Add,
-                    lhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(2))),
+                    lhs: Box::new(Expr::Literal(Literal::Integer(1))),
+                    rhs: Box::new(Expr::Literal(Literal::Integer(2))),
                 }),
                 max: Box::new(Expr::BinaryOp {
                     op: BinaryOperator::Add,
-                    lhs: Box::new(Expr::Literal(Literal::UnsignedInteger(3))),
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(5))),
+                    lhs: Box::new(Expr::Literal(Literal::Integer(3))),
+                    rhs: Box::new(Expr::Literal(Literal::Integer(5))),
                 }),
                 negated: false,
             };
@@ -2266,7 +2263,7 @@ mod tests {
             let qs = b"-256";
             let expected = Expr::UnaryOp {
                 op: UnaryOperator::Neg,
-                rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(256))),
+                rhs: Box::new(Expr::Literal(Literal::Integer(256))),
             };
             let (remaining, result) =
                 to_nom_result(expression(Dialect::MySQL)(LocatedSpan::new(qs))).unwrap();
@@ -2314,7 +2311,7 @@ mod tests {
                 op: UnaryOperator::Not,
                 rhs: Box::new(Expr::UnaryOp {
                     op: UnaryOperator::Neg,
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
+                    rhs: Box::new(Expr::Literal(Literal::Integer(1))),
                 }),
             };
             let (remaining, result) =
@@ -2330,7 +2327,7 @@ mod tests {
                 op: UnaryOperator::Neg,
                 rhs: Box::new(Expr::UnaryOp {
                     op: UnaryOperator::Neg,
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
+                    rhs: Box::new(Expr::Literal(Literal::Integer(1))),
                 }),
             };
             let (remaining, result) =
@@ -2363,10 +2360,7 @@ mod tests {
             let c1 = res1.unwrap().1;
             let expected1 = Expr::In {
                 lhs: Box::new(Expr::Column("id".into())),
-                rhs: InValue::List(vec![
-                    Expr::Literal(1_u32.into()),
-                    Expr::Literal(2_u32.into()),
-                ]),
+                rhs: InValue::List(vec![Expr::Literal(1.into()), Expr::Literal(2.into())]),
                 negated: true,
             };
             assert_eq!(c1, expected1);
@@ -2517,7 +2511,7 @@ mod tests {
                     lhs: Box::new(Expr::BinaryOp {
                         lhs: Box::new(Expr::Column("read_ribbons.is_following".into())),
                         op: BinaryOperator::Equal,
-                        rhs: Box::new(Expr::Literal(1_u32.into())),
+                        rhs: Box::new(Expr::Literal(1.into())),
                     }),
                     rhs: Box::new(Expr::BinaryOp {
                         op: BinaryOperator::And,
@@ -2531,7 +2525,7 @@ mod tests {
                             lhs: Box::new(Expr::BinaryOp {
                                 lhs: Box::new(Expr::Column("saldo".into())),
                                 op: BinaryOperator::GreaterOrEqual,
-                                rhs: Box::new(Expr::Literal(0_u32.into())),
+                                rhs: Box::new(Expr::Literal(0.into())),
                             }),
                             rhs: Box::new(Expr::BinaryOp {
                                 op: BinaryOperator::And,
@@ -2576,7 +2570,7 @@ mod tests {
                                         rhs: Box::new(Expr::BinaryOp {
                                             lhs: Box::new(Expr::Column("saldo".into())),
                                             op: BinaryOperator::GreaterOrEqual,
-                                            rhs: Box::new(Expr::Literal(0_u32.into())),
+                                            rhs: Box::new(Expr::Literal(0.into())),
                                         }),
                                     }),
                                     rhs: Box::new(Expr::BinaryOp {
@@ -2607,7 +2601,7 @@ mod tests {
                     Expr::BinaryOp {
                         lhs: Box::new(Expr::Column(Column::from("foo"))),
                         op: BinaryOperator::Equal,
-                        rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(42)))
+                        rhs: Box::new(Expr::Literal(Literal::Integer(42)))
                     }
                 );
 
@@ -2647,10 +2641,7 @@ mod tests {
             let c1 = res1.unwrap().1;
             let expected1 = Expr::In {
                 lhs: Box::new(Expr::Column("id".into())),
-                rhs: InValue::List(vec![
-                    Expr::Literal(1_u32.into()),
-                    Expr::Literal(2_u32.into()),
-                ]),
+                rhs: InValue::List(vec![Expr::Literal(1.into()), Expr::Literal(2.into())]),
                 negated: true,
             };
             assert_eq!(c1, expected1);
@@ -2784,7 +2775,7 @@ mod tests {
                 test_parse!(expression(Dialect::PostgreSQL), b"1 = ANY('{1,2}') = true"),
                 Expr::BinaryOp {
                     lhs: Box::new(Expr::OpAny {
-                        lhs: Box::new(Expr::Literal(1u64.into())),
+                        lhs: Box::new(Expr::Literal(1.into())),
                         op: BinaryOperator::Equal,
                         rhs: Box::new(Expr::Literal("{1,2}".into()))
                     }),
@@ -2803,7 +2794,7 @@ mod tests {
                 ),
                 Expr::BinaryOp {
                     lhs: Box::new(Expr::OpAny {
-                        lhs: Box::new(Expr::Literal(1u64.into())),
+                        lhs: Box::new(Expr::Literal(1.into())),
                         op: BinaryOperator::Equal,
                         rhs: Box::new(Expr::Literal("{1,2}".into()))
                     }),
@@ -2811,7 +2802,7 @@ mod tests {
                     rhs: Box::new(Expr::BinaryOp {
                         lhs: Box::new(Expr::Column("y".into())),
                         op: BinaryOperator::Equal,
-                        rhs: Box::new(Expr::Literal(4u64.into()))
+                        rhs: Box::new(Expr::Literal(4.into()))
                     })
                 }
             );
@@ -3023,7 +3014,7 @@ mod tests {
                     lhs: Box::new(Expr::BinaryOp {
                         lhs: Box::new(Expr::Column("read_ribbons.is_following".into())),
                         op: BinaryOperator::Equal,
-                        rhs: Box::new(Expr::Literal(1_u32.into())),
+                        rhs: Box::new(Expr::Literal(1.into())),
                     }),
                     rhs: Box::new(Expr::BinaryOp {
                         op: BinaryOperator::And,
@@ -3037,7 +3028,7 @@ mod tests {
                             lhs: Box::new(Expr::BinaryOp {
                                 lhs: Box::new(Expr::Column("saldo".into())),
                                 op: BinaryOperator::GreaterOrEqual,
-                                rhs: Box::new(Expr::Literal(0_u32.into())),
+                                rhs: Box::new(Expr::Literal(0.into())),
                             }),
                             rhs: Box::new(Expr::BinaryOp {
                                 op: BinaryOperator::And,
@@ -3082,7 +3073,7 @@ mod tests {
                                         rhs: Box::new(Expr::BinaryOp {
                                             lhs: Box::new(Expr::Column("saldo".into())),
                                             op: BinaryOperator::GreaterOrEqual,
-                                            rhs: Box::new(Expr::Literal(0_u32.into())),
+                                            rhs: Box::new(Expr::Literal(0.into())),
                                         }),
                                     }),
                                     rhs: Box::new(Expr::BinaryOp {
@@ -3113,7 +3104,7 @@ mod tests {
                     Expr::BinaryOp {
                         lhs: Box::new(Expr::Column(Column::from("foo"))),
                         op: BinaryOperator::Equal,
-                        rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(42)))
+                        rhs: Box::new(Expr::Literal(Literal::Integer(42)))
                     }
                 );
 
@@ -3141,7 +3132,7 @@ mod tests {
                     Expr::BinaryOp {
                         lhs: Box::new(Expr::Literal("[1, 2, 3]".into())),
                         op: BinaryOperator::Arrow1,
-                        rhs: Box::new(Expr::Literal(2u64.into())),
+                        rhs: Box::new(Expr::Literal(2.into())),
                     }
                 );
             }
@@ -3155,7 +3146,7 @@ mod tests {
                     Expr::BinaryOp {
                         lhs: Box::new(Expr::Literal("[1, 2, 3]".into())),
                         op: BinaryOperator::Arrow2,
-                        rhs: Box::new(Expr::Literal(2u64.into())),
+                        rhs: Box::new(Expr::Literal(2.into())),
                     }
                 );
             }
@@ -3213,14 +3204,14 @@ mod tests {
                 res,
                 Expr::Array(vec![
                     Expr::Array(vec![
-                        Expr::Literal(1u32.into()),
+                        Expr::Literal(1.into()),
                         Expr::Cast {
                             expr: Box::new(Expr::Literal("2".into())),
                             ty: SqlType::Int(None),
                             postgres_style: true,
                         },
                     ]),
-                    Expr::Array(vec![Expr::Literal(3u32.into())])
+                    Expr::Array(vec![Expr::Literal(3.into())])
                 ])
             );
         }
@@ -3247,9 +3238,9 @@ mod tests {
                 Expr::Row {
                     explicit: true,
                     exprs: vec![
-                        Expr::Literal(1u32.into()),
-                        Expr::Literal(2u32.into()),
-                        Expr::Literal(3u32.into())
+                        Expr::Literal(1.into()),
+                        Expr::Literal(2.into()),
+                        Expr::Literal(3.into())
                     ]
                 }
             );
@@ -3257,7 +3248,7 @@ mod tests {
                 test_parse!(expression(Dialect::PostgreSQL), b"ROW(7)"),
                 Expr::Row {
                     explicit: true,
-                    exprs: vec![Expr::Literal(7u32.into())]
+                    exprs: vec![Expr::Literal(7.into())]
                 }
             );
         }
@@ -3269,9 +3260,9 @@ mod tests {
                 Expr::Row {
                     explicit: false,
                     exprs: vec![
-                        Expr::Literal(1u32.into()),
-                        Expr::Literal(2u32.into()),
-                        Expr::Literal(3u32.into())
+                        Expr::Literal(1.into()),
+                        Expr::Literal(2.into()),
+                        Expr::Literal(3.into())
                     ]
                 }
             );
@@ -3279,7 +3270,7 @@ mod tests {
             // Only one expr is not a ROW expr
             assert_eq!(
                 test_parse!(expression(Dialect::PostgreSQL), b"(7)"),
-                Expr::Literal(7u32.into())
+                Expr::Literal(7.into())
             );
         }
     }

--- a/nom-sql/src/insert.rs
+++ b/nom-sql/src/insert.rs
@@ -172,10 +172,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: None,
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false
                 }
@@ -195,7 +192,7 @@ mod tests {
                     table: Relation::from("users"),
                     fields: None,
                     data: vec![vec![
-                        Expr::Literal(42_u32.into()),
+                        Expr::Literal(42.into()),
                         Expr::Literal("test".into()),
                         Expr::Literal("test".into()),
                         Expr::Call(FunctionExpr::Call {
@@ -219,10 +216,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false
                 }
@@ -240,10 +234,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false
                 }
@@ -263,10 +254,7 @@ mod tests {
                         name: "users".into(),
                     },
                     fields: None,
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false,
                 }
@@ -284,8 +272,8 @@ mod tests {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
                     data: vec![
-                        vec![Expr::Literal(42_u32.into()), Expr::Literal("test".into())],
-                        vec![Expr::Literal(21_u32.into()), Expr::Literal("test2".into())],
+                        vec![Expr::Literal(42.into()), Expr::Literal("test".into())],
+                        vec![Expr::Literal(21.into()), Expr::Literal("test2".into())],
                     ],
                     on_duplicate: None,
                     ignore: false,
@@ -313,7 +301,7 @@ mod tests {
                         Expr::BinaryOp {
                             op: BinaryOperator::Add,
                             lhs: Box::new(Expr::Column(Column::from("value"))),
-                            rhs: Box::new(Expr::Literal(1_u32.into()))
+                            rhs: Box::new(Expr::Literal(1.into()))
                         },
                     )]),
                     ignore: false,
@@ -331,10 +319,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false,
                 }
@@ -367,10 +352,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: None,
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false,
                 }
@@ -388,7 +370,7 @@ mod tests {
                     table: Relation::from("users"),
                     fields: None,
                     data: vec![vec![
-                        Expr::Literal(42_u32.into()),
+                        Expr::Literal(42.into()),
                         Expr::Literal("test".into()),
                         Expr::Literal("test".into()),
                         Expr::Call(FunctionExpr::Call {
@@ -412,10 +394,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false,
                 }
@@ -433,10 +412,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false,
                 }
@@ -456,10 +432,7 @@ mod tests {
                         name: "users".into(),
                     },
                     fields: None,
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     on_duplicate: None,
                     ignore: false,
                 }
@@ -477,8 +450,8 @@ mod tests {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
                     data: vec![
-                        vec![Expr::Literal(42_u32.into()), Expr::Literal("test".into())],
-                        vec![Expr::Literal(21_u32.into()), Expr::Literal("test2".into())],
+                        vec![Expr::Literal(42.into()), Expr::Literal("test".into())],
+                        vec![Expr::Literal(21.into()), Expr::Literal("test2".into())],
                     ],
                     ignore: false,
                     on_duplicate: None
@@ -506,7 +479,7 @@ mod tests {
                         Expr::BinaryOp {
                             op: BinaryOperator::Add,
                             lhs: Box::new(Expr::Column(Column::from("value"))),
-                            rhs: Box::new(Expr::Literal(1_u32.into()))
+                            rhs: Box::new(Expr::Literal(1.into()))
                         },
                     ),]),
                     ignore: false
@@ -524,10 +497,7 @@ mod tests {
                 InsertStatement {
                     table: Relation::from("users"),
                     fields: Some(vec![Column::from("id"), Column::from("name")]),
-                    data: vec![vec![
-                        Expr::Literal(42_u32.into()),
-                        Expr::Literal("test".into())
-                    ]],
+                    data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                     ignore: false,
                     on_duplicate: None
                 }

--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -288,10 +288,7 @@ mod tests {
             let expected = SqlQuery::Insert(InsertStatement {
                 table: Relation::from("users"),
                 fields: None,
-                data: vec![vec![
-                    Expr::Literal(42_u32.into()),
-                    Expr::Literal("test".into()),
-                ]],
+                data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                 ignore: false,
                 on_duplicate: None,
             });
@@ -499,10 +496,7 @@ mod tests {
             let expected = SqlQuery::Insert(InsertStatement {
                 table: Relation::from("users"),
                 fields: None,
-                data: vec![vec![
-                    Expr::Literal(42_u32.into()),
-                    Expr::Literal("test".into()),
-                ]],
+                data: vec![vec![Expr::Literal(42.into()), Expr::Literal("test".into())]],
                 ignore: false,
                 on_duplicate: None,
             });

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -679,7 +679,7 @@ mod tests {
             res.unwrap().1,
             SelectStatement {
                 fields: vec![FieldDefinitionExpr::Expr {
-                    expr: Expr::Literal(Literal::UnsignedInteger(1)),
+                    expr: Expr::Literal(Literal::Integer(1)),
                     alias: None
                 }],
                 ..Default::default()
@@ -840,22 +840,22 @@ mod tests {
         assert_eq!(
             res1.limit_clause,
             LimitClause::LimitOffset {
-                limit: Some(10_u32.into()),
+                limit: Some(10.into()),
                 offset: None
             }
         );
         assert_eq!(
             res2.limit_clause,
             LimitClause::LimitOffset {
-                limit: Some(10_u32.into()),
-                offset: Some(10_u32.into())
+                limit: Some(10.into()),
+                offset: Some(10.into())
             }
         );
         assert_eq!(
             res3.limit_clause,
             LimitClause::OffsetCommaLimit {
-                limit: 10_u32.into(),
-                offset: 5_u32.into()
+                limit: 10.into(),
+                offset: 5.into()
             }
         );
         res3_pgsql.unwrap_err();
@@ -1054,7 +1054,7 @@ mod tests {
                 fields: vec![FieldDefinitionExpr::All],
                 where_clause: expected_where_cond,
                 limit_clause: LimitClause::LimitOffset {
-                    limit: Some(10_u32.into()),
+                    limit: Some(10.into()),
                     offset: None
                 },
                 ..Default::default()
@@ -1153,7 +1153,7 @@ mod tests {
         let filter_cond = Expr::BinaryOp {
             lhs: Box::new(Expr::Column(Column::from("vote_id"))),
             op: BinaryOperator::Greater,
-            rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(10))),
+            rhs: Box::new(Expr::Literal(Literal::Integer(10))),
         };
         let agg_expr = FunctionExpr::Count {
             expr: Box::new(Expr::CaseWhen {
@@ -1185,7 +1185,7 @@ mod tests {
         let filter_cond = Expr::BinaryOp {
             lhs: Box::new(Expr::Column(Column::from("sign"))),
             op: BinaryOperator::Equal,
-            rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
+            rhs: Box::new(Expr::Literal(Literal::Integer(1))),
         };
         let agg_expr = FunctionExpr::Sum {
             expr: Box::new(Expr::CaseWhen {
@@ -1218,7 +1218,7 @@ mod tests {
         let filter_cond = Expr::BinaryOp {
             lhs: Box::new(Expr::Column(Column::from("sign"))),
             op: BinaryOperator::Equal,
-            rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
+            rhs: Box::new(Expr::Literal(Literal::Integer(1))),
         };
         let agg_expr = FunctionExpr::Sum {
             expr: Box::new(Expr::CaseWhen {
@@ -1226,7 +1226,7 @@ mod tests {
                     condition: filter_cond,
                     body: Expr::Column(Column::from("vote_id")),
                 }],
-                else_expr: Some(Box::new(Expr::Literal(Literal::UnsignedInteger(6)))),
+                else_expr: Some(Box::new(Expr::Literal(Literal::Integer(6)))),
             }),
             distinct: false,
         };
@@ -1259,7 +1259,7 @@ mod tests {
             rhs: Box::new(Expr::BinaryOp {
                 lhs: Box::new(Expr::Column(Column::from("votes.vote"))),
                 op: BinaryOperator::Equal,
-                rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(0))),
+                rhs: Box::new(Expr::Literal(Literal::Integer(0))),
             }),
             op: BinaryOperator::And,
         };
@@ -1365,7 +1365,7 @@ mod tests {
                     )],
                 }),
                 limit_clause: LimitClause::LimitOffset {
-                    limit: Some(50_u32.into()),
+                    limit: Some(50.into()),
                     offset: None
                 },
                 ..Default::default()
@@ -1600,7 +1600,7 @@ mod tests {
                 where_clause: Some(Expr::BinaryOp {
                     lhs: Box::new(Expr::Column("x".into())),
                     op: BinaryOperator::Equal,
-                    rhs: Box::new(Expr::Literal(1u64.into()))
+                    rhs: Box::new(Expr::Literal(1.into()))
                 }),
                 ..Default::default()
             }
@@ -1662,7 +1662,7 @@ mod tests {
                     "o_id".into(),
                 ))))),
                 op: BinaryOperator::Subtract,
-                rhs: Box::new(Expr::Literal(3333_u32.into())),
+                rhs: Box::new(Expr::Literal(3333.into())),
             })],
             ..Default::default()
         };
@@ -1684,7 +1684,7 @@ mod tests {
                         "o_id".into(),
                     ))))),
                     op: BinaryOperator::Multiply,
-                    rhs: Box::new(Expr::Literal(2_u32.into())),
+                    rhs: Box::new(Expr::Literal(2.into())),
                 },
             }],
             ..Default::default()
@@ -1827,7 +1827,7 @@ mod tests {
                     tables: vec![TableExpr::from(Relation::from("users"))],
                     fields: vec![
                         FieldDefinitionExpr::from(Expr::Literal(Literal::Null,)),
-                        FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(1),)),
+                        FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(1),)),
                         FieldDefinitionExpr::from(
                             Expr::Literal(Literal::String("foo".to_owned()),)
                         ),
@@ -1854,7 +1854,7 @@ mod tests {
                 lhs: Box::new(Expr::Column(Column::from(
                     "auth_permission.content_type_id",
                 ))),
-                rhs: InValue::List(vec![Expr::Literal(0_u32.into())]),
+                rhs: InValue::List(vec![Expr::Literal(0.into())]),
                 negated: false,
             });
 
@@ -1966,7 +1966,7 @@ mod tests {
                 Some(Expr::BinaryOp {
                     lhs: Box::new(Expr::Call(FunctionExpr::CountStar)),
                     op: BinaryOperator::Greater,
-                    rhs: Box::new(Expr::Literal(1_u32.into()))
+                    rhs: Box::new(Expr::Literal(1.into()))
                 })
             );
             let stringified = res.display(Dialect::MySQL).to_string();
@@ -2055,7 +2055,7 @@ mod tests {
                     tables: vec![TableExpr::from(Relation::from("users"))],
                     fields: vec![
                         FieldDefinitionExpr::from(Expr::Literal(Literal::Null,)),
-                        FieldDefinitionExpr::from(Expr::Literal(Literal::UnsignedInteger(1),)),
+                        FieldDefinitionExpr::from(Expr::Literal(Literal::Integer(1),)),
                         FieldDefinitionExpr::from(
                             Expr::Literal(Literal::String("foo".to_owned()),)
                         ),
@@ -2082,7 +2082,7 @@ mod tests {
                 lhs: Box::new(Expr::Column(Column::from(
                     "auth_permission.content_type_id",
                 ))),
-                rhs: InValue::List(vec![Expr::Literal(0_u32.into())]),
+                rhs: InValue::List(vec![Expr::Literal(0.into())]),
                 negated: false,
             });
 
@@ -2151,7 +2151,7 @@ mod tests {
                 Some(Expr::BinaryOp {
                     lhs: Box::new(Expr::Call(FunctionExpr::CountStar)),
                     op: BinaryOperator::Greater,
-                    rhs: Box::new(Expr::Literal(1_u32.into()))
+                    rhs: Box::new(Expr::Literal(1.into()))
                 })
             );
             let stringified = res.display(Dialect::PostgreSQL).to_string();
@@ -2283,6 +2283,26 @@ mod tests {
             };
 
             let res = test_parse!(selection(Dialect::PostgreSQL), qstr);
+            assert_eq!(res, expected);
+        }
+
+        #[test]
+        fn select_with_decimal_limit_very_large_limit() {
+            let qstr = "SELECT id FROM a LIMIT 3791947566539531989 OFFSET -0.0";
+            let expected = SelectStatement {
+                tables: vec![TableExpr::from(Relation::from("a"))],
+                fields: columns(&["id"]),
+                limit_clause: LimitClause::LimitOffset {
+                    limit: Some(Literal::Integer(3791947566539531989)),
+                    offset: Some(Literal::Double(Double {
+                        value: -0.0,
+                        precision: 1,
+                    })),
+                },
+                ..Default::default()
+            };
+
+            let res = test_parse!(selection(Dialect::PostgreSQL), qstr.as_bytes());
             assert_eq!(res, expected);
         }
     }

--- a/nom-sql/src/set.rs
+++ b/nom-sql/src/set.rs
@@ -445,7 +445,7 @@ mod tests {
                         scope: VariableScope::Local,
                         name: "sql_auto_is_null".into()
                     },
-                    Expr::Literal(0_u32.into())
+                    Expr::Literal(0.into())
                 )),
             })
         );
@@ -463,7 +463,7 @@ mod tests {
                         scope: VariableScope::User,
                         name: "var".into()
                     },
-                    Expr::Literal(123_u32.into())
+                    Expr::Literal(123.into())
                 )),
             })
         );
@@ -567,9 +567,9 @@ mod tests {
                         name: "myvar".into()
                     },
                     Expr::BinaryOp {
-                        lhs: Box::new(Expr::Literal(100_u32.into())),
+                        lhs: Box::new(Expr::Literal(100.into())),
                         op: crate::BinaryOperator::Add,
-                        rhs: Box::new(Expr::Literal(200_u32.into())),
+                        rhs: Box::new(Expr::Literal(200.into())),
                     }
                 )),
             })
@@ -590,9 +590,9 @@ mod tests {
                             name: "myvar".into()
                         },
                         Expr::BinaryOp {
-                            lhs: Box::new(Expr::Literal(100_u32.into())),
+                            lhs: Box::new(Expr::Literal(100.into())),
                             op: crate::BinaryOperator::Add,
-                            rhs: Box::new(Expr::Literal(200_u32.into())),
+                            rhs: Box::new(Expr::Literal(200.into())),
                         }
                     ),
                     (
@@ -706,7 +706,7 @@ mod tests {
                     name: "whatever".into(),
                     value: SetPostgresParameterValue::Value(PostgresParameterValue::List(vec![
                         PostgresParameterValueInner::Literal("x".into()),
-                        PostgresParameterValueInner::Literal(1_u32.into()),
+                        PostgresParameterValueInner::Literal(1.into()),
                         PostgresParameterValueInner::Identifier("hi".into()),
                     ]))
                 })

--- a/nom-sql/src/update.rs
+++ b/nom-sql/src/update.rs
@@ -96,7 +96,7 @@ mod tests {
             UpdateStatement {
                 table: Relation::from("users"),
                 fields: vec![
-                    (Column::from("id"), Expr::Literal(42_u32.into())),
+                    (Column::from("id"), Expr::Literal(42.into())),
                     (Column::from("name"), Expr::Literal("test".into())),
                 ],
                 where_clause: None
@@ -112,7 +112,7 @@ mod tests {
         let expected_left = Expr::Column(Column::from("id"));
         let expected_where_cond = Some(Expr::BinaryOp {
             lhs: Box::new(expected_left),
-            rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1))),
+            rhs: Box::new(Expr::Literal(Literal::Integer(1))),
             op: BinaryOperator::Equal,
         });
         assert_eq!(
@@ -120,7 +120,7 @@ mod tests {
             UpdateStatement {
                 table: Relation::from("users"),
                 fields: vec![
-                    (Column::from("id"), Expr::Literal(Literal::from(42_u32)),),
+                    (Column::from("id"), Expr::Literal(Literal::from(42)),),
                     (Column::from("name"), Expr::Literal(Literal::from("test",)),),
                 ],
                 where_clause: expected_where_cond,
@@ -149,7 +149,7 @@ mod tests {
                     Expr::BinaryOp {
                         op: BinaryOperator::Add,
                         lhs: Box::new(Expr::Column(Column::from("karma"))),
-                        rhs: Box::new(Expr::Literal(1_u32.into()))
+                        rhs: Box::new(Expr::Literal(1.into()))
                     },
                 ),],
                 where_clause: expected_where_cond,
@@ -211,7 +211,7 @@ mod tests {
                         Expr::BinaryOp {
                             op: BinaryOperator::Add,
                             lhs: Box::new(Expr::Column(Column::from("karma"))),
-                            rhs: Box::new(Expr::Literal(1_u32.into()))
+                            rhs: Box::new(Expr::Literal(1.into()))
                         },
                     ),],
                     where_clause: None
@@ -310,7 +310,7 @@ mod tests {
                         Expr::BinaryOp {
                             op: BinaryOperator::Add,
                             lhs: Box::new(Expr::Column(Column::from("karma"))),
-                            rhs: Box::new(Expr::Literal(1_u32.into()))
+                            rhs: Box::new(Expr::Literal(1.into()))
                         },
                     ),],
                     where_clause: None

--- a/readyset-adapter/src/rewrite.rs
+++ b/readyset-adapter/src/rewrite.rs
@@ -1053,7 +1053,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users WHERE id = 1",
                 "SELECT id FROM users WHERE id = ?",
-                vec![(0, 1_u32.into())],
+                vec![(0, 1.into())],
             );
         }
 
@@ -1062,7 +1062,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users WHERE id = 1 AND name = \"bob\"",
                 "SELECT id FROM users WHERE id = ? AND name = ?",
-                vec![(0, 1_u32.into()), (1, "bob".into())],
+                vec![(0, 1.into()), (1, "bob".into())],
             );
         }
 
@@ -1071,7 +1071,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users WHERE x = ? AND id = 1 AND name = \"bob\"",
                 "SELECT id FROM users WHERE x = ? AND id = ? AND name = ?",
-                vec![(1, 1_u32.into()), (2, "bob".into())],
+                vec![(1, 1.into()), (2, "bob".into())],
             );
         }
 
@@ -1080,7 +1080,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users WHERE id = 1 AND name = \"bob\" AND x = ?",
                 "SELECT id FROM users WHERE id = ? AND name = ? AND x = ?",
-                vec![(0, 1_u32.into()), (1, "bob".into())],
+                vec![(0, 1.into()), (1, "bob".into())],
             );
         }
 
@@ -1089,7 +1089,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users WHERE id = 1 AND x = ? AND name = \"bob\"",
                 "SELECT id FROM users WHERE id = ? AND x = ? AND name = ?",
-                vec![(0, 1_u32.into()), (2, "bob".into())],
+                vec![(0, 1.into()), (2, "bob".into())],
             );
         }
 
@@ -1107,7 +1107,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id = 1",
                 "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id = ?",
-                vec![(0, 1_u32.into())],
+                vec![(0, 1.into())],
             )
         }
 
@@ -1116,7 +1116,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id + 1 FROM users WHERE id = 1",
                 "SELECT id + 1 FROM users WHERE id = ?",
-                vec![(0, 1_u32.into())],
+                vec![(0, 1.into())],
             )
         }
 
@@ -1125,7 +1125,7 @@ mod tests {
             test_auto_parametrize(
                 "select hashtags.*, from hashtags inner join invites_hashtags on hashtags.id = invites_hashtags.hashtag_id where invites_hashtags.invite_id in (10,20,31)",
                 "select hashtags.*, from hashtags inner join invites_hashtags on hashtags.id = invites_hashtags.hashtag_id where invites_hashtags.invite_id in (?,?,?)",
-                    vec![(0, 10_u32.into()), (1, 20_u32.into()), (2, 31_u32.into())],
+                    vec![(0, 10.into()), (1, 20.into()), (2, 31.into())],
             );
         }
 
@@ -1134,7 +1134,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT id FROM users WHERE id in (1, 2) AND name = 'bob'",
                 "SELECT id FROM users WHERE id in (?, ?) AND name = ?",
-                vec![(0, 1_u32.into()), (1, 2_u32.into()), (2, "bob".into())],
+                vec![(0, 1.into()), (1, 2.into()), (2, "bob".into())],
             );
         }
 
@@ -1145,8 +1145,8 @@ mod tests {
                 "SELECT id FROM users WHERE x = ? AND id in (?, ?) AND name = ?",
                 vec![
                     (0, "foo".into()),
-                    (1, 1_u32.into()),
-                    (2, 2_u32.into()),
+                    (1, 1.into()),
+                    (2, 2.into()),
                     (3, "bob".into()),
                 ],
             );
@@ -1157,7 +1157,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT count(*) FROM users WHERE id = 1 AND x IN (1, 2)",
                 "SELECT count(*) FROM users WHERE id = ? AND x IN (1, 2)",
-                vec![(0, 1_u32.into())],
+                vec![(0, 1.into())],
             );
         }
 
@@ -1166,7 +1166,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT * FROM users WHERE 1 = id",
                 "SELECT * FROM users WHERE id = ?",
-                vec![(0, 1_u32.into())],
+                vec![(0, 1.into())],
             );
         }
 
@@ -1184,7 +1184,7 @@ mod tests {
             test_auto_parametrize(
                 "SELECT * FROM posts WHERE id = 1 ORDER BY SCORE ASC LIMIT 3 OFFSET 6",
                 "SELECT * FROM posts WHERE id = ? ORDER BY SCORE ASC LIMIT 3 OFFSET ?",
-                vec![(0, 1_u32.into()), (1, 6_u32.into())],
+                vec![(0, 1.into()), (1, 6.into())],
             );
         }
 

--- a/readyset-logictest/src/from_query_log/querylog.rs
+++ b/readyset-logictest/src/from_query_log/querylog.rs
@@ -330,16 +330,10 @@ mod tests {
             )
             .unwrap();
         assert_eq!(parsed, &common_insert);
-        assert_eq!(
-            values,
-            vec![UnsignedInteger(1), UnsignedInteger(2), UnsignedInteger(3)]
-        );
+        assert_eq!(values, vec![Integer(1), Integer(2), Integer(3)]);
         let (parsed, values) = session.find_prepared_statement(&parse_query(Dialect::MySQL, "INSERT INTO payment (customer_id, amount, account_name) VALUES (1, 'str', NULL)").unwrap()).unwrap();
         assert_eq!(parsed, &common_insert);
-        assert_eq!(
-            values,
-            vec![UnsignedInteger(1), String("str".to_string()), Null]
-        );
+        assert_eq!(values, vec![Integer(1), String("str".to_string()), Null]);
         let (parsed, values) = session
             .find_prepared_statement(
                 &parse_query(
@@ -350,10 +344,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(parsed, &common_update);
-        assert_eq!(
-            values,
-            vec![String("test".to_string()), UnsignedInteger(123)]
-        );
+        assert_eq!(values, vec![String("test".to_string()), Integer(123)]);
         let (parsed, values) = session
             .find_prepared_statement(
                 &parse_query(
@@ -364,7 +355,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(parsed, &common_delete);
-        assert_eq!(values, vec![UnsignedInteger(9)]);
+        assert_eq!(values, vec![Integer(9)]);
         let (parsed, values) = session.find_prepared_statement(&parse_query(Dialect::MySQL, "SELECT column_name AS column_name, data_type AS data_type, column_type AS full_data_type, character_maximum_length AS character_maximum_length, numeric_precision AS numeric_precision, numeric_scale AS numeric_scale, datetime_precision AS datetime_precision, column_default AS column_default, is_nullable AS is_nullable, extra AS extra, table_name AS table_name FROM information_schema.columns WHERE (table_schema = 'dbtest') ORDER BY ordinal_position ASC").unwrap()).unwrap();
         assert_eq!(parsed, &select_information_schema);
         assert_eq!(values, vec![String("dbtest".to_string())]);
@@ -379,7 +370,7 @@ mod tests {
                 }),
                 Null,
                 String("somebody".to_string()),
-                UnsignedInteger(867)
+                Integer(867)
             ]
         );
     }

--- a/readyset-mysql/src/query_handler.rs
+++ b/readyset-mysql/src/query_handler.rs
@@ -883,7 +883,7 @@ impl QueryHandler for MySqlQueryHandler {
                     }
                 }) {
                     return SetAutocommit(
-                        matches!(val, Expr::Literal(Literal::UnsignedInteger(i)) if *i == 1),
+                        matches!(val, Expr::Literal(Literal::Integer(i)) if *i == 1),
                     );
                 }
 

--- a/readyset-server/src/controller/sql/query_graph.rs
+++ b/readyset-server/src/controller/sql/query_graph.rs
@@ -793,7 +793,7 @@ pub(crate) fn extract_limit_offset(
         .offset()
         .as_ref()
         // For now, remove offset if it is a literal 0
-        .filter(|offset| !matches!(offset, Literal::UnsignedInteger(0)))
+        .filter(|offset| !matches!(offset, Literal::Integer(0)))
         .map(|offset| -> ReadySetResult<ViewPlaceholder> {
             match offset {
                 Literal::Placeholder(ItemPlaceholder::DollarNumber(idx)) => {
@@ -1470,7 +1470,7 @@ mod tests {
             vec![Expr::BinaryOp {
                 lhs: Box::new(Expr::Column("t.x".into())),
                 op: BinaryOperator::Greater,
-                rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(2)))
+                rhs: Box::new(Expr::Literal(Literal::Integer(2)))
             }]
         );
         assert_eq!(qg.aggregates, HashMap::new());
@@ -1487,7 +1487,7 @@ mod tests {
                         table: None
                     })),
                     op: BinaryOperator::Greater,
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(1)))
+                    rhs: Box::new(Expr::Literal(Literal::Integer(1)))
                 },
                 Expr::BinaryOp {
                     lhs: Box::new(Expr::Column(Column {
@@ -1495,7 +1495,7 @@ mod tests {
                         table: None
                     })),
                     op: BinaryOperator::Greater,
-                    rhs: Box::new(Expr::Literal(Literal::UnsignedInteger(3)))
+                    rhs: Box::new(Expr::Literal(Literal::Integer(3)))
                 },
             ]
         );
@@ -1589,7 +1589,7 @@ mod tests {
     #[test]
     fn constant_filter() {
         let qg = make_query_graph("SELECT x FROM t WHERE x = $1 AND 1");
-        assert_eq!(qg.global_predicates, vec![Expr::Literal(1u64.into())])
+        assert_eq!(qg.global_predicates, vec![Expr::Literal(1.into())])
     }
 
     #[test]
@@ -1600,7 +1600,7 @@ mod tests {
             vec![Expr::BinaryOp {
                 lhs: Box::new(Expr::Column("t2.y".into())),
                 op: BinaryOperator::Equal,
-                rhs: Box::new(Expr::Literal(4u64.into()))
+                rhs: Box::new(Expr::Literal(4.into()))
             }]
         )
     }

--- a/readyset-server/src/controller/sql/registry.rs
+++ b/readyset-server/src/controller/sql/registry.rs
@@ -1247,7 +1247,7 @@ mod tests {
                     .unwrap(),
                 vec![MatchedCache {
                     name: "foo".into(),
-                    required_values: HashMap::from_iter([(1, Literal::UnsignedInteger(1))]),
+                    required_values: HashMap::from_iter([(1, Literal::Integer(1))]),
                     key_mapping: HashMap::new(),
                 }]
             );
@@ -1299,17 +1299,17 @@ mod tests {
             let truth = vec![
                 MatchedCache {
                     name: "foo".into(),
-                    required_values: HashMap::from_iter([(1, Literal::UnsignedInteger(1))]),
+                    required_values: HashMap::from_iter([(1, Literal::Integer(1))]),
                     key_mapping: HashMap::from_iter([(1, Literal::String("string".to_string()))]),
                 },
                 MatchedCache {
                     name: "bar".into(),
-                    required_values: HashMap::from_iter([(1, Literal::UnsignedInteger(2))]),
+                    required_values: HashMap::from_iter([(1, Literal::Integer(2))]),
                     key_mapping: HashMap::from_iter([(1, Literal::String("string".to_string()))]),
                 },
                 MatchedCache {
                     name: "baz".into(),
-                    required_values: HashMap::from_iter([(1, Literal::UnsignedInteger(2))]),
+                    required_values: HashMap::from_iter([(1, Literal::Integer(2))]),
                     key_mapping: HashMap::from_iter([
                         (1, Literal::String("string".to_string())),
                         (2, Literal::Null),
@@ -1329,8 +1329,8 @@ mod tests {
                     name: "baz".into(),
                     required_values: HashMap::new(),
                     key_mapping: HashMap::from_iter([
-                        (1, Literal::UnsignedInteger(1)),
-                        (2, Literal::UnsignedInteger(2))
+                        (1, Literal::Integer(1)),
+                        (2, Literal::Integer(2))
                     ])
                 }]
             );
@@ -1369,7 +1369,7 @@ mod tests {
             assert_eq!(
                 entry[0].1,
                 vec![
-                    Literal::UnsignedInteger(1),
+                    Literal::Integer(1),
                     Literal::Placeholder(ItemPlaceholder::QuestionMark)
                 ]
             );

--- a/readyset-sql-passes/src/inline_literals.rs
+++ b/readyset-sql-passes/src/inline_literals.rs
@@ -49,8 +49,8 @@ mod test {
         );
         let literals = vec![
             (1, Literal::String("one".into())),
-            (2, Literal::UnsignedInteger(2)),
-            (3, Literal::UnsignedInteger(3)),
+            (2, Literal::Integer(2)),
+            (3, Literal::Integer(3)),
         ]
         .into_iter()
         .collect::<HashMap<_, _>>();

--- a/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
+++ b/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
@@ -187,7 +187,7 @@ mod tests {
                 assert_eq!(
                     stmt.limit_clause,
                     LimitClause::LimitOffset {
-                        limit: Some(4_u32.into()),
+                        limit: Some(4.into()),
                         offset: None
                     }
                 );

--- a/readyset-sql-passes/src/strip_literals.rs
+++ b/readyset-sql-passes/src/strip_literals.rs
@@ -85,9 +85,9 @@ mod test {
             literals,
             vec![
                 Literal::String("literal".to_string()),
-                Literal::UnsignedInteger(1),
-                Literal::UnsignedInteger(2),
-                Literal::UnsignedInteger(3),
+                Literal::Integer(1),
+                Literal::Integer(2),
+                Literal::Integer(3),
                 Literal::Placeholder(ItemPlaceholder::QuestionMark),
                 Literal::Placeholder(ItemPlaceholder::QuestionMark)
             ]


### PR DESCRIPTION
If we are parsing a raw integer literal and it doesn't have a sign, we
previously defaulted to interpreting it as an UnsignedInteger. This is
different than the behavior of mysql, which defaults to signed integers.
Postgres doesn't have unsigned integer types, so it makes sense for the
default to be signed integers.

