### PR TITLE
quickstart: Point to readyset image on docker hub

### DIFF
--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -1,7 +1,7 @@
 name: readyset-mysql
 services:
   cache:
-    image: public.ecr.aws/readyset/readyset:beta-latest
+    image: docker.io/readysettech/readyset:latest
     platform: linux/amd64
     expose:
       - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -1,7 +1,7 @@
 name: readyset-postgres
 services:
   cache:
-    image: public.ecr.aws/readyset/readyset:beta-latest
+    image: docker.io/readysettech/readyset:latest
     platform: linux/amd64
     expose:
       - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -1,7 +1,7 @@
 name: readyset
 services:
   cache:
-    image: "public.ecr.aws/readyset/readyset:beta-latest"
+    image: "docker.io/readysettech/readyset:latest"
     platform: linux/amd64
     expose:
       - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics


### PR DESCRIPTION
The Quickstart demo will now pull the readyset images from docker hub
instead of `public.ecr.aws`.

