### PR TITLE
nom-sql: Add support for parsing EXPLAIN MATERIALIZATIONS

### DIFF
--- a/nom-sql/src/explain.rs
+++ b/nom-sql/src/explain.rs
@@ -26,6 +26,8 @@ pub enum ExplainStatement {
     /// List all CREATE CACHE statements that have been executed, for the
     /// purpose of exporting them
     Caches,
+    /// List and give information about all materializations in the graph
+    Materializations,
 }
 
 impl Display for ExplainStatement {
@@ -41,6 +43,7 @@ impl Display for ExplainStatement {
             ExplainStatement::LastStatement => write!(f, "LAST STATEMENT;"),
             ExplainStatement::Domains => write!(f, "DOMAINS;"),
             ExplainStatement::Caches => write!(f, "CACHES;"),
+            ExplainStatement::Materializations => write!(f, "MATERIALIZATIONS;"),
         }
     }
 }
@@ -67,6 +70,10 @@ pub(crate) fn explain_statement(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], Ex
         ),
         value(ExplainStatement::Domains, tag_no_case("domains")),
         value(ExplainStatement::Caches, tag_no_case("caches")),
+        value(
+            ExplainStatement::Materializations,
+            tag_no_case("materializations"),
+        ),
     ))(i)?;
     let (i, _) = statement_terminator(i)?;
     Ok((i, stmt))
@@ -110,5 +117,13 @@ mod tests {
             test_parse!(explain_statement, b"explain caches;"),
             ExplainStatement::Caches
         )
+    }
+
+    #[test]
+    fn explain_materializations() {
+        assert_eq!(
+            test_parse!(explain_statement, b"explain   mAtERIaLIZAtIOns"),
+            ExplainStatement::Materializations
+        );
     }
 }

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1917,6 +1917,11 @@ where
                 self.noria.explain_domains().await
             }
             SqlQuery::Explain(nom_sql::ExplainStatement::Caches) => self.explain_caches().await,
