### PR TITLE
adapter: Implement EXPLAIN MATERIALIZATIONS

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1923,9 +1923,7 @@ where
             }
             SqlQuery::Explain(nom_sql::ExplainStatement::Caches) => self.explain_caches().await,
             SqlQuery::Explain(nom_sql::ExplainStatement::Materializations) => {
-                return Some(Err(unsupported_err!(
-                    "EXPLAIN MATERIALIZATIONS not implemented yet"
-                )))
+                self.noria.explain_materializations().await
             }
             SqlQuery::CreateCache(CreateCacheStatement {
                 name,

--- a/readyset-client/src/debug/info.rs
+++ b/readyset-client/src/debug/info.rs
@@ -47,8 +47,8 @@ impl Default for KeyCount {
 }
 
 /// Used to wrap the materialized size of a node's state
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NodeMaterializedSize(usize);
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct NodeMaterializedSize(pub usize);
 
 /// Use to aggregate various node stats that describe its size
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
Fully implement the EXPLAIN MATERIALIZATIONS command in the adapter, by
querying the materialization_info controller RPC and building a table of
the results. That table looks like this (with \x on):

    localhost/test=> explain materializations;
    -[ RECORD 1 ]----+----------------------------
    node_index       | 1
    node_name        | public.t1
    node_description | B
    keys             | ~1
    size_byes        | 1141
    partial          | f
    indexes          | {"HashMap[0]","HashMap[1]"}
    -[ RECORD 2 ]----+----------------------------
    node_index       | 3
    node_name        | q_dbad6a69a4a2b479
    node_description | R
    keys             | 1
    size_byes        | 72
    partial          | f
    indexes          | {"HashMap[2]"}
    -[ RECORD 3 ]----+----------------------------
    node_index       | 7
    node_name        | q_28e90bf841f5d626
    node_description | R
    keys             | 1
    size_byes        | 88
    partial          | t
    indexes          | {"HashMap[0]"}
    -[ RECORD 4 ]----+----------------------------
    node_index       | 11
    node_name        | q_fe2b3c5162ad7235_n8
    node_description | |*| γ[1]
    keys             | 0
    size_byes        | 0
    partial          | t
    indexes          | {"HashMap[0]"}
    -[ RECORD 5 ]----+----------------------------
    node_index       | 13
    node_name        | q_64c2da1e0a7a392c
    node_description | R
    keys             | 0
    size_byes        | 0
    partial          | t
    indexes          | {"HashMap[1]"}

