### PR TITLE
readyset-server: controller->replicator channel

### DIFF
--- a/replicators/src/lib.rs
+++ b/replicators/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod table_filter;
 
 use std::time::Duration;
 
+use nom_sql::Relation;
 pub use noria_adapter::{cleanup, NoriaAdapter};
 use readyset_errors::ReadySetError;
 pub use replication_offset::mysql::MySqlPosition;
@@ -30,6 +31,12 @@ pub enum ReplicatorMessage {
     /// The replicator encountered an error that caused it to restart, but the error could be
     /// recoverable. The controller is notified so that it can update status for the user.
     RecoverableError(ReadySetError),
+}
+
+/// Event notification sent from the controller to the replicator
+pub enum ControllerMessage {
+    /// Drop the specified table and require a new partial snapshot
+    ResnapshotTable { table: Relation },
 }
 
 /// Provide a simplistic human-readable estimate for how much time remains to complete an operation


### PR DESCRIPTION
Added a new channel to exchange communication between controller->replicator.

The new ControllerMessage::ResnapshotTable is meant to propagate message informing the replicator the specific table has to be dropped and resnapshotted.

Next steps: 
1. Read the channel messages at noria_adapter.rs::main_loop and act accordingly
3. Send ControllerMessage::ResnapshotTable at [drop_snapshot_query](https://github.com/altmannmarcelo/readyset/blob/issue-456-parse/readyset-adapter/src/backend.rs#L1716)