### PR TITLE
dataflow: Add min persisted offset RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5005,6 +5005,7 @@ dependencies = [
  "clap 4.3.2",
  "criterion",
  "database-utils",
+ "dataflow-state",
  "derive_more",
  "diff",
  "enum-kinds",

--- a/dataflow-state/src/lib.rs
+++ b/dataflow-state/src/lib.rs
@@ -22,10 +22,11 @@ use itertools::Either;
 pub use partial_map::PartialMap;
 use readyset_client::debug::info::KeyCount;
 use readyset_client::internal::Index;
-use readyset_client::KeyComparison;
+use readyset_client::{KeyComparison, PersistencePoint};
 use readyset_data::DfValue;
 use readyset_errors::ReadySetResult;
 use replication_offset::ReplicationOffset;
+use serde::{Deserialize, Serialize};
 
 pub use crate::key::{PointKey, RangeKey};
 pub use crate::memory_state::MemoryState;
@@ -72,12 +73,13 @@ pub enum MaterializedNodeState {
     PersistentReadHandle(PersistentStateHandle),
 }
 
-/// The point up to which data in a state has been persisted.
-pub enum PersistencePoint {
-    /// All of the data in this state has been persisted
-    Persisted,
-    /// The data in this state has been persisted up to this offset
-    UpTo(ReplicationOffset),
+/// Enum representing whether a base table node was already initialized (and has a replication
+/// offset assigned), or if it is still pending initialization. This type is used as a container
+/// for responses from base tables that will only return data if the base table is initialized.
+#[derive(Serialize, Deserialize)]
+pub enum BaseTableState<T> {
+    Initialized(T),
+    Pending,
 }
 
 /// The [`State`] trait is the interface to the state of a non-reader node in the graph, containing

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -31,7 +31,7 @@ use crate::metrics::MetricsDump;
 use crate::recipe::changelist::ChangeList;
 use crate::recipe::{ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
 use crate::status::ReadySetStatus;
-use crate::table::{Table, TableBuilder, TableRpc};
+use crate::table::{PersistencePoint, Table, TableBuilder, TableRpc};
 use crate::view::{View, ViewBuilder, ViewRpc};
 use crate::{
     ReplicationOffset, SingleKeyEviction, TableStatus, ViewCreateRequest, ViewFilter, ViewRequest,
@@ -887,8 +887,12 @@ impl ReadySetHandle {
     );
 
     simple_request!(
-        /// Get a list of all current tables node indexes that are involved in snapshotting.
-        snapshotting_tables() -> Vec<String>
+        /// Gets the minimum replication offset up to which data has been persisted across all the base
+        /// table nodes. If no base tables have unpersisted data, this method returns `None`.
+        ///
+        /// See [the documentation for PersistentState](::readyset_dataflow::state::persistent_state)
+        /// for more information about replication offsets.
+        min_persisted_replication_offset() -> PersistencePoint
     );
 
     /// Poll in a loop to wait for all tables to finish compacting

--- a/readyset-client/src/lib.rs
+++ b/readyset-client/src/lib.rs
@@ -353,8 +353,8 @@ use url::Url;
 pub use crate::consensus::WorkerDescriptor;
 pub use crate::controller::{ControllerDescriptor, GraphvizOptions, ReadySetHandle};
 pub use crate::table::{
-    Modification, Operation, PacketData, PacketPayload, PacketTrace, Table, TableOperation,
-    TableReplicationStatus, TableRequest, TableStatus,
+    Modification, Operation, PacketData, PacketPayload, PacketTrace, PersistencePoint, Table,
+    TableOperation, TableReplicationStatus, TableRequest, TableStatus,
 };
 pub use crate::view::{
     KeyComparison, LookupResult, ReadQuery, ReadReply, ReadReplyBatch, ReadReplyStats, SchemaType,

--- a/readyset-client/src/table.rs
+++ b/readyset-client/src/table.rs
@@ -1020,3 +1020,12 @@ impl Table {
         .await
     }
 }
+
+/// The point up to which data in a table has been persisted.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub enum PersistencePoint {
+    /// All of the data in this table has been persisted
+    Persisted,
+    /// The data in this table has been persisted up to this offset
+    UpTo(ReplicationOffset),
+}

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -14,8 +14,8 @@ use std::{cell, cmp, mem, process, time};
 use ahash::RandomState;
 use backoff::ExponentialBackoffBuilder;
 use dataflow_state::{
-    EvictBytesResult, EvictKeysResult, EvictRandomResult, MaterializedNodeState, PointKey,
-    RangeKey, RangeLookupResult,
+    BaseTableState, EvictBytesResult, EvictKeysResult, EvictRandomResult, MaterializedNodeState,
+    PointKey, RangeKey, RangeLookupResult,
 };
 use failpoint_macros::failpoint;
 use futures_util::future::FutureExt;
@@ -27,13 +27,13 @@ use petgraph::graph::NodeIndex;
 use readyset_alloc::StdThreadBuildWrapper;
 use readyset_client::debug::info::KeyCount;
 use readyset_client::internal::Index;
-use readyset_client::{channel, internal, KeyComparison, ReaderAddress};
+use readyset_client::{channel, internal, KeyComparison, PersistencePoint, ReaderAddress};
 use readyset_errors::{internal, internal_err, ReadySetError, ReadySetResult};
 use readyset_util::futures::abort_on_panic;
 use readyset_util::progress::report_progress_with;
 use readyset_util::redacted::Sensitive;
 use readyset_util::Indices;
-use replication_offset::ReplicationOffsetState;
+use replication_offset::ReplicationOffset;
 use serde::{Deserialize, Serialize};
 use timekeeper::{RealTime, SimpleTracker, ThreadTime, Timer, TimerSet};
 use tokio::sync::mpsc::Sender;
@@ -2273,6 +2273,9 @@ impl Domain {
                 self.update_state_sizes();
                 Ok(None)
             }
+            DomainRequest::RequestMinPersistedReplicationOffset => Ok(Some(bincode::serialize(
+                &self.min_persisted_replication_offset()?,
+            )?)),
             DomainRequest::RequestReplicationOffsets => {
                 Ok(Some(bincode::serialize(&self.replication_offsets())?))
             }
@@ -4357,7 +4360,36 @@ impl Domain {
             .sum()
     }
 
-    pub fn replication_offsets(&self) -> NodeMap<ReplicationOffsetState> {
+    pub fn min_persisted_replication_offset(
+        &self,
+    ) -> ReadySetResult<BaseTableState<PersistencePoint>> {
+        let mut cur_min = PersistencePoint::Persisted;
+
+        for (idx, n) in self.nodes.iter() {
+            let node = n.borrow();
+            if node.is_base() && !node.is_dropped() {
+                if let Some(state) = self.state.get(idx) {
+                    match (&mut cur_min, state.persisted_up_to()) {
+                        (_, PersistencePoint::Persisted) => continue,
+                        (PersistencePoint::Persisted, PersistencePoint::UpTo(offset)) => {
+                            cur_min = PersistencePoint::UpTo(offset);
+                        }
+                        (PersistencePoint::UpTo(min), PersistencePoint::UpTo(offset)) => {
+                            if offset.try_partial_cmp(min)?.is_lt() {
+                                cur_min = PersistencePoint::UpTo(offset);
+                            }
+                        }
+                    }
+                } else {
+                    return Ok(BaseTableState::Pending);
+                }
+            }
+        }
+
+        Ok(BaseTableState::Initialized(cur_min))
+    }
+
+    pub fn replication_offsets(&self) -> NodeMap<BaseTableState<Option<ReplicationOffset>>> {
         self.nodes
             .iter()
             .filter_map(|(idx, n)| {
@@ -4369,10 +4401,8 @@ impl Domain {
                         idx,
                         self.state
                             .get(idx)
-                            .map(|s| {
-                                ReplicationOffsetState::Initialized(s.replication_offset().cloned())
-                            })
-                            .unwrap_or(ReplicationOffsetState::Pending),
+                            .map(|s| BaseTableState::Initialized(s.replication_offset().cloned()))
+                            .unwrap_or(BaseTableState::Pending),
                     ))
                 }
             })

--- a/readyset-dataflow/src/lib.rs
+++ b/readyset-dataflow/src/lib.rs
@@ -60,7 +60,7 @@ pub use dataflow_expression::{
     PostLookupAggregateFunction, PostLookupAggregates, ReaderProcessing,
 };
 pub use dataflow_state::{
-    DurabilityMode, MaterializedNodeState, PersistenceParameters, PersistentState,
+    BaseTableState, DurabilityMode, MaterializedNodeState, PersistenceParameters, PersistentState,
 };
 
 pub use crate::domain::{Domain, DomainBuilder, DomainIndex};

--- a/readyset-dataflow/src/payload.rs
+++ b/readyset-dataflow/src/payload.rs
@@ -394,6 +394,10 @@ pub enum DomainRequest {
         index: HashSet<Index>,
     },
 
+    /// Request the minimum offset up to which data has been persisted across all of the base
+    /// tables in the domain
+    RequestMinPersistedReplicationOffset,
+
     /// Request a map of all replication offsets of the base table nodes in the domain
     RequestReplicationOffsets,
 

--- a/readyset-server/Cargo.toml
+++ b/readyset-server/Cargo.toml
@@ -79,6 +79,7 @@ strawpoll = "0.2.2"
 
 # local deps
 dataflow = { path = "../readyset-dataflow", package = "readyset-dataflow" }
+dataflow-state = { path = "../dataflow-state" }
 mir = { path = "../readyset-mir", package = "readyset-mir" }
 common = { path = "../readyset-common", package = "readyset-common" }
 readyset-alloc = { path = "../readyset-alloc" }

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -449,6 +449,13 @@ impl Leader {
                 let ds = self.dataflow_state_handle.read().await;
                 return_serialized!(ds.get_info()?)
             }
+            (&Method::POST, "/min_persisted_replication_offset") => {
+                let res = {
+                    let ds = self.dataflow_state_handle.read().await;
+                    ds.min_persisted_replication_offset().await
+                }?;
+                return_serialized!(res);
+            }
             (&Method::POST, "/replication_offsets") => {
                 let res = {
                     let ds = self.dataflow_state_handle.read().await;

--- a/replication-offset/src/lib.rs
+++ b/replication-offset/src/lib.rs
@@ -15,14 +15,6 @@ use postgres::PostgresPosition;
 use readyset_errors::{internal_err, ReadySetError, ReadySetResult};
 use serde::{Deserialize, Serialize};
 
-/// Enum representing whether a base table node was already initialized (and has a replication
-/// offset assigned), or if it is still pending initialization.
-#[derive(Serialize, Deserialize)]
-pub enum ReplicationOffsetState {
-    Initialized(Option<ReplicationOffset>),
-    Pending,
-}
-
 /// A data type representing an offset in a replication log
 ///
 /// Replication offsets are represented by a single global [offset](ReplicationOffset::offset),


### PR DESCRIPTION
This commit adds a `/min_persisted_replication_offset` controller RPC
that queries each base table domain for the replication offset up to
which the table has persisted data to disk, computes the minimum of
those, and returns the result. Eventually, this offset will be used by
the replicator to determine the greatest offset it can ACK upstream such
that the upstream database doesn't purge any WAL files it would need to
replay events after a crash.

Refs: REA-3434
