### PR TITLE
materializations: Properly clear new_readers on commit()

### DIFF
--- a/readyset-server/src/controller/migrate/materialization/mod.rs
+++ b/readyset-server/src/controller/migrate/materialization/mod.rs
@@ -1220,6 +1220,7 @@ impl Materializations {
         }
 
         self.added.clear();
+        self.new_readers.clear();
         self.had.extend(self.have.keys().copied());
         Ok(())
     }


### PR DESCRIPTION
Not doing this doesn't cause any *issues*, because everything we do with
this set is idempotent, but could cause performance degradation if we
have graphs with a large number of readers that we have to look at
during each migration.

