### PR TITLE
persistent-state: Add `wal_state`

### DIFF
--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -15,8 +15,8 @@ use tracing::trace;
 use crate::keyed_state::KeyedState;
 use crate::single_state::SingleState;
 use crate::{
-    AllRecords, EvictBytesResult, EvictKeysResult, EvictRandomResult, LookupResult, PointKey,
-    RangeKey, RangeLookupResult, RecordResult, Row, Rows, State,
+    AllRecords, EvictBytesResult, EvictKeysResult, EvictRandomResult, LookupResult,
+    PersistencePoint, PointKey, RangeKey, RangeLookupResult, RecordResult, Row, Rows, State,
 };
 
 #[derive(Default)]
@@ -395,6 +395,10 @@ impl State for MemoryState {
 
     fn replication_offset(&self) -> Option<&ReplicationOffset> {
         self.replication_offset.as_ref()
+    }
+
+    fn persisted_up_to(&self) -> PersistencePoint {
+        PersistencePoint::Persisted
     }
 
     fn add_weak_index(&mut self, index: Index) {


### PR DESCRIPTION
This commit adds a new `State::persisted_up_to` method that, in a future
commit, will expose the offset up to which data has been persisted for a
given base table. Eventually, the replicator will read this field from
the base table domains to determine the greatest offset it is able to ACK
upstream such that the upstream database doesn't purge WAL files that
contain data it would need to recover any unpersisted data after a crash.

This commit also adds a new `wal_state` to `SharedState` that will be used
to represent the state of the RocksDB WAL as it relates to flushing and
syncing data to disk. The `WalState` enum will eventually hold the
offsets up to which data has been flushed and persisted for the given
persistent state. Right now, the only possible state is
`FlushedAndPersisted` since we flush and sync the WAL with every write,
but when we add periodic WAL flushing in a future commit, more states
will be added.

Refs: REA-3434
