### PR TITLE
replicators: Change WAL pos during snapshot

### DIFF
--- a/replication-offset/src/postgres.rs
+++ b/replication-offset/src/postgres.rs
@@ -36,6 +36,16 @@ impl PostgresPosition {
         }
     }
 
+    /// Constructs a [`PostgresPosition`] from a [`CommitLsn`] that points to the end position in
+    /// the given commit. In other words, this method constructs a [`PostgresPosition`] that points
+    /// to `(commit_lsn, commit_lsn)`.
+    pub fn commit_end(commit_lsn: CommitLsn) -> Self {
+        Self {
+            commit_lsn,
+            lsn: Lsn(commit_lsn.0),
+        }
+    }
+
     /// Consumes `self`, constructing a new [`PostgresPosition`] with `self`'s [`CommitLsn`] and the
     /// given [`Lsn`].
     pub fn with_lsn(self, lsn: impl Into<Lsn>) -> Self {

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -691,7 +691,7 @@ impl<'a> PostgresReplicator<'a> {
         snapshot_report_interval_secs: u16,
         full_snapshot: bool,
     ) -> ReadySetResult<()> {
-        let wal_position = PostgresPosition::commit_start(replication_slot.consistent_point).into();
+        let wal_position = PostgresPosition::commit_end(replication_slot.consistent_point).into();
         self.set_snapshot(&replication_slot.snapshot_name).await?;
 
         let table_list = self.get_table_list(TableKind::RegularTable).await?;


### PR DESCRIPTION
When we snapshot a Postgres database, we use the replication slot's
"consistent point" as our current position in the logs; however, when we
first start up we transform this LSN to the `PostgresPosition`
`(consistent_point, 0)`. This means that if we don't receive any events
before the next time we need to send a status update to Postgres, we
would report our current position as "0/0", since that's the LSN
component of the `PostgresPosition`.

This commit fixes this by transforming the slot's consistent point to
the `PostgresPosition` `(consistent_point, consistent_point)`, which
ensure that we we'll report our position as the consistent point.

Refs: REA-3303
