### PR TITLE
nom-sql: Derive Arbitrary for the full AST

### DIFF
--- a/nom-sql/src/alter.rs
+++ b/nom-sql/src/alter.rs
@@ -14,6 +14,7 @@ use nom::sequence::{preceded, terminated};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::column::{column_specification, ColumnSpecification};
 use crate::common::{
@@ -26,7 +27,7 @@ use crate::table::{relation, Relation};
 use crate::whitespace::whitespace1;
 use crate::{Dialect, Literal, NomSqlResult, SqlIdentifier};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum AlterColumnOperation {
     SetColumnDefault(Literal),
     DropColumnDefault,
@@ -43,7 +44,7 @@ impl AlterColumnOperation {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum DropBehavior {
     Cascade,
     Restrict,
@@ -58,7 +59,7 @@ impl fmt::Display for DropBehavior {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ReplicaIdentity {
     Default,
     UsingIndex { index_name: SqlIdentifier },
@@ -77,7 +78,7 @@ impl Display for ReplicaIdentity {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum AlterTableDefinition {
     AddColumn(ColumnSpecification),
     AddKey(TableKey),
@@ -162,7 +163,7 @@ impl AlterTableDefinition {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct AlterTableStatement {
     pub table: Relation,
     /// The result of parsing the alter table definitions.

--- a/nom-sql/src/column.rs
+++ b/nom-sql/src/column.rs
@@ -83,7 +83,7 @@ impl Column {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ColumnConstraint {
     Null,
     NotNull,
@@ -120,7 +120,7 @@ impl ColumnConstraint {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct ColumnSpecification {
     pub column: Column,
     pub sql_type: SqlType,

--- a/nom-sql/src/comment.rs
+++ b/nom-sql/src/comment.rs
@@ -7,12 +7,13 @@ use nom::sequence::{delimited, terminated};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::statement_terminator;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{literal, Dialect, NomSqlResult, SqlIdentifier};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum CommentStatement {
     Column {
         column_name: SqlIdentifier,

--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -16,6 +16,7 @@ use nom::{IResult, InputLength, InputTake};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::column::Column;
 use crate::dialect::Dialect;
@@ -32,7 +33,7 @@ pub fn debug_print(tag: &str, i: &[u8]) {
 #[cfg(not(feature = "debug"))]
 pub fn debug_print(_tag: &str, _i: &[u8]) {}
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum IndexType {
     BTree,
     Hash,
@@ -47,7 +48,7 @@ impl Display for IndexType {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ReferentialAction {
     Cascade,
     SetNull,
@@ -72,7 +73,7 @@ impl fmt::Display for ReferentialAction {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum TableKey {
     PrimaryKey {
         constraint_name: Option<SqlIdentifier>,
@@ -268,7 +269,7 @@ impl TableKey {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 #[allow(clippy::large_enum_variant)] // NOTE(aspen): do we actually care about this?
 #[derive(Default)]
 pub enum FieldDefinitionExpr {
@@ -330,7 +331,7 @@ pub enum Sign {
 
 /// A reference to a field in a query, usable in either the `GROUP BY` or `ORDER BY` clauses of the
 /// query
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub enum FieldReference {
     /// A reference to a field in the `SELECT` list by its (1-based) index.
     Numeric(u64),

--- a/nom-sql/src/compound_select.rs
+++ b/nom-sql/src/compound_select.rs
@@ -8,6 +8,7 @@ use nom::sequence::{delimited, preceded, tuple};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::{opt_delimited, terminated_with_statement_terminator};
 use crate::order::{order_clause, OrderClause};
@@ -15,7 +16,7 @@ use crate::select::{limit_offset_clause, nested_selection, LimitClause, SelectSt
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, NomSqlResult};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, Arbitrary)]
 pub enum CompoundSelectOperator {
     Union,
     DistinctUnion,
@@ -34,7 +35,7 @@ impl fmt::Display for CompoundSelectOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, Arbitrary)]
 pub struct CompoundSelectStatement {
     pub selects: Vec<(Option<CompoundSelectOperator>, SelectStatement)>,
     pub order: Option<OrderClause>,

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -13,6 +13,7 @@ use nom::sequence::{delimited, preceded, terminated, tuple};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::column::{column_specification, Column, ColumnSpecification};
 use crate::common::{
@@ -28,7 +29,7 @@ use crate::table::{relation, Relation};
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, NomSqlError, NomSqlResult, SqlIdentifier};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CreateTableBody {
     pub fields: Vec<ColumnSpecification>,
     pub keys: Option<Vec<TableKey>>,
@@ -55,7 +56,7 @@ impl CreateTableBody {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CreateTableStatement {
     pub if_not_exists: bool,
     pub table: Relation,
@@ -135,7 +136,7 @@ impl CreateTableStatement {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 #[allow(clippy::large_enum_variant)] // TODO: maybe this actually matters
 pub enum SelectSpecification {
     Compound(CompoundSelectStatement),
@@ -151,7 +152,7 @@ impl SelectSpecification {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CreateViewStatement {
     pub name: Relation,
     pub or_replace: bool,
@@ -189,7 +190,7 @@ impl CreateViewStatement {
 }
 
 /// The SelectStatement or query ID referenced in a [`CreateCacheStatement`]
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, From)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, From, Arbitrary)]
 pub enum CacheInner {
     Statement(Box<SelectStatement>),
     Id(SqlIdentifier),
@@ -214,7 +215,7 @@ struct CreateCacheOptions {
 /// `CREATE CACHE [CONCURRENTLY] [ALWAYS] [<name>] FROM ...`
 ///
 /// This is a non-standard ReadySet specific extension to SQL
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CreateCacheStatement {
     pub name: Option<Relation>,
     /// The result of parsing the inner statement or query ID for the `CREATE CACHE` statement.

--- a/nom-sql/src/create_table_options.rs
+++ b/nom-sql/src/create_table_options.rs
@@ -10,13 +10,14 @@ use nom::multi::separated_list0;
 use nom::sequence::{separated_pair, tuple};
 use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::{ws_sep_comma, ws_sep_equals};
 use crate::literal::integer_literal;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, Literal, NomSqlResult, SqlIdentifier};
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Arbitrary)]
 pub enum CharsetName {
     Quoted(SqlIdentifier),
     Unquoted(SqlIdentifier),
@@ -30,7 +31,7 @@ impl fmt::Display for CharsetName {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Arbitrary)]
 pub enum CollationName {
     Quoted(SqlIdentifier),
     Unquoted(SqlIdentifier),
@@ -44,7 +45,7 @@ impl fmt::Display for CollationName {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Arbitrary)]
 pub enum CreateTableOption {
     AutoIncrement(u64),
     Engine(Option<String>),

--- a/nom-sql/src/delete.rs
+++ b/nom-sql/src/delete.rs
@@ -6,6 +6,7 @@ use nom::sequence::{delimited, tuple};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::statement_terminator;
 use crate::select::where_clause;
@@ -13,7 +14,7 @@ use crate::table::{relation, Relation};
 use crate::whitespace::whitespace1;
 use crate::{Dialect, Expr, NomSqlResult};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DeleteStatement {
     pub table: Relation,
     pub where_clause: Option<Expr>,

--- a/nom-sql/src/drop.rs
+++ b/nom-sql/src/drop.rs
@@ -9,6 +9,7 @@ use nom::sequence::preceded;
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::{statement_terminator, ws_sep_comma};
 use crate::table::{relation, table_list, Relation};
@@ -33,7 +34,7 @@ fn restrict_cascade(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], (bool, bool)> 
     Ok((i, (restrict.is_some(), cascade.is_some())))
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DropTableStatement {
     pub tables: Vec<Relation>,
     pub if_exists: bool,
@@ -77,7 +78,7 @@ pub fn drop_table(
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DropCacheStatement {
     pub name: Relation,
 }
@@ -102,7 +103,7 @@ pub fn drop_cached_query(
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DropViewStatement {
     pub views: Vec<Relation>,
     pub if_exists: bool,
@@ -143,7 +144,7 @@ pub fn drop_view(
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DropAllCachesStatement {}
 
 impl Display for DropAllCachesStatement {

--- a/nom-sql/src/explain.rs
+++ b/nom-sql/src/explain.rs
@@ -6,6 +6,7 @@ use nom::combinator::{opt, value};
 use nom::sequence::{terminated, tuple};
 use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::statement_terminator;
 use crate::whitespace::whitespace1;
@@ -14,7 +15,7 @@ use crate::NomSqlResult;
 /// EXPLAIN statements
 ///
 /// This is a non-standard ReadySet-specific extension to SQL
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ExplainStatement {
     /// Print a (maybe simplified) graphviz representation of the current query graph to stdout
     Graphviz { simplified: bool },

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -28,7 +28,7 @@ use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Column, Dialect, Literal, NomSqlResult, SelectStatement, SqlIdentifier, SqlType};
 
 /// Function call expressions
-#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize, Arbitrary)]
 pub enum FunctionExpr {
     /// `AVG` aggregation. The boolean argument is `true` if `DISTINCT`
     Avg { expr: Box<Expr>, distinct: bool },
@@ -351,7 +351,9 @@ impl Display for UnaryOperator {
 }
 
 /// Right-hand side of IN
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From, Arbitrary,
+)]
 pub enum InValue {
     Subquery(Box<SelectStatement>),
     List(Vec<Expr>),
@@ -371,7 +373,9 @@ impl InValue {
 }
 
 /// A single branch of a `CASE WHEN` statement
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From)]
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize, From, Arbitrary,
+)]
 pub struct CaseWhenBranch {
     pub condition: Expr,
     pub body: Expr,

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -625,7 +625,7 @@ impl Expr {
                 }
                 write!(f, ")")
             }
-            Expr::Variable(var) => write!(f, "{}", var),
+            Expr::Variable(var) => write!(f, "{}", var.display(dialect)),
         })
     }
 }

--- a/nom-sql/src/insert.rs
+++ b/nom-sql/src/insert.rs
@@ -8,6 +8,7 @@ use nom::sequence::{delimited, preceded, terminated, tuple};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::column::Column;
 use crate::common::{
@@ -17,7 +18,7 @@ use crate::table::{relation, Relation};
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, Expr, NomSqlResult};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct InsertStatement {
     pub table: Relation,
     pub fields: Option<Vec<Column>>,

--- a/nom-sql/src/join.rs
+++ b/nom-sql/src/join.rs
@@ -12,7 +12,7 @@ use test_strategy::Arbitrary;
 use crate::column::Column;
 use crate::{Dialect, Expr, NomSqlResult, TableExpr};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub enum JoinRightSide {
     /// A single table expression.
     Table(TableExpr),
@@ -77,7 +77,7 @@ impl fmt::Display for JoinOperator {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub enum JoinConstraint {
     On(Expr),
     Using(Vec<Column>),

--- a/nom-sql/src/order.rs
+++ b/nom-sql/src/order.rs
@@ -45,7 +45,7 @@ impl fmt::Display for OrderType {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub struct OrderClause {
     pub order_by: Vec<(FieldReference, Option<OrderType>)>,
 }

--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -6,6 +6,7 @@ use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use readyset_util::redacted::Sensitive;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::alter::{alter_table_statement, AlterTableStatement};
 use crate::comment::{comment, CommentStatement};
@@ -37,7 +38,7 @@ use crate::use_statement::{use_statement, UseStatement};
 use crate::whitespace::whitespace0;
 use crate::{Dialect, DropAllCachesStatement, Expr, NomSqlResult, SqlType, TableKey};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 #[allow(clippy::large_enum_variant)]
 pub enum SqlQuery {
     CreateTable(CreateTableStatement),

--- a/nom-sql/src/rename.rs
+++ b/nom-sql/src/rename.rs
@@ -7,13 +7,14 @@ use nom::multi::separated_list1;
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::ws_sep_comma;
 use crate::table::{relation, Relation};
 use crate::whitespace::whitespace1;
 use crate::{Dialect, NomSqlResult};
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct RenameTableStatement {
     pub ops: Vec<RenameTableOperation>,
 }
@@ -43,7 +44,7 @@ pub fn rename_table(
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct RenameTableOperation {
     pub from: Relation,
     pub to: Relation,

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -10,6 +10,7 @@ use nom::sequence::{delimited, preceded, terminated, tuple};
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::{
     field_definition_expr, field_list, field_reference_list, terminated_with_statement_terminator,
@@ -26,7 +27,9 @@ use crate::{
     TableExpr,
 };
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Default, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Default, Serialize, Deserialize, Arbitrary,
+)]
 pub struct GroupByClause {
     pub fields: Vec<FieldReference>,
 }
@@ -46,7 +49,7 @@ impl GroupByClause {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub struct JoinClause {
     pub operator: JoinOperator,
     pub right: JoinRightSide,
@@ -67,7 +70,9 @@ impl JoinClause {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
+)]
 pub struct CommonTableExpr {
     pub name: SqlIdentifier,
     pub statement: SelectStatement,
@@ -87,7 +92,7 @@ impl CommonTableExpr {
 }
 
 /// AST representation of the SQL limit and offset clauses.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub enum LimitClause {
     /// The standard limit and offset syntax: `LIMIT <limit> OFFSET <offset>`.
     LimitOffset {
@@ -174,7 +179,9 @@ impl LimitClause {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
+)]
 pub struct SelectStatement {
     pub ctes: Vec<CommonTableExpr>,
     pub distinct: bool,

--- a/nom-sql/src/set.rs
+++ b/nom-sql/src/set.rs
@@ -19,7 +19,7 @@ use crate::literal::literal;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, Expr, Literal, NomSqlError, NomSqlResult, SqlIdentifier};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum SetStatement {
     Variable(SetVariables),
     Names(SetNames),
@@ -48,7 +48,7 @@ impl SetStatement {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum PostgresParameterScope {
     Session,
     Local,
@@ -70,7 +70,7 @@ fn postgres_parameter_scope(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], Postgr
     ))(i)
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum SetPostgresParameterValue {
     Default,
     Value(PostgresParameterValue),
@@ -97,7 +97,7 @@ fn set_postgres_parameter_value(
 }
 
 /// A *single* value which can be used as the value for a postgres parameter
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum PostgresParameterValueInner {
     Identifier(SqlIdentifier),
     Literal(Literal),
@@ -114,7 +114,7 @@ impl PostgresParameterValueInner {
 
 /// The value for a postgres parameter, which can either be an identifier, a literal, or a list of
 /// those
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum PostgresParameterValue {
     Single(PostgresParameterValueInner),
     List(Vec<PostgresParameterValueInner>),
@@ -240,7 +240,7 @@ pub struct Variable {
     pub name: SqlIdentifier,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct SetVariables {
     /// A list of variables and their assigned values
     pub variables: Vec<(Variable, Expr)>,
@@ -296,7 +296,7 @@ impl SetVariables {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct SetNames {
     pub charset: String,
     pub collation: Option<String>,
@@ -312,7 +312,7 @@ impl Display for SetNames {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct SetPostgresParameter {
     pub scope: Option<PostgresParameterScope>,
     pub name: SqlIdentifier,

--- a/nom-sql/src/show.rs
+++ b/nom-sql/src/show.rs
@@ -5,8 +5,12 @@ use nom::bytes::complete::tag_no_case;
 use nom::combinator::{map, map_res, opt, value};
 use nom::sequence::{preceded, tuple};
 use nom_locate::LocatedSpan;
+use prop::string::string_regex;
+use proptest::option;
+use proptest::prelude::prop;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::expression::expression;
 use crate::whitespace::{whitespace0, whitespace1};
@@ -14,7 +18,7 @@ use crate::{Dialect, Expr, NomSqlResult};
 
 pub type QueryID = String;
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ShowStatement {
     Events,
     Tables(Tables),
@@ -83,8 +87,9 @@ fn cached_queries(
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct ProxiedQueriesOptions {
+    #[strategy(option::of(string_regex("q_{a-z}{16}").unwrap()))]
     pub query_id: Option<String>,
     pub only_supported: bool,
 }
@@ -150,7 +155,7 @@ pub fn show(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct Tables {
     pub full: bool,
     pub from_db: Option<String>,
@@ -202,7 +207,7 @@ fn show_tables(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum FilterPredicate {
     Like(String),
     Where(Expr),

--- a/nom-sql/src/table.rs
+++ b/nom-sql/src/table.rs
@@ -96,7 +96,7 @@ impl Relation {
 }
 
 /// An expression for a table in a query
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Arbitrary)]
 pub enum TableExprInner {
     Table(Relation),
     Subquery(Box<SelectStatement>),
@@ -128,7 +128,7 @@ impl TableExprInner {
 }
 
 /// An expression for a table in the `FROM` clause of a query, with optional alias
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Arbitrary)]
 pub struct TableExpr {
     pub inner: TableExprInner,
     pub alias: Option<SqlIdentifier>,

--- a/nom-sql/src/transaction.rs
+++ b/nom-sql/src/transaction.rs
@@ -6,13 +6,14 @@ use nom::combinator::{map, opt};
 use nom::sequence::tuple;
 use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::common::statement_terminator;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, NomSqlResult};
 
 // TODO(peter): Handle dialect differences.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum StartTransactionStatement {
     // TODO(ENG-2992): Implement optional fields for START TRANSACTION
     Start,
@@ -28,7 +29,7 @@ impl fmt::Display for StartTransactionStatement {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CommitStatement;
 
 impl fmt::Display for CommitStatement {
@@ -37,7 +38,7 @@ impl fmt::Display for CommitStatement {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct RollbackStatement;
 
 impl fmt::Display for RollbackStatement {

--- a/nom-sql/src/update.rs
+++ b/nom-sql/src/update.rs
@@ -7,6 +7,7 @@ use nom::sequence::tuple;
 use nom_locate::LocatedSpan;
 use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::column::Column;
 use crate::common::{assignment_expr_list, statement_terminator};
@@ -15,7 +16,7 @@ use crate::table::{relation, Relation};
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{Dialect, Expr, NomSqlResult};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct UpdateStatement {
     pub table: Relation,
     pub fields: Vec<(Column, Expr)>,

--- a/nom-sql/src/use_statement.rs
+++ b/nom-sql/src/use_statement.rs
@@ -3,11 +3,12 @@ use std::fmt;
 use nom::bytes::complete::tag_no_case;
 use nom_locate::LocatedSpan;
 use serde::{Deserialize, Serialize};
+use test_strategy::Arbitrary;
 
 use crate::whitespace::whitespace1;
 use crate::{Dialect, NomSqlResult, SqlIdentifier};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct UseStatement {
     pub database: SqlIdentifier,
 }


### PR DESCRIPTION
Derive Arbitrary using test_strategy::Arbitrary for all structs in the
full nom-sql AST, all the way down from SqlQuery. This will allow
writing proptests on the full AST.

Co-Authored-By: Luke Osborne <luke@readyset.io>
