### PR TITLE
adapter: Drop "view not found" log to debug

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -99,7 +99,7 @@ use readyset_util::redacted::Sensitive;
 use readyset_version::READYSET_VERSION;
 use timestamp_service::client::{TimestampClient, WriteId, WriteKey};
 use tokio::sync::mpsc::UnboundedSender;
-use tracing::{error, instrument, trace, warn};
+use tracing::{debug, error, instrument, trace, warn};
 use vec1::Vec1;
 
 use crate::backend::noria_connector::ExecuteSelectContext;
@@ -879,7 +879,7 @@ where
             }
             Some(Err(e)) => {
                 if e.caused_by_view_not_found() {
-                    warn!(error = %e, "View not found during mirror_prepare()");
+                    debug!(error = %e, "View not found during mirror_prepare()");
                     self.state.query_status_cache.view_not_found_for_query(
                         &ViewCreateRequest::new(
                             select_meta.rewritten.clone(),


### PR DESCRIPTION
This log message is hit every time we prepare a non-migrated query for
the first time, since the adapter always asks the server for the view
for a prepared query in case that query was migrated by another adapter.
There's nothing a user can do about this in that case - and in general
this log message is *very* noisy and not very actionable. Let's drop it
down to debug.

