### PR TITLE
readyset-client: Implement removal of stored caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2795,9 +2795,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memmap"
@@ -4494,6 +4494,7 @@ dependencies = [
  "readyset-sql-passes",
  "readyset-tracing",
  "readyset-util",
+ "regex",
  "replication-offset",
  "reqwest",
  "rmp-serde",
@@ -5193,13 +5194,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.8",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -5212,6 +5214,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.5",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5219,9 +5232,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "replication-offset"

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -217,6 +217,7 @@ struct CreateCacheOptions {
 /// This is a non-standard ReadySet specific extension to SQL
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CreateCacheStatement {
+    /// The name of the cache. If not provided, a name will be generated based on the statement
     pub name: Option<Relation>,
     /// The result of parsing the inner statement or query ID for the `CREATE CACHE` statement.
     ///
@@ -224,6 +225,9 @@ pub struct CreateCacheStatement {
     /// statement. If it failed to parse, this will be an `Err` with the remainder [`String`]
     /// that could not be parsed.
     pub inner: Result<CacheInner, String>,
+    /// If `always` is true, a cached query executed inside a transaction can be served from
+    /// a readyset cache.
+    /// if false, cached queries within a transaction are proxied to upstream
     pub always: bool,
     /// Whether the CREATE CACHE STATEMENT should block or run concurrently
     pub concurrently: bool,

--- a/readyset-client/Cargo.toml
+++ b/readyset-client/Cargo.toml
@@ -96,6 +96,7 @@ tournament-kway = { path = "../tournament-kway" }
 nom-sql = { path = "../nom-sql" }
 readyset-sql-passes = { path = "../readyset-sql-passes" }
 replication-offset = { path = "../replication-offset" }
+regex = "1.9.5"
 
 [dev-dependencies]
 serial_test = "0.5.1"

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -40,7 +40,7 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
-use crate::controller::state::{DfState, DfStateHandle};
+use crate::controller::state::{DfState, DfStateHandle, RecipeChanges};
 use crate::controller::{ControllerState, Worker, WorkerIdentifier};
 use crate::worker::WorkerRequestKind;
 
@@ -520,7 +520,12 @@ impl Leader {
                     let authority = Arc::clone(authority);
                     let mut migration = tokio::spawn(async move {
                         let mut writer = dataflow_state_handle.write().await;
-                        writer.as_mut().extend_recipe(body, false).await?;
+                        let RecipeChanges {
+                            new_cache_statements,
+                        } = writer.as_mut().extend_recipe(body, false).await?;
+                        authority
+                            .add_create_cache_statements(new_cache_statements)
+                            .await?;
                         dataflow_state_handle.commit(writer, &authority).await?;
                         Ok(())
                     })

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use self::recipe::{QueryID, Recipe, Schema};
 use self::registry::ExprRegistry;
 use crate::controller::mir_to_flow::{mir_node_to_flow_parts, mir_query_to_flow_parts};
 use crate::controller::sql::registry::RecipeExpr;
+use crate::controller::state::RecipeChanges;
 use crate::controller::Migration;
 use crate::sql::mir::MirRemovalResult;
 use crate::ReuseConfigType;
@@ -209,7 +210,8 @@ impl SqlIncorporator {
         &mut self,
         changelist: ChangeList,
         mig: &mut Migration<'_>,
-    ) -> ReadySetResult<()> {
+    ) -> ReadySetResult<RecipeChanges> {
+        let mut res = RecipeChanges::default();
         debug!(
             num_queries = self.registry.len(),
             named_queries = self.registry.num_aliases(),
@@ -308,6 +310,7 @@ impl SqlIncorporator {
                     self.add_view(stmt.name, definition, schema_search_path.clone())?;
                 }
                 Change::CreateCache(cc) => {
+                    res.add_cache_statement(cc.clone());
                     self.add_query(cc.name, *cc.statement, cc.always, &schema_search_path, mig)?;
                 }
                 Change::AlterTable(_) => {
@@ -478,7 +481,7 @@ impl SqlIncorporator {
             }
         }
 
-        Ok(())
+        Ok(res)
     }
 
     fn invalidate_queries_for_added_relation(

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -16,6 +16,7 @@ use vec1::Vec1;
 use super::registry::{MatchedCache, RecipeExpr};
 use super::BaseSchema;
 use crate::controller::sql::SqlIncorporator;
+use crate::controller::state::RecipeChanges;
 use crate::controller::Migration;
 
 pub(crate) type QueryID = u128;
@@ -165,7 +166,7 @@ impl Recipe {
         &mut self,
         mig: &mut Migration<'_>,
         changelist: ChangeList,
-    ) -> ReadySetResult<()> {
+    ) -> ReadySetResult<RecipeChanges> {
         self.inc.apply_changelist(changelist, mig)
     }
 

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -1495,12 +1495,14 @@ impl DfState {
         }
     }
 
-    /// Return 1 if one or more expressions were removed, else return 0.
-    /// Someday we may want to return # expressions (and aliases?) dropped.
-    pub(super) async fn remove_query(&mut self, query_name: &Relation) -> ReadySetResult<u64> {
-        let name = match self.recipe.resolve_alias(query_name) {
-            None => return Ok(0),
-            Some(name) => name,
+    /// Returns the original name of the query that was removed (if any), else returns None
+    pub(super) async fn remove_query(
+        &mut self,
+        query_alias: &Relation,
+    ) -> ReadySetResult<Option<Relation>> {
+        let name = match self.recipe.resolve_alias(query_alias) {
+            None => return Ok(None),
+            Some(name) => name.clone(),
         };
 
         let changelist = ChangeList::from_change(
@@ -1516,7 +1518,7 @@ impl DfState {
             return Err(error);
         }
 
-        Ok(1)
+        Ok(Some(name))
     }
 
     pub(super) async fn remove_all_queries(&mut self) -> ReadySetResult<RecipeChanges> {

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -955,7 +955,7 @@ async fn caches_go_in_authority_list() {
     let stmts = authority.create_cache_statements().await.unwrap();
     assert_eq!(
         stmts,
-        vec![r#"CREATE CACHE CONCURRENTLY "q" FROM SELECT "x" FROM "t""#]
+        vec![r#"CREATE CACHE CONCURRENTLY "q" FROM SELECT "x" FROM "t""#.to_string()]
     );
 
     shutdown_tx.shutdown().await;


### PR DESCRIPTION
This adds a function to Authority to allow for removal of a stored
`CREATE CACHE` statement, for use when a cache is explicitly dropped,
along with a function for removing them all if `DROP ALL CACHES` is run.

Since removal of a cache uses a name of the cache (there can be multiple
due to cache aliases), we first resolve the alias to the original name
of the cache and use that to remove it from the authority. This matches
how we store the caches in the authority as well, and there is a
debug_assert added to enforce this invariant.

We specifically don't rely on the type system to enforce it because
keeping things as a String makes this storage less prone to backwards
incompatibility.

