### PR TITLE
adapter: Don't warn if we fail to parse

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2438,7 +2438,12 @@ where
             }
             // Parse error, send to fallback
             Err(e) => {
-                if !matches!(e, ReadySetError::ReaderMissingKey) {
+                if !matches!(
+                    e,
+                    ReadySetError::ReaderMissingKey
+                    | ReadySetError::NoCacheForQuery
+                    | ReadySetError::UnparseableQuery { .. }
+                    ) {
                     warn!(error = %e, "Error received from noria, sending query to fallback");
                     event.set_noria_error(&e);
                 }


### PR DESCRIPTION
Similar to 9dc4b3db1e0717785e2d2fd52b0fd5dc8d2d2331 but in a different
place, suppress warn! logs if the reason for the query failure is us
failing to parse. We purposely don't parse unsupported queries and this
is very common to happen and not worth attention currently.

