### PR TITLE
server: Allow generating graphviz for a single query

### DIFF
--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -16,8 +16,8 @@ use readyset_client::internal::LocalNodeIndex;
 use readyset_client::recipe::changelist::{Change, ChangeList, IntoChanges};
 use readyset_client::results::{ResultIterator, Results};
 use readyset_client::{
-    ColumnSchema, ReadQuery, ReaderAddress, ReaderHandle, ReadySetHandle, SchemaType, Table,
-    TableOperation, View, ViewCreateRequest, ViewQuery,
+    ColumnSchema, GraphvizOptions, ReadQuery, ReaderAddress, ReaderHandle, ReadySetHandle,
+    SchemaType, Table, TableOperation, View, ViewCreateRequest, ViewQuery,
 };
 use readyset_data::{DfType, DfValue, Dialect, TimestampTz};
 use readyset_errors::ReadySetError::{self, PreparedStatementMissing};
@@ -524,13 +524,21 @@ impl NoriaConnector {
         &mut self,
         simplified: bool,
     ) -> ReadySetResult<QueryResult<'static>> {
-        let noria = &mut self.inner.get_mut()?.noria;
-
-        let (label, graphviz) = if simplified {
-            ("SIMPLIFIED GRAPHVIZ", noria.simple_graphviz().await?)
+        let label = if simplified {
+            "SIMPLIFIED GRAPHVIZ"
         } else {
-            ("GRAPHVIZ", noria.graphviz().await?)
+            "GRAPHVIZ"
         };
+
+        let graphviz = self
+            .inner
+            .get_mut()?
+            .noria
+            .graphviz(GraphvizOptions {
+                detailed: !simplified,
+                ..Default::default()
+            })
+            .await?;
 
         Ok(QueryResult::Meta(vec![(label, graphviz).into()]))
     }

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -286,6 +286,28 @@ impl Service<ControllerRequest> for Controller {
     }
 }
 
+/// Options for generating graphviz [dot][] visualizations of the ReadySet dataflow graph.
+///
+/// Used as the argument to [`ReadySetHandle::graphviz`].
+///
+/// [dot]: https://graphviz.org/doc/info/lang.html
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GraphvizOptions {
+    /// Limit to only visualizing the graph for a single query by name
+    pub for_query: Option<Relation>,
+    /// Generate a detailed representation of the graph, larger and with more information
+    pub detailed: bool,
+}
+
+impl Default for GraphvizOptions {
+    fn default() -> Self {
+        Self {
+            for_query: None,
+            detailed: true,
+        }
+    }
+}
+
 /// A handle to a ReadySet controller.
 ///
 /// This handle is the primary mechanism for interacting with a running ReadySet instance, and lets
