### PR TITLE
treewide: Add a description why a table cannot be replicated

### DIFF
--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -50,7 +50,10 @@ pub use self::set::{
 pub use self::show::ShowStatement;
 pub use self::sql_identifier::SqlIdentifier;
 pub use self::sql_type::{EnumVariants, SqlType, SqlTypeArbitraryOptions};
-pub use self::table::{replicator_table_list, Relation, TableExpr, TableExprInner};
+pub use self::table::{
+    replicator_table_list, NonReplicatedRelation, NotReplicatedReason, Relation, TableExpr,
+    TableExprInner,
+};
 pub use self::transaction::StartTransactionStatement;
 pub use self::update::UpdateStatement;
 pub use self::use_statement::UseStatement;

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use futures_util::future;
 use hyper::client::HttpConnector;
-use nom_sql::{CreateCacheStatement, Relation};
+use nom_sql::{CreateCacheStatement, NonReplicatedRelation, Relation};
 use parking_lot::RwLock;
 use petgraph::graph::NodeIndex;
 use readyset_errors::{
@@ -449,7 +449,9 @@ impl ReadySetHandle {
     /// recorded via [`Change::AddNonReplicatedRelation`]).
     ///
     /// [`Change::AddNonReplicatedRelation`]: readyset_client::recipe::changelist::Change::AddNonReplicatedRelation
-    pub async fn non_replicated_relations(&mut self) -> ReadySetResult<HashSet<Relation>> {
+    pub async fn non_replicated_relations(
+        &mut self,
+    ) -> ReadySetResult<HashSet<NonReplicatedRelation>> {
         self.simple_post_request("non_replicated_relations").await
     }
 

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -38,8 +38,8 @@ use dataflow_expression::Dialect;
 use nom_locate::LocatedSpan;
 use nom_sql::{
     AlterTableStatement, CacheInner, CreateCacheStatement, CreateTableStatement,
-    CreateViewStatement, DropTableStatement, DropViewStatement, Relation, SelectStatement,
-    SqlIdentifier, SqlQuery,
+    CreateViewStatement, DropTableStatement, DropViewStatement, NonReplicatedRelation, Relation,
+    SelectStatement, SqlIdentifier, SqlQuery,
 };
 use readyset_data::DfType;
 use readyset_errors::{internal, unsupported, ReadySetError, ReadySetResult};
@@ -359,7 +359,7 @@ pub enum Change {
     /// This is important both to have better error messages for queries that select from
     /// non-replicated relations, and to ensure we don't skip over these tables during schema
     /// resolution, resulting in queries that read from tables in the wrong schema.
-    AddNonReplicatedRelation(Relation),
+    AddNonReplicatedRelation(NonReplicatedRelation),
     /// Add a new view to the graph, represented by the given `CREATE VIEW` statement
     CreateView(CreateViewStatement),
     /// Add a new cached query to the graph

--- a/readyset-data/src/type.rs
+++ b/readyset-data/src/type.rs
@@ -306,8 +306,10 @@ impl DfType {
             MacAddr => Self::MacAddr,
             Inet => Self::Inet,
             Citext => Self::Text(Collation::Citext),
-            Other(ref id) => resolve_custom_type(id.clone())
-                .ok_or_else(|| unsupported_err!("Unsupported type: {}", id.display_unquoted()))?,
+            Other(ref id) => resolve_custom_type(id.clone()).ok_or_else(|| {
+                let id_upper = format!("{}", id.display_unquoted()).to_uppercase();
+                unsupported_err!("Unsupported type: {}", id_upper)
+            })?,
         })
     }
 }

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -31,7 +31,7 @@ use futures::stream::{self, FuturesUnordered, StreamExt, TryStreamExt};
 use futures::{FutureExt, TryFutureExt, TryStream};
 use lazy_static::lazy_static;
 use metrics::{gauge, histogram};
-use nom_sql::{CreateCacheStatement, Relation, SqlIdentifier, SqlQuery};
+use nom_sql::{CreateCacheStatement, NonReplicatedRelation, Relation, SqlIdentifier, SqlQuery};
 use petgraph::visit::Bfs;
 use rand::Rng;
 use readyset_client::builders::{
@@ -234,7 +234,7 @@ impl DfState {
     /// recorded via [`Change::AddNonReplicatedRelation`]).
     ///
     /// [`Change::AddNonReplicatedRelation`]: readyset_client::recipe::changelist::Change::AddNonReplicatedRelation
-    pub(super) fn non_replicated_relations(&self) -> &HashSet<Relation> {
+    pub(super) fn non_replicated_relations(&self) -> &HashSet<NonReplicatedRelation> {
         self.recipe.sql_inc().non_replicated_relations()
     }
 
@@ -919,9 +919,9 @@ impl DfState {
             })
             .chain(non_replicated_relations.iter().cloned().map(|tbl| {
                 (
-                    tbl,
+                    tbl.name,
                     TableStatus {
-                        replication_status: TableReplicationStatus::NotReplicated,
+                        replication_status: TableReplicationStatus::NotReplicated(tbl.reason),
                     },
                 )
             }))

--- a/readyset-sql-passes/src/lib.rs
+++ b/readyset-sql-passes/src/lib.rs
@@ -31,8 +31,8 @@ use std::collections::{HashMap, HashSet};
 use dataflow_expression::Dialect;
 pub use nom_sql::analysis::{contains_aggregate, is_aggregate};
 use nom_sql::{
-    CompoundSelectStatement, CreateTableBody, CreateTableStatement, CreateViewStatement, Relation,
-    SelectSpecification, SelectStatement, SqlIdentifier,
+    CompoundSelectStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
+    NonReplicatedRelation, Relation, SelectSpecification, SelectStatement, SqlIdentifier,
 };
 use readyset_errors::ReadySetResult;
 
@@ -75,7 +75,7 @@ pub struct RewriteContext<'a> {
     /// Set of relations that are known to exist in the upstream database, but are not being
     /// replicated. Used as part of schema resolution to ensure that queries that would resolve to
     /// these tables if they *were* being replicated correctly return an error
-    pub non_replicated_relations: &'a HashSet<Relation>,
+    pub non_replicated_relations: &'a HashSet<NonReplicatedRelation>,
 
     /// Map from schema name to the set of custom types in that schema
     pub custom_types: &'a HashMap<&'a SqlIdentifier, HashSet<&'a SqlIdentifier>>,
@@ -114,7 +114,7 @@ impl<'a> RewriteContext<'a> {
             .chain(
                 self.non_replicated_relations
                     .iter()
-                    .map(|t| (t, CanQuery::No)),
+                    .map(|t| (&(t.name), CanQuery::No)),
             )
             .fold(
                 HashMap::<&SqlIdentifier, HashMap<&SqlIdentifier, CanQuery>>::new(),

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -12,7 +12,7 @@ use metrics::register_gauge;
 use mysql::prelude::Queryable;
 use mysql::{Transaction, TxOpts};
 use mysql_async as mysql;
-use nom_sql::Relation;
+use nom_sql::{NonReplicatedRelation, NotReplicatedReason, Relation};
 use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::{Change, ChangeList};
 use readyset_data::Dialect;
@@ -177,9 +177,12 @@ impl MySqlReplicator {
                 non_replicated_tables
                     .into_iter()
                     .map(|(schema, name)| {
-                        Change::AddNonReplicatedRelation(Relation {
-                            schema: Some(schema.into()),
-                            name: name.into(),
+                        Change::AddNonReplicatedRelation(NonReplicatedRelation {
+                            name: Relation {
+                                schema: Some(schema.into()),
+                                name: name.into(),
+                            },
+                            reason: NotReplicatedReason::Configuration,
                         })
                     })
                     .collect::<Vec<_>>(),
@@ -230,9 +233,12 @@ impl MySqlReplicator {
 
                     noria
                         .extend_recipe_no_leader_ready(ChangeList::from_change(
-                            Change::AddNonReplicatedRelation(Relation {
-                                schema: Some(db.into()),
-                                name: table.into(),
+                            Change::AddNonReplicatedRelation(NonReplicatedRelation {
+                                name: Relation {
+                                    schema: Some(db.into()),
+                                    name: table.into(),
+                                },
+                                reason: NotReplicatedReason::Configuration,
                             }),
                             Dialect::DEFAULT_MYSQL,
                         ))
@@ -274,9 +280,12 @@ impl MySqlReplicator {
                     warn!(%view, %error, "Error extending CREATE VIEW, view will not be used");
                     noria
                         .extend_recipe_no_leader_ready(ChangeList::from_change(
-                            Change::AddNonReplicatedRelation(Relation {
-                                schema: Some(db.into()),
-                                name: view.into(),
+                            Change::AddNonReplicatedRelation(NonReplicatedRelation {
+                                name: Relation {
+                                    schema: Some(db.into()),
+                                    name: view.into(),
+                                },
+                                reason: NotReplicatedReason::Configuration,
                             }),
                             Dialect::DEFAULT_MYSQL,
                         ))


### PR DESCRIPTION
Updated the command "show readyset table" with a description column that
specifies why a particular table was not replicated.

