### PR TITLE
server: Improve error message for disallowed full mat

### DIFF
--- a/readyset-server/src/controller/migrate/materialization/mod.rs
+++ b/readyset-server/src/controller/migrate/materialization/mod.rs
@@ -622,7 +622,13 @@ impl Materializations {
                     replay_obligations.entry(mi).or_default().extend(indices);
                 }
             } else if !graph[ni].is_base() && !self.config.allow_full_materialization {
-                unsupported!("Creation of fully materialized query is disabled.");
+                unsupported!(
+                    "Creation of fully materialized query is disabled \
+                     (node {} / {} / {}  would be fully materialized)",
+                    ni.index(),
+                    graph[ni].name().display_unquoted(),
+                    graph[ni].description(true),
+                );
             } else {
                 invariant!(
                     !graph[ni].purge,

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -8489,7 +8489,7 @@ async fn forbid_full_materialization() {
     let err = res.err().unwrap();
     assert!(err
         .to_string()
-        .contains("Creation of fully materialized query is disabled."));
+        .contains("Creation of fully materialized query is disabled"));
     assert!(err.caused_by_unsupported());
 
     shutdown_tx.shutdown().await;


### PR DESCRIPTION
If we're returning an unsupported error due to the creation of a fully
materialized query, return info about the node that would be fully
materialized as part of that error message.