@@ -808,7 +830,7 @@ impl ReadySetHandle {
         /// Fetch a graphviz description of the dataflow graph.
         ///
         /// `Self::poll_ready` must have returned `Async::Ready` before you call this method.
-        graphviz() -> String
+        graphviz(options: GraphvizOptions) -> String
     );
 
     simple_request!(

--- a/readyset-client/src/lib.rs
+++ b/readyset-client/src/lib.rs
@@ -351,7 +351,7 @@ impl<T> From<T> for Tagged<T> {
 use url::Url;
 
 pub use crate::consensus::WorkerDescriptor;
-pub use crate::controller::{ControllerDescriptor, ReadySetHandle};
+pub use crate::controller::{ControllerDescriptor, GraphvizOptions, ReadySetHandle};
 pub use crate::table::{
     Modification, Operation, PacketData, PacketPayload, PacketTrace, Table, TableOperation,
     TableReplicationStatus, TableRequest, TableStatus,

--- a/readyset-clustertest/src/readyset.rs
+++ b/readyset-clustertest/src/readyset.rs
@@ -254,7 +254,7 @@ async fn replicated_readers() {
     .await
     .unwrap();
 
-    eprintln!("{}", lh.graphviz().await.unwrap());
+    eprintln!("{}", lh.graphviz(Default::default()).await.unwrap());
 
     let mut t = lh.table("t").await.unwrap();
     t.insert_many(vec![
@@ -354,7 +354,7 @@ async fn replicated_readers_with_unions() {
     .await
     .unwrap();
 
-    eprintln!("{}", lh.graphviz().await.unwrap());
+    eprintln!("{}", lh.graphviz(Default::default()).await.unwrap());
 
     let mut t = lh.table("t").await.unwrap();
     t.insert_many(vec![
@@ -428,7 +428,7 @@ async fn no_readers_worker_doesnt_get_readers() {
     .await
     .unwrap();
 
-    eprintln!("{}", lh.graphviz().await.unwrap());
+    eprintln!("{}", lh.graphviz(Default::default()).await.unwrap());
 
     let view_0 = lh.view("q0").await.unwrap().into_reader_handle().unwrap();
     let view_1 = lh.view("q1").await.unwrap().into_reader_handle().unwrap();

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -81,6 +81,10 @@ pub enum ReadySetError {
     #[error("No query known by id {id}")]
     NoQueryForId { id: String },
 
+    /// An operation was performed that referenced an unknown query by name
+    #[error("Query named {name} not found")]
+    QueryNotFound { name: String },
+
     /// The adapter will return this error on any set statement that is not
     /// explicitly allowed.
     #[error("Set statement disallowed: {}", Sensitive(statement))]

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -356,7 +356,7 @@ impl TestScript {
                         if opts.verbose {
                             eprintln!("     > graphviz");
                         }
-                        println!("{}", noria.graphviz().await?);
+                        println!("{}", noria.graphviz(Default::default()).await?);
                     }
                 }
             }

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -311,7 +311,7 @@ async fn sharded_shuffle() {
         })
         .await;
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut base = g.table_by_index(a).await.unwrap();
     let mut view = g.view("base").await.unwrap().into_reader_handle().unwrap();
@@ -403,7 +403,7 @@ async fn broad_recursing_upquery() {
         })
         .await;
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut base_x = g.table_by_index(x).await.unwrap();
     let mut reader = g
@@ -4280,7 +4280,7 @@ async fn between_parametrized() {
         things.insert(vec![i.into()]).await.unwrap();
     }
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut q = g.view("q").await.unwrap().into_reader_handle().unwrap();
     assert_eq!(q.key_map(), &[(ViewPlaceholder::Between(1, 2), 0)]);
@@ -4373,7 +4373,7 @@ async fn simple_pagination() {
     .await
     .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut t = g.table("t").await.unwrap();
 
@@ -7044,7 +7044,7 @@ async fn partial_distinct_multi() {
     .await
     .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut t = g.table("test").await.unwrap();
     let mut q = g
@@ -7152,7 +7152,7 @@ async fn join_straddled_columns() {
         .into_reader_handle()
         .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     a.insert_many(vec![
         vec![DfValue::from(1i32), DfValue::from(2i32)],
@@ -7225,7 +7225,7 @@ async fn straddled_join_range_query() {
 
     sleep().await;
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let rows = q
         .multi_lookup(
@@ -8198,7 +8198,7 @@ async fn reroutes_recursively() {
     g.extend_recipe(ChangeList::from_str(sql2, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
     let mut m1 = g.table("t1").await.unwrap();
     m1.insert(vec![1.into(), 2.into()]).await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -8241,7 +8241,7 @@ async fn reroutes_two_children_at_once() {
     g.extend_recipe(ChangeList::from_str(sql1, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let sql2 = "
         CREATE CACHE q2 FROM SELECT t1.a, t1.b, t2.c, t2.d FROM t1 INNER JOIN t2 ON t1.a = t2.c;
@@ -8250,7 +8250,7 @@ async fn reroutes_two_children_at_once() {
     g.extend_recipe(ChangeList::from_str(sql2, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut m1 = g.table("t1").await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -8308,7 +8308,7 @@ async fn reroutes_same_migration() {
     g.extend_recipe(ChangeList::from_str(sql, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut m1 = g.table("t1").await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -8373,7 +8373,7 @@ async fn reroutes_dependent_children() {
     g.extend_recipe(ChangeList::from_str(sql2, Dialect::DEFAULT_MYSQL).unwrap())
         .await
         .unwrap();
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     let mut m1 = g.table("t1").await.unwrap();
     let mut m2 = g.table("t2").await.unwrap();
@@ -9260,7 +9260,7 @@ async fn multiple_schemas_explicit() {
         .await
         .unwrap();
 
-    eprintln!("{}", g.graphviz().await.unwrap());
+    eprintln!("{}", g.graphviz(Default::default()).await.unwrap());
 
     sleep().await;
 


### PR DESCRIPTION
Allow limiting the graphviz generated by the /graphviz RPC endpoint to
only those nodes that are part of a single query. Under the hood, this
means only those nodes reachable via *incoming* edges from the reader
node of that query.

Since this is the second way that graphviz can be configured via
arguments to controller RPCs, and I want to avoid an explosion in
different RPC endpoints, I've also gotten rid of the /simple_graphviz
RPC endpoint in favor of a new GraphvizOptions struct passed to the
`graphviz()` method.

I have, however, exposed this through a (non-bincode!) GET
/graph/query_name controller HTTP endpoint, which can be useful on the
command-line.

