### PR TITLE
adapter: Don't warn log on failed to parse

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1277,10 +1277,14 @@ where
                         info.execute_unsupported();
                     }
                 }
-                if !matches!(
-                    noria_err,
-                    ReadySetError::ReaderMissingKey | ReadySetError::NoCacheForQuery
-                ) {
+                if !noria_err.any_cause(|e| {
+                    matches!(
+                        e,
+                        ReadySetError::ReaderMissingKey
+                            | ReadySetError::NoCacheForQuery
+                            | ReadySetError::UnparseableQuery { .. }
+                    )
+                }) {
                     warn!(error = %noria_err,
                           "Error received from noria, sending query to fallback");
                 }

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -708,7 +708,8 @@ impl ReadySetError {
         }
     }
 
-    fn any_cause<F>(&self, f: F) -> bool
+    /// Returns true if any of the causes of the error satisfy the given predicate
+    pub fn any_cause<F>(&self, f: F) -> bool
     where
         F: Fn(&Self) -> bool + Clone,
     {


### PR DESCRIPTION
If we fail to migrate a query due to it failing to parse, don't warn log
at all. This happens all the time in real-world applications, both for
invalid queries and (more significantly) queries that we just don't know
how to parse, and there's nothing a user can do about it.

