### PR TITLE
nom-sql: Simplify SqlIdentifer Arbitrary

### DIFF
--- a/nom-sql/src/sql_identifier.rs
+++ b/nom-sql/src/sql_identifier.rs
@@ -405,10 +405,14 @@ impl Arbitrary for SqlIdentifier {
     type Strategy = proptest::strategy::BoxedStrategy<SqlIdentifier>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::arbitrary::any;
         use proptest::prelude::*;
 
-        any::<String>().prop_map(Into::into).boxed()
+        // This is the full set allowed by Postgres sans `$` (which isn't valid per the SQL
+        // standard), with a limited length
+        // "[\\p{L_}][\\p{L}_0-9]{1,62}".prop_map(Into::into).boxed()
+        //
+        // A simplified version
+        "[a-zA-Z_][a-zA-Z_0-9]{1,62}".prop_map(Into::into).boxed()
     }
 }
 


### PR DESCRIPTION
any<String>() causes invalid postgres identifers to be generated.

A regex attempting to match the postgres spec (left commented out in
this commit) is also currently failing, so use a fairly simple one for
now to deal with lower hanging fruit before tackling the more arcane
character possiblities.

