### PR TITLE
nom-sql: Add round trip test for JoinRightSide

### DIFF
--- a/nom-sql/src/join.rs
+++ b/nom-sql/src/join.rs
@@ -17,6 +17,7 @@ pub enum JoinRightSide {
     /// A single table expression.
     Table(TableExpr),
     /// A comma-separated (and implicitly joined) sequence of tables.
+    #[strategy(size_range(1..12))]
     Tables(Vec<TableExpr>),
 }
 

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -464,6 +464,7 @@ fn join_rhs(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u
                 delimited(tag("("), table_expr_list(dialect), tag(")")),
                 JoinRightSide::Tables,
             ),
+            map(tag("()"), |_| JoinRightSide::Tables(vec![])),
         ))(i)
     }
 }
@@ -2071,6 +2072,7 @@ mod tests {
 
         test_format_parse_round_trip!(
             rt_limit_clause(limit_offset, LimitClause, Dialect::PostgreSQL);
+            rt_join_rhs(join_rhs, JoinRightSide, Dialect::PostgreSQL);
         );
 
         #[test]

--- a/nom-sql/src/table.rs
+++ b/nom-sql/src/table.rs
@@ -101,6 +101,8 @@ impl Relation {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Arbitrary)]
 pub enum TableExprInner {
     Table(Relation),
+    // TODO: re-enable after SelectStatement round-trips
+    #[weight(0)]
     Subquery(Box<SelectStatement>),
 }
 


### PR DESCRIPTION
This limits the SelectStatement branch until that can be stably
round-tripped and adds a round trip test for JoinRightSide otherwise. It
adds one parser fix where an empty join `()` was not being parsed as an
empty vec.

