### PR TITLE
replicators: lower ignored write warning log to debug

### DIFF
--- a/replicators/src/postgres_connector/wal_reader.rs
+++ b/replicators/src/postgres_connector/wal_reader.rs
@@ -11,7 +11,7 @@ use replication_offset::postgres::{CommitLsn, Lsn};
 use rust_decimal::prelude::FromStr;
 use rust_decimal::Decimal;
 use tokio_postgres as pgsql;
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, trace};
 
 use super::ddl_replication::DdlEvent;
 use super::wal::{self, RelationMapping, WalData, WalError, WalRecord};
@@ -124,7 +124,7 @@ impl WalReader {
                     schema,
                     table,
                 }) => {
-                    warn!(
+                    debug!(
                         type_oid,
                         schema = schema,
                         table = table,


### PR DESCRIPTION
If there is an unsupported type, we filter out the table so it's not
replicated but also filter out writes of that unsupported type. We don't
need to warn about this filtering as we expect the table to be not
replicated anyway.

