### PR TITLE
server: Add an RPC for loading info about materializations

### DIFF
--- a/nom-sql/src/explain.rs
+++ b/nom-sql/src/explain.rs
@@ -1,24 +1,31 @@
-use std::fmt::{self, Display};
+use std::fmt;
 
 use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
 use nom::combinator::{opt, value};
 use nom::sequence::{terminated, tuple};
 use nom_locate::LocatedSpan;
+use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 
 use crate::common::statement_terminator;
+use crate::table::relation;
 use crate::whitespace::whitespace1;
-use crate::NomSqlResult;
+use crate::{Dialect, NomSqlResult, Relation};
 
 /// EXPLAIN statements
 ///
 /// This is a non-standard ReadySet-specific extension to SQL
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ExplainStatement {
-    /// Print a (maybe simplified) graphviz representation of the current query graph to stdout
-    Graphviz { simplified: bool },
+    /// Print a graphviz representation of the current query graph to stdout
+    Graphviz {
+        /// Print a *simplified* graphviz representation, smaller but with less information
+        simplified: bool,
+        /// Limit the graph to only a single cache
+        for_cache: Option<Relation>,
+    },
     /// Provides metadata about the last statement that was executed.
     LastStatement,
     /// List domain shard replicas and what worker they're running on
@@ -30,53 +37,80 @@ pub enum ExplainStatement {
     Materializations,
 }
 
-impl Display for ExplainStatement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "EXPLAIN ")?;
-        match self {
-            ExplainStatement::Graphviz { simplified } => {
-                if *simplified {
-                    write!(f, "SIMPLIFIED ")?;
+impl ExplainStatement {
+    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+        fmt_with(move |f| {
+            write!(f, "EXPLAIN ")?;
+            match self {
+                ExplainStatement::Graphviz {
+                    simplified,
+                    for_cache,
+                } => {
+                    if *simplified {
+                        write!(f, "SIMPLIFIED ")?;
+                    }
+                    write!(f, "GRAPHVIZ")?;
+                    if let Some(cache) = for_cache {
+                        write!(f, " FOR CACHE {}", cache.display(dialect))?;
+                    }
+                    write!(f, ";")
                 }
-                write!(f, "GRAPHVIZ;")
+                ExplainStatement::LastStatement => write!(f, "LAST STATEMENT;"),
+                ExplainStatement::Domains => write!(f, "DOMAINS;"),
+                ExplainStatement::Caches => write!(f, "CACHES;"),
+                ExplainStatement::Materializations => write!(f, "MATERIALIZATIONS;"),
             }
-            ExplainStatement::LastStatement => write!(f, "LAST STATEMENT;"),
-            ExplainStatement::Domains => write!(f, "DOMAINS;"),
-            ExplainStatement::Caches => write!(f, "CACHES;"),
-            ExplainStatement::Materializations => write!(f, "MATERIALIZATIONS;"),
-        }
+        })
     }
 }
 
-fn explain_graphviz(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], ExplainStatement> {
-    let (i, simplified) = opt(terminated(tag_no_case("simplified"), whitespace1))(i)?;
-    let (i, _) = tag_no_case("graphviz")(i)?;
-    Ok((
-        i,
-        ExplainStatement::Graphviz {
-            simplified: simplified.is_some(),
-        },
-    ))
+fn explain_graphviz(
+    dialect: Dialect,
+) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], ExplainStatement> {
+    move |i| {
+        let (i, simplified) = opt(terminated(tag_no_case("simplified"), whitespace1))(i)?;
+        let (i, _) = tag_no_case("graphviz")(i)?;
+        let (i, for_cache) = opt(move |i| {
+            let (i, _) = whitespace1(i)?;
+            let (i, _) = tag_no_case("for")(i)?;
+            let (i, _) = whitespace1(i)?;
+            let (i, _) = tag_no_case("cache")(i)?;
+            let (i, _) = whitespace1(i)?;
+            relation(dialect)(i)
+        })(i)?;
+
+        Ok((
+            i,
+            ExplainStatement::Graphviz {
+                simplified: simplified.is_some(),
+                for_cache,
+            },
+        ))
+    }
 }
 
-pub(crate) fn explain_statement(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], ExplainStatement> {
-    let (i, _) = tag_no_case("explain")(i)?;
-    let (i, _) = whitespace1(i)?;
-    let (i, stmt) = alt((
-        explain_graphviz,
-        value(
-            ExplainStatement::LastStatement,
-            tuple((tag_no_case("last"), whitespace1, tag_no_case("statement"))),
-        ),
-        value(ExplainStatement::Domains, tag_no_case("domains")),
-        value(ExplainStatement::Caches, tag_no_case("caches")),
-        value(
-            ExplainStatement::Materializations,
-            tag_no_case("materializations"),
-        ),
-    ))(i)?;
-    let (i, _) = statement_terminator(i)?;
-    Ok((i, stmt))
+pub(crate) fn explain_statement(
+    dialect: Dialect,
+) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], ExplainStatement> {
+    move |i| {
+        let (i, _) = tag_no_case("explain")(i)?;
+        let (i, _) = whitespace1(i)?;
+        let (i, stmt) = alt((
+            explain_graphviz(dialect),
+            value(
+                ExplainStatement::LastStatement,
+                tuple((tag_no_case("last"), whitespace1, tag_no_case("statement"))),
+            ),
+            value(ExplainStatement::Domains, tag_no_case("domains")),
+            value(ExplainStatement::Caches, tag_no_case("caches")),
+            value(
+                ExplainStatement::Materializations,
+                tag_no_case("materializations"),
+            ),
+        ))(i)?;
+        let (i, _) = statement_terminator(i)?;
+        Ok((i, stmt))
+    }
 }
 
 #[cfg(test)]
@@ -86,17 +120,37 @@ mod tests {
     #[test]
     fn explain_graphviz() {
         assert_eq!(
-            explain_statement(LocatedSpan::new(b"explain graphviz;"))
+            explain_statement(Dialect::MySQL)(LocatedSpan::new(b"explain graphviz;"))
                 .unwrap()
                 .1,
-            ExplainStatement::Graphviz { simplified: false }
+            ExplainStatement::Graphviz {
+                simplified: false,
+                for_cache: None
+            }
+        );
+    }
+
+    #[test]
+    fn explain_graphviz_for_cache() {
+        assert_eq!(
+            test_parse!(
+                explain_statement(Dialect::MySQL),
+                b"explain graphviz for cache q"
+            ),
+            ExplainStatement::Graphviz {
+                simplified: false,
+                for_cache: Some(Relation {
+                    schema: None,
+                    name: "q".into()
+                })
+            }
         );
     }
 
     #[test]
     fn explain_last_statement() {
         assert_eq!(
-            explain_statement(LocatedSpan::new(b"explain last statement;"))
+            explain_statement(Dialect::MySQL)(LocatedSpan::new(b"explain last statement;"))
                 .unwrap()
                 .1,
             ExplainStatement::LastStatement
@@ -106,7 +160,7 @@ mod tests {
     #[test]
     fn explain_domains() {
         assert_eq!(
-            test_parse!(explain_statement, b"explain domains;"),
+            test_parse!(explain_statement(Dialect::MySQL), b"explain domains;"),
             ExplainStatement::Domains
         );
     }
@@ -114,7 +168,7 @@ mod tests {
     #[test]
     fn explain_caches() {
         assert_eq!(
-            test_parse!(explain_statement, b"explain caches;"),
+            test_parse!(explain_statement(Dialect::MySQL), b"explain caches;"),
             ExplainStatement::Caches
         )
     }
@@ -122,7 +176,10 @@ mod tests {
     #[test]
     fn explain_materializations() {
         assert_eq!(
-            test_parse!(explain_statement, b"explain   mAtERIaLIZAtIOns"),
+            test_parse!(
+                explain_statement(Dialect::MySQL),
+                b"explain   mAtERIaLIZAtIOns"
+            ),
             ExplainStatement::Materializations
         );
     }

--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -88,7 +88,7 @@ impl SqlQuery {
             Self::RenameTable(rename) => write!(f, "{}", rename.display(dialect)),
             Self::Use(use_db) => write!(f, "{}", use_db),
             Self::Show(show) => write!(f, "{}", show.display(dialect)),
-            Self::Explain(explain) => write!(f, "{}", explain),
+            Self::Explain(explain) => write!(f, "{}", explain.display(dialect)),
             Self::Comment(c) => write!(f, "{}", c.display(dialect)),
         })
     }
@@ -174,7 +174,7 @@ fn sql_query_part1(
             map(rename_table(dialect), SqlQuery::RenameTable),
             map(use_statement(dialect), SqlQuery::Use),
             map(show(dialect), SqlQuery::Show),
-            map(explain_statement, SqlQuery::Explain),
+            map(explain_statement(dialect), SqlQuery::Explain),
         ))(i)
     }
 }

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1914,7 +1914,7 @@ where
             SqlQuery::Explain(nom_sql::ExplainStatement::LastStatement) => {
                 self.explain_last_statement()
             }
-            SqlQuery::Explain(nom_sql::ExplainStatement::Graphviz { simplified }) => {
+            SqlQuery::Explain(nom_sql::ExplainStatement::Graphviz { simplified, .. }) => {
                 self.noria.graphviz(*simplified).await
             }
             SqlQuery::Explain(nom_sql::ExplainStatement::Domains) => {

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1914,9 +1914,10 @@ where
             SqlQuery::Explain(nom_sql::ExplainStatement::LastStatement) => {
                 self.explain_last_statement()
             }
-            SqlQuery::Explain(nom_sql::ExplainStatement::Graphviz { simplified, .. }) => {
-                self.noria.graphviz(*simplified).await
-            }
+            SqlQuery::Explain(nom_sql::ExplainStatement::Graphviz {
+                simplified,
+                for_cache,
+            }) => self.noria.graphviz(*simplified, for_cache.clone()).await,
             SqlQuery::Explain(nom_sql::ExplainStatement::Domains) => {
                 self.noria.explain_domains().await
             }

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -523,6 +523,7 @@ impl NoriaConnector {
     pub(crate) async fn graphviz(
         &mut self,
         simplified: bool,
+        for_query: Option<Relation>,
     ) -> ReadySetResult<QueryResult<'static>> {
         let label = if simplified {
             "SIMPLIFIED GRAPHVIZ"
@@ -536,7 +537,7 @@ impl NoriaConnector {
             .noria
             .graphviz(GraphvizOptions {
                 detailed: !simplified,
-                ..Default::default()
+                for_query,
             })
             .await?;
 

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -16,8 +16,8 @@ use readyset_client::internal::LocalNodeIndex;
 use readyset_client::recipe::changelist::{Change, ChangeList, IntoChanges};
 use readyset_client::results::{ResultIterator, Results};
 use readyset_client::{
-    ColumnSchema, ReadQuery, ReaderAddress, ReaderHandle, ReadySetHandle, SchemaType, Table,
-    TableOperation, View, ViewCreateRequest, ViewQuery,
+    ColumnSchema, GraphvizOptions, ReadQuery, ReaderAddress, ReaderHandle, ReadySetHandle,
+    SchemaType, Table, TableOperation, View, ViewCreateRequest, ViewQuery,
 };
 use readyset_data::{DfType, DfValue, Dialect, TimestampTz};
 use readyset_errors::ReadySetError::{self, PreparedStatementMissing};
@@ -524,13 +524,21 @@ impl NoriaConnector {
         &mut self,
         simplified: bool,
     ) -> ReadySetResult<QueryResult<'static>> {
-        let noria = &mut self.inner.get_mut()?.noria;
-
-        let (label, graphviz) = if simplified {
-            ("SIMPLIFIED GRAPHVIZ", noria.simple_graphviz().await?)
+        let label = if simplified {
+            "SIMPLIFIED GRAPHVIZ"
         } else {
-            ("GRAPHVIZ", noria.graphviz().await?)
+            "GRAPHVIZ"
         };
+
+        let graphviz = self
+            .inner
+            .get_mut()?
+            .noria
+            .graphviz(GraphvizOptions {
+                detailed: !simplified,
+                ..Default::default()
+            })
+            .await?;
 
         Ok(QueryResult::Meta(vec![(label, graphviz).into()]))
     }

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -286,6 +286,28 @@ impl Service<ControllerRequest> for Controller {
     }
 }
 
+/// Options for generating graphviz [dot][] visualizations of the ReadySet dataflow graph.
+///
+/// Used as the argument to [`ReadySetHandle::graphviz`].
+///
+/// [dot]: https://graphviz.org/doc/info/lang.html
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphvizOptions {
+    /// Limit to only visualizing the graph for a single query by name
+    pub for_query: Option<Relation>,
+    /// Generate a detailed representation of the graph, larger and with more information
+    pub detailed: bool,
+}
+
+impl Default for GraphvizOptions {
+    fn default() -> Self {
+        Self {
+            for_query: None,
+            detailed: true,
+        }
+    }
+}
+
 /// A handle to a ReadySet controller.
 ///
 /// This handle is the primary mechanism for interacting with a running ReadySet instance, and lets
@@ -808,7 +830,7 @@ impl ReadySetHandle {
         /// Fetch a graphviz description of the dataflow graph.
         ///
         /// `Self::poll_ready` must have returned `Async::Ready` before you call this method.
-        graphviz() -> String
+        graphviz(options: GraphvizOptions) -> String
     );
 
     simple_request!(

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -24,7 +24,7 @@ use tracing::{debug, trace};
 use url::Url;
 
 use crate::consensus::{Authority, AuthorityControl};
-use crate::debug::info::{GraphInfo, NodeSize};
+use crate::debug::info::{GraphInfo, MaterializationInfo, NodeSize};
 use crate::debug::stats;
 use crate::internal::{DomainIndex, ReplicaAddress};
 use crate::metrics::MetricsDump;
@@ -891,6 +891,11 @@ impl ReadySetHandle {
         ///
         /// `Self::poll_ready` must have returned `Async::Ready` before you call this method.
         domains() -> HashMap<DomainIndex, Vec<Vec<Option<Url>>>>
+    );
+
+    simple_request!(
+        /// Get information about all materializations (stateful nodes) within the graph
+        materialization_info() -> Vec<MaterializationInfo>
     );
 
     simple_request!(

--- a/readyset-client/src/debug/info.rs
+++ b/readyset-client/src/debug/info.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Display};
 use std::ops::{AddAssign, Deref};
 
+use nom_sql::Relation;
 use petgraph::graph::NodeIndex;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -39,17 +40,40 @@ pub enum KeyCount {
     ExternalMaterialization,
 }
 
+impl Default for KeyCount {
+    fn default() -> Self {
+        Self::ExactKeyCount(0)
+    }
+}
+
 /// Used to wrap the materialized size of a node's state
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeMaterializedSize(usize);
 
 /// Use to aggregate various node stats that describe its size
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeSize {
     /// The number of keys materialized for a node
     pub key_count: KeyCount,
     /// The approximate size of the materialized state in bytes
     pub bytes: NodeMaterializedSize,
+}
+
+/// Information about a single materialization (stateful node) in the graph
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MaterializationInfo {
+    /// The index of the materialized node
+    pub node_index: NodeIndex,
+    /// The node's name
+    pub node_name: Relation,
+    /// A string description of the node
+    pub node_description: String,
+    /// The size of the materialization
+    pub size: NodeSize,
+    /// Is the materialization partial?
+    pub partial: bool,
+    /// Set of ways the materialization is indexed
+    pub indexes: HashSet<Index>,
 }
 
 impl Display for KeyCount {

--- a/readyset-client/src/lib.rs
+++ b/readyset-client/src/lib.rs
@@ -351,7 +351,7 @@ impl<T> From<T> for Tagged<T> {
 use url::Url;
 
 pub use crate::consensus::WorkerDescriptor;
-pub use crate::controller::{ControllerDescriptor, ReadySetHandle};
+pub use crate::controller::{ControllerDescriptor, GraphvizOptions, ReadySetHandle};
 pub use crate::table::{
     Modification, Operation, PacketData, PacketPayload, PacketTrace, Table, TableOperation,
     TableReplicationStatus, TableRequest, TableStatus,

--- a/readyset-clustertest/src/readyset.rs
+++ b/readyset-clustertest/src/readyset.rs
@@ -254,7 +254,7 @@ async fn replicated_readers() {
     .await
     .unwrap();
 
-    eprintln!("{}", lh.graphviz().await.unwrap());
+    eprintln!("{}", lh.graphviz(Default::default()).await.unwrap());
 
     let mut t = lh.table("t").await.unwrap();
     t.insert_many(vec![
@@ -354,7 +354,7 @@ async fn replicated_readers_with_unions() {
     .await
     .unwrap();
 
-    eprintln!("{}", lh.graphviz().await.unwrap());
+    eprintln!("{}", lh.graphviz(Default::default()).await.unwrap());
 
     let mut t = lh.table("t").await.unwrap();
     t.insert_many(vec![
@@ -428,7 +428,7 @@ async fn no_readers_worker_doesnt_get_readers() {
     .await
     .unwrap();
 
-    eprintln!("{}", lh.graphviz().await.unwrap());
+    eprintln!("{}", lh.graphviz(Default::default()).await.unwrap());
 
     let view_0 = lh.view("q0").await.unwrap().into_reader_handle().unwrap();
     let view_1 = lh.view("q1").await.unwrap().into_reader_handle().unwrap();

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -81,6 +81,10 @@ pub enum ReadySetError {
     #[error("No query known by id {id}")]
     NoQueryForId { id: String },
 
+    /// An operation was performed that referenced an unknown query by name
+    #[error("Query named {name} not found")]
+    QueryNotFound { name: String },
+
     /// The adapter will return this error on any set statement that is not
     /// explicitly allowed.
     #[error("Set statement disallowed: {}", Sensitive(statement))]

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -356,7 +356,7 @@ impl TestScript {
                         if opts.verbose {
                             eprintln!("     > graphviz");
                         }
-                        println!("{}", noria.graphviz().await?);
+                        println!("{}", noria.graphviz(Default::default()).await?);
                     }
                 }
             }

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -320,6 +320,10 @@ impl Leader {
                     .collect();
                 return_serialized!(res)
             }
+            (&Method::GET | &Method::POST, "/materialization_info") => {
+                let ds = self.dataflow_state_handle.read().await;
+                return_serialized!(ds.materialization_info().await?);
+            }
             (&Method::GET, "/allocated_bytes") => {
                 let alloc_bytes = tikv_jemalloc_ctl::epoch::mib()
                     .and_then(|m| m.advance())

--- a/readyset-server/src/controller/migrate/materialization/mod.rs
+++ b/readyset-server/src/controller/migrate/materialization/mod.rs
@@ -887,7 +887,8 @@ impl Materializations {
                                                         detailed: true,
                                                         node_sizes: None,
                                                         materializations: self,
-                                                        domain_nodes: None
+                                                        domain_nodes: None,
+                                                        reachable_from: None,
                                                     }
                                                 );
                                                 error!(
@@ -932,7 +933,8 @@ impl Materializations {
                             detailed: true,
                             node_sizes: None,
                             materializations: self,
-                            domain_nodes: None
+                            domain_nodes: None,
+                            reachable_from: None,
                         }
                     );
                     internal!("found purge node {} above non-purge node", ni.index())
@@ -1101,7 +1103,8 @@ impl Materializations {
                                     detailed: true,
                                     node_sizes: None,
                                     materializations: self,
-                                    domain_nodes: None
+                                    domain_nodes: None,
+                                    reachable_from: None,
                                 }
                             );
                             error!(

--- a/readyset-server/src/controller/migrate/materialization/plan.rs
+++ b/readyset-server/src/controller/migrate/materialization/plan.rs
@@ -446,7 +446,8 @@ impl<'a> Plan<'a> {
                             detailed: true,
                             node_sizes: None,
                             materializations: self.m,
-                            domain_nodes: None
+                            domain_nodes: None,
+                            reachable_from: None,
                         }
                     );
                     internal!("detected A-B-A domain replay path");

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -704,6 +704,7 @@ impl DfState {
             node_sizes,
             materializations: &self.materializations,
             domain_nodes: Some(&self.domain_nodes),
+            reachable_from: None,
         }
         .to_string()
     }

--- a/readyset-server/src/controller/state/graphviz.rs
+++ b/readyset-server/src/controller/state/graphviz.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display};
 use dataflow::prelude::{Graph, NodeIndex};
 use dataflow::{DomainIndex, NodeMap};
 use lazy_static::lazy_static;
-use readyset_client::NodeSize;
+use readyset_client::debug::info::NodeSize;
 use regex::Regex;
 
 use crate::controller::migrate::materialization::Materializations;

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -311,7 +311,7 @@ async fn sharded_shuffle() {
         })
         .await;
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut base = g.table_by_index(a).await.unwrap();
     let mut view = g.view("base").await.unwrap().into_reader_handle().unwrap();
@@ -403,7 +403,7 @@ async fn broad_recursing_upquery() {
         })
         .await;
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut base_x = g.table_by_index(x).await.unwrap();
     let mut reader = g
@@ -4280,7 +4280,7 @@ async fn between_parametrized() {
         things.insert(vec![i.into()]).await.unwrap();
     }
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut q = g.view("q").await.unwrap().into_reader_handle().unwrap();
     assert_eq!(q.key_map(), &[(ViewPlaceholder::Between(1, 2), 0)]);
@@ -4373,7 +4373,7 @@ async fn simple_pagination() {
     .await
     .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut t = g.table("t").await.unwrap();
 
@@ -7044,7 +7044,7 @@ async fn partial_distinct_multi() {
     .await
     .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut t = g.table("test").await.unwrap();
     let mut q = g
@@ -7152,7 +7152,7 @@ async fn join_straddled_columns() {
         .into_reader_handle()
         .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     a.insert_many(vec![
         vec![DfValue::from(1i32), DfValue::from(2i32)],
@@ -7225,7 +7225,7 @@ async fn straddled_join_range_query() {
 
     sleep().await;
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let rows = q
         .multi_lookup(
@@ -8198,7 +8198,7 @@ async fn reroutes_recursively() {
     g.extend_recipe(ChangeList::from_str(sql2, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
     let mut m1 = g.table("t1").await.unwrap();
     m1.insert(vec![1.into(), 2.into()]).await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -8241,7 +8241,7 @@ async fn reroutes_two_children_at_once() {
     g.extend_recipe(ChangeList::from_str(sql1, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let sql2 = "
         CREATE CACHE q2 FROM SELECT t1.a, t1.b, t2.c, t2.d FROM t1 INNER JOIN t2 ON t1.a = t2.c;
@@ -8250,7 +8250,7 @@ async fn reroutes_two_children_at_once() {
     g.extend_recipe(ChangeList::from_str(sql2, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut m1 = g.table("t1").await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -8308,7 +8308,7 @@ async fn reroutes_same_migration() {
     g.extend_recipe(ChangeList::from_str(sql, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut m1 = g.table("t1").await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -8373,7 +8373,7 @@ async fn reroutes_dependent_children() {
     g.extend_recipe(ChangeList::from_str(sql2, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut m1 = g.table("t1").await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -9260,7 +9260,7 @@ async fn multiple_schemas_explicit() {
         .await
         .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     sleep().await;
 


### PR DESCRIPTION
Add a new controller RPC for loading info about all the materializations
in the graph, including the index of the materialized node, the node's
name and description, the indexes in the materialization, and its size.

This RPC will be (but is not currently) used for retrieving the info
displayed in the result of the new EXPLAIN MATERIALIZATIONS command.

Refs: REA-3517
