### PR TITLE
quickstart: Use port 6034 for quickstart metrics

### DIFF
--- a/build/docker/grafana/dashboards/query_specific.json
+++ b/build/docker/grafana/dashboards/query_specific.json
@@ -309,7 +309,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "readyset_query_log_execution_time{quantile=~\"0.5\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.5\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6034\"} * 1000",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -319,7 +319,7 @@
         },
         {
           "exemplar": true,
-          "expr": "readyset_query_log_execution_time{quantile=~\"0.5\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.5\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6034\"} * 1000",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -428,7 +428,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "readyset_query_log_execution_time{quantile=~\"0.9\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.9\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6034\"} * 1000",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -438,7 +438,7 @@
         },
         {
           "exemplar": true,
-          "expr": "readyset_query_log_execution_time{quantile=~\"0.9\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.9\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6034\"} * 1000",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -547,7 +547,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "readyset_query_log_execution_time{quantile=~\"0.99\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.99\",database_type=\"readyset\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6034\"} * 1000",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -557,7 +557,7 @@
         },
         {
           "exemplar": true,
-          "expr": "readyset_query_log_execution_time{quantile=~\"0.99\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6033\"} * 1000",
+          "expr": "readyset_query_log_execution_time{quantile=~\"0.99\",database_type=\"mysql\",deployment=\"$deployment\",query_id=\"${queryfilter:raw}\",instance=\"cache:6034\"} * 1000",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -673,7 +673,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"mysql\"}",
+          "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6034\",database_type=\"mysql\"}",
           "instant": false,
           "interval": "",
           "legendFormat": "{{upstream_db_type}}",
@@ -681,7 +681,7 @@
         },
         {
           "exemplar": true,
-          "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"readyset\"}",
+          "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6034\",database_type=\"readyset\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "ReadySet",
@@ -866,14 +866,14 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "rate(readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"mysql\"}[$__rate_interval])",
+          "expr": "rate(readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6034\",database_type=\"mysql\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "Queries Per Second ({{upstream_db_type}})",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "rate(readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6033\",database_type=\"readyset\"}[$__rate_interval])",
+          "expr": "rate(readyset_query_log_execution_time_count{deployment=\"$deployment\", query_id=\"${queryfilter:raw}\",instance=\"cache:6034\",database_type=\"readyset\"}[$__rate_interval])",
           "hide": false,
           "interval": "",
           "legendFormat": "Queries Per Second (ReadySet)",

--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -3,12 +3,12 @@ services:
   cache:
     image: docker.io/readysettech/readyset:latest
     platform: linux/amd64
-    expose:
-      - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics
-      - 6034  # ReadySet Adapter Prometheus metrics at http://readyset:6034/metrics
     ports:
       # The ReadySet Adapter listen port, i.e. what your application / SQL shell connects to
       - "3307:3307"
+      # ReadySet Prometheus metrics available at http://localhost:6034/metrics
+      # e.g. curl -X GET http://localhost:6034/metrics
+      - "6034:6034"
     environment:
       DEPLOYMENT_ENV: quickstart_docker
       DB_DIR: /state
@@ -24,7 +24,7 @@ services:
     volumes:
       - "readyset:/state"
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "127.0.0.1:6033/health" ]
+      test: [ "CMD", "curl", "--fail", "127.0.0.1:6034/health" ]
       interval: 2s
       timeout: 1s
       retries: 5

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -3,12 +3,12 @@ services:
   cache:
     image: docker.io/readysettech/readyset:latest
     platform: linux/amd64
-    expose:
-      - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics
-      - 6034  # ReadySet Adapter Prometheus metrics at http://readyset:6034/metrics
     ports:
       # The ReadySet Adapter listen port, i.e. what your application / SQL shell connects to
       - "5433:5433"
+      # ReadySet Prometheus metrics available at http://localhost:6034/metrics
+      # e.g. curl -X GET http://localhost:6034/metrics
+      - "6034:6034"
     environment:
       DEPLOYMENT_ENV: quickstart_docker
       DB_DIR: /state
@@ -24,7 +24,7 @@ services:
     volumes:
       - "readyset:/state"
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "127.0.0.1:6033/health" ]
+      test: [ "CMD", "curl", "--fail", "127.0.0.1:6034/health" ]
       interval: 2s
       timeout: 1s
       retries: 5

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -3,12 +3,12 @@ services:
   cache:
     image: "docker.io/readysettech/readyset:latest"
     platform: linux/amd64
-    expose:
-      - 6033  # ReadySet Server Prometheus metrics at http://readyset:6033/metrics
-      - 6034  # ReadySet Adapter Prometheus metrics at http://readyset:6034/metrics
     ports:
       # The ReadySet Adapter listen port, i.e. what your application / SQL shell connects to
       - "5433:5433"
+      # ReadySet Prometheus metrics available at http://localhost:6034/metrics
+      # e.g. curl -X GET http://localhost:6034/metrics
+      - "6034:6034"
     environment:
       DEPLOYMENT_ENV: quickstart_docker
       DB_DIR: /state
@@ -26,7 +26,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "127.0.0.1:6033/health" ]
+      test: [ "CMD", "curl", "--fail", "127.0.0.1:6034/health" ]
       interval: 2s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
The quickstart runs ReadySet in standalone mode, so 6034 (the adapter)
endpoint is the default.

This also changes the quickstart compose files to map port 6034 so it is
available to run http requests against with localhost by default.

It updates the grafana dashboards to look for metrics on port 6034
instead of 6033, which wasn't working in standalone mode and was the
impetus for this change.

