### PR TITLE
readyset-adapter: lower parsing warning to debug

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1060,7 +1060,7 @@ where
                 } else {
                     PrepareMeta::Proxy
                 };
-                warn!(query = %Sensitive(&query), plan = ?mode, "ReadySet failed to parse query");
+                debug!(query = %Sensitive(&query), plan = ?mode, "ReadySet failed to parse query");
                 mode
             }
         }


### PR DESCRIPTION
It's currently normal if we fail to parse because our parser is
incomplete--lowering this log to warning until we want it to be more of
an assertion about parser completeness.

