### PR TITLE
state: Propagate WAL flush errors upwards

### DIFF
--- a/dataflow-state/src/lib.rs
+++ b/dataflow-state/src/lib.rs
@@ -152,7 +152,7 @@ pub trait State: SizeOf + Send {
     ///
     /// See [the documentation for PersistentState](::readyset_dataflow::state::persistent_state)
     /// for more information about replication offsets.
-    fn persisted_up_to(&self) -> PersistencePoint;
+    fn persisted_up_to(&self) -> ReadySetResult<PersistencePoint>;
 
     /// Mark the given `key` as a *filled hole* in the given partial `tag`, causing all lookups to
     /// that key to return an empty non-miss result, and all writes to that key to not be dropped.
@@ -363,7 +363,7 @@ impl State for MaterializedNodeState {
         }
     }
 
-    fn persisted_up_to(&self) -> PersistencePoint {
+    fn persisted_up_to(&self) -> ReadySetResult<PersistencePoint> {
         match self {
             MaterializedNodeState::Memory(ms) => ms.persisted_up_to(),
             MaterializedNodeState::Persistent(ps) => ps.persisted_up_to(),

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -397,8 +397,8 @@ impl State for MemoryState {
         self.replication_offset.as_ref()
     }
 
-    fn persisted_up_to(&self) -> PersistencePoint {
-        PersistencePoint::Persisted
+    fn persisted_up_to(&self) -> ReadySetResult<PersistencePoint> {
+        Ok(PersistencePoint::Persisted)
     }
 
     fn add_weak_index(&mut self, index: Index) {

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -4369,7 +4369,7 @@ impl Domain {
             let node = n.borrow();
             if node.is_base() && !node.is_dropped() {
                 if let Some(state) = self.state.get(idx) {
-                    match (&mut cur_min, state.persisted_up_to()) {
+                    match (&mut cur_min, state.persisted_up_to()?) {
                         (_, PersistencePoint::Persisted) => continue,
                         (PersistencePoint::Persisted, PersistencePoint::UpTo(offset)) => {
                             cur_min = PersistencePoint::UpTo(offset);


### PR DESCRIPTION
This commit adds the ability for the WAL flush background thread for
persistent state to report errors upwards to the replicator by setting a
new `last_wal_flush_error` field on `SharedState`. This field is read
when the replicator queries for the "min persisted up to" offset, and if
an error is present, it is returned by the controller RPC. Upon
receiving this error, the replicator enters its retry loop, sleeping for
a brief period before reconnecting to the upstream database and
re-initializing replication.

Note that there is no change in behavior here from the previous state of
the world. Before we introduced background WAL flushing, errors that
occurred during the flushing/syncing of the WAL happened *in the write
path*, which means that the table RPCs sent by the replicator would
fail. This resulted in the same retry logic as is introduced in this
commit. In the future, way may want to do something more sophisticated,
such as parsing the error description we get from RocksDB to try to
understand why the flush/sync failed.

Refs: REA-3434
