### PR TITLE
replicators: ACK min `persisted_up_to`

### DIFF
--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -887,8 +887,9 @@ impl ReadySetHandle {
     );
 
     simple_request!(
-        /// Gets the minimum replication offset up to which data has been persisted across all the base
-        /// table nodes. If no base tables have unpersisted data, this method returns `None`.
+        /// Each base table has an offset up to which data has been persisted to disk, and this
+        /// method returns the minimum of those offsets. If no base tables have unpersisted data,
+        /// this method returns `PersistencePoint::Persisted`.
         ///
         /// See [the documentation for PersistentState](::readyset_dataflow::state::persistent_state)
         /// for more information about replication offsets.

--- a/readyset-dataflow/src/payload.rs
+++ b/readyset-dataflow/src/payload.rs
@@ -394,8 +394,8 @@ pub enum DomainRequest {
         index: HashSet<Index>,
     },
 
-    /// Request the minimum offset up to which data has been persisted across all of the base
-    /// tables in the domain
+    /// Each base table has an offset up to which data has been persisted to disk, and this
+    /// request type requests the minimum of those offsets for the base tables in the domain
     RequestMinPersistedReplicationOffset,
 
     /// Request a map of all replication offsets of the base table nodes in the domain

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -835,8 +835,9 @@ impl DfState {
             .buffer_unordered(CONCURRENT_REQUESTS)
     }
 
-    /// Returns the minimum replication offset up to which data has been persisted across every base
-    /// table. If no unpersisted data exists in any base tables, it returns `None`.
+    /// Each base table has an offset up to which data has been persisted to disk, and this
+    /// method returns the minimum of those offsets. If no base tables have unpersisted data,
+    /// this method returns `PersistencePoint::Persisted`.
     ///
     /// See [the documentation for PersistentState](::readyset_dataflow::state::persistent_state)
     /// for more information about replication offsets.

--- a/replication-offset/src/postgres.rs
+++ b/replication-offset/src/postgres.rs
@@ -87,10 +87,10 @@ impl Add<i64> for Lsn {
     }
 }
 
-impl TryFrom<ReplicationOffset> for Lsn {
+impl TryFrom<&ReplicationOffset> for Lsn {
     type Error = ReadySetError;
 
-    fn try_from(offset: ReplicationOffset) -> Result<Self, Self::Error> {
+    fn try_from(offset: &ReplicationOffset) -> Result<Self, Self::Error> {
         Ok(PostgresPosition::try_from(offset)?.lsn)
     }
 }

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -517,7 +517,6 @@ impl NoriaAdapter {
         let replication_offsets = noria.replication_offsets().await?;
         let pos = replication_offsets
             .max_offset()?
-            .map(Clone::clone)
             .map(TryInto::try_into)
             .transpose()?;
         let snapshot_report_interval_secs = config.snapshot_report_interval_secs;
@@ -561,6 +560,7 @@ impl NoriaAdapter {
                 &repl_slot_name,
                 enable_statement_logging,
                 full_resnapshot,
+                noria.clone(),
             )
             .await?,
         );


### PR DESCRIPTION
This commit has the Postgres replicator query the controller for the
minimum persisted replication offset whenever it needs to send a status
update upstream. If this value is present, it ACKs it upstream to tell
the upstream database that we've persisted all the data up to that
point; otherwise, it ACKs its current position.

Refs: REA-3434