+            SqlQuery::Explain(nom_sql::ExplainStatement::Materializations) => {
+                return Some(Err(unsupported_err!(
+                    "EXPLAIN MATERIALIZATIONS not implemented yet"
+                )))
+            }
             SqlQuery::CreateCache(CreateCacheStatement {
                 name,
                 inner,

--- a/replicators/src/lib.rs
+++ b/replicators/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod table_filter;
 
 use std::time::Duration;
 
+use nom_sql::Relation;
 pub use noria_adapter::{cleanup, NoriaAdapter};
 use readyset_errors::ReadySetError;
 pub use replication_offset::mysql::MySqlPosition;
@@ -30,6 +31,12 @@ pub enum ReplicatorMessage {
     /// The replicator encountered an error that caused it to restart, but the error could be
     /// recoverable. The controller is notified so that it can update status for the user.
     RecoverableError(ReadySetError),
+}
+
+/// Event notification sent from the controller to the replicator
+pub enum ControllerMessage {
+    /// Drop the specified table and require a new partial snapshot
+    ResnapshotTable { table: Relation },
 }
 
 /// Provide a simplistic human-readable estimate for how much time remains to complete an operation

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -23,7 +23,7 @@ use readyset_errors::{internal_err, set_failpoint_return_err, ReadySetError, Rea
 use readyset_telemetry_reporter::{TelemetryBuilder, TelemetryEvent, TelemetrySender};
 use readyset_util::select;
 use replication_offset::{ReplicationOffset, ReplicationOffsets};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, info, info_span, trace, warn, Instrument};
 use {mysql_async as mysql, tokio_postgres as pgsql};
 
@@ -34,7 +34,7 @@ use crate::postgres_connector::{
     PostgresWalConnector, PUBLICATION_NAME, REPLICATION_SLOT,
 };
 use crate::table_filter::TableFilter;
-use crate::ReplicatorMessage;
+use crate::{ControllerMessage, ReplicatorMessage};
 
 /// Time to wait for requests to coalesce between snapshotting. Useful for preventing a series of
 /// DDL changes from thrashing snapshotting
@@ -163,6 +163,7 @@ impl NoriaAdapter {
         noria: ReadySetHandle,
         mut config: UpstreamConfig,
         notification_channel: &UnboundedSender<ReplicatorMessage>,
+        controller_channel: &UnboundedReceiver<ControllerMessage>,
         telemetry_sender: TelemetrySender,
         server_startup: bool,
         enable_statement_logging: bool,
@@ -191,6 +192,7 @@ impl NoriaAdapter {
                     noria,
                     config,
                     notification_channel,
+                    controller_channel,
                     resnapshot,
                     &telemetry_sender,
                     enable_statement_logging,
@@ -231,6 +233,7 @@ impl NoriaAdapter {
                     noria,
                     config,
                     notification_channel,
+                    controller_channel,
                     resnapshot,
                     full_snapshot,
                     &telemetry_sender,
@@ -280,6 +283,7 @@ impl NoriaAdapter {
         mut noria: ReadySetHandle,
         mut config: UpstreamConfig,
         notification_channel: &UnboundedSender<ReplicatorMessage>,
+        controller_channel: &UnboundedReceiver<ControllerMessage>,
         resnapshot: bool,
         telemetry_sender: &TelemetrySender,
         enable_statement_logging: bool,
@@ -447,7 +451,12 @@ impl NoriaAdapter {
                 info!(start = %current_pos, end = %max, "Catching up");
                 let max = max.clone();
                 adapter
-                    .main_loop(&mut current_pos, Some(max), notification_channel)
+                    .main_loop(
+                        &mut current_pos,
+                        Some(max),
+                        notification_channel,
+                        controller_channel,
+                    )
                     .await?;
             }
             _ => {}
@@ -461,7 +470,12 @@ impl NoriaAdapter {
         let _ = notification_channel.send(ReplicatorMessage::SnapshotDone);
 
         adapter
-            .main_loop(&mut current_pos, None, notification_channel)
+            .main_loop(
+                &mut current_pos,
+                None,
+                notification_channel,
+                controller_channel,
+            )
             .await?;
 
         unreachable!("`main_loop` will never stop with an Ok status if `until = None`");
@@ -473,6 +487,7 @@ impl NoriaAdapter {
         mut noria: ReadySetHandle,
         mut config: UpstreamConfig,
         notification_channel: &UnboundedSender<ReplicatorMessage>,
+        controller_channel: &UnboundedReceiver<ControllerMessage>,
         resnapshot: bool,
         full_resnapshot: bool,
         telemetry_sender: &TelemetrySender,
@@ -676,7 +691,12 @@ impl NoriaAdapter {
         if min_pos != max_pos {
             info!(start = %min_pos, end = %max_pos, "Catching up");
             adapter
-                .main_loop(&mut min_pos, Some(max_pos), notification_channel)
+                .main_loop(
+                    &mut min_pos,
+                    Some(max_pos),
+                    notification_channel,
+                    controller_channel,
+                )
                 .await?;
         }
 
@@ -687,7 +707,7 @@ impl NoriaAdapter {
         info!("Streaming replication started");
 
         adapter
-            .main_loop(&mut min_pos, None, notification_channel)
+            .main_loop(&mut min_pos, None, notification_channel, controller_channel)
             .await?;
 
         unreachable!("`main_loop` will never stop with an Ok status if `until = None`");
@@ -965,6 +985,7 @@ impl NoriaAdapter {
         position: &mut ReplicationOffset,
         until: Option<ReplicationOffset>,
         notification_channel: &UnboundedSender<ReplicatorMessage>,
+        _controller_channel: &UnboundedReceiver<ControllerMessage>,
     ) -> ReadySetResult<()> {
         // Notify the controller that we've started replication if we've entered the main (not
         // catchup) replication loop.


### PR DESCRIPTION
Add support for parsing a new EXPLAIN MATERIALIZATIONS statement to
nom-sql, left unsupported in the adapter.

Refs: REA-3517
