### PR TITLE
adpapter: Downgrade another parse fail log to debug

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1060,7 +1060,7 @@ where
                 } else {
                     PrepareMeta::Proxy
                 };
-                warn!(query = %Sensitive(&query), plan = ?mode, "ReadySet failed to parse query");
+                debug!(query = %Sensitive(&query), plan = ?mode, "ReadySet failed to parse query");
                 mode
             }
         }


### PR DESCRIPTION
As with the other parse failure logs, this happens often on queries that
are valid, but that we just fail to parse, and isn't usually
user-actionable, so we don't want to spam it on applications

