### PR TITLE
nom-sql: Add format-parse-rt for FieldDefinitionExpr

### DIFF
--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -278,6 +278,8 @@ pub enum FieldDefinitionExpr {
     #[default]
     All,
     AllInTable(Relation),
+    // TODO: re-enable once Expr round trip is stable
+    #[weight(0)]
     Expr {
         expr: Expr,
         alias: Option<SqlIdentifier>,
@@ -1179,6 +1181,10 @@ mod tests {
 
     mod postgres {
         use super::*;
+
+        test_format_parse_round_trip!(
+            rt_field_def_expr(field_definition_expr, Vec<FieldDefinitionExpr>, Dialect::PostgreSQL);
+        );
 
         #[test]
         fn cast() {

--- a/nom-sql/src/dialect.rs
+++ b/nom-sql/src/dialect.rs
@@ -53,6 +53,16 @@ where
     }
 }
 
+#[cfg(test)]
+impl<T> DialectDisplay for Vec<T>
+where
+    T: DialectDisplay,
+{
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + '_ {
+        self.iter().map(|i| i.display(dialect)).join(", ")
+    }
+}
+
 #[inline]
 pub(crate) fn is_sql_identifier(chr: u8) -> bool {
     is_alphanumeric(chr) || chr == b'_'


### PR DESCRIPTION
Adds a round trip test for Vec<FieldDefinitionExpr> with one branch
being disabled currently until Expr can round trip more reliably.

