### PR TITLE
buildkite: Add retry on agent failure to jobs

### DIFF
--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -22,6 +22,12 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: ':rust: :lock: Check cargo-deny'
     commands:
@@ -41,6 +47,12 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: ':clippy: Check clippy'
     key: check-clippy
@@ -63,6 +75,12 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: ':rust: Run tests'
     key: rust-tests
@@ -95,6 +113,12 @@ steps:
           retries: 3
     agents:
       queue: c6a-4xlarge
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: 'Run logictest'
     key: logictest
@@ -122,6 +146,12 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: 'Run clustertests'
     key: readyset-clustertest
@@ -153,6 +183,12 @@ steps:
           mount-buildkite-agent: true
       - ecr#v2.2.0:
           login: true
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: 'Test benchmark framework'
     key: test-benchmark
@@ -181,3 +217,9 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,6 +20,12 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: ':docker: Build cargo-deny image'
     key: cargo-deny-image
@@ -31,6 +37,12 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
+    retry:
+      automatic:
+        - exit_status: -1  # Agent was lost
+          limit: 2
+        - exit_status: 255 # Forced agent shutdown
+          limit: 2
 
   - label: ':pipeline: Upload public-common pipeline'
     commands:

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1923,9 +1923,7 @@ where
             }
             SqlQuery::Explain(nom_sql::ExplainStatement::Caches) => self.explain_caches().await,
             SqlQuery::Explain(nom_sql::ExplainStatement::Materializations) => {
-                return Some(Err(unsupported_err!(
-                    "EXPLAIN MATERIALIZATIONS not implemented yet"
-                )))
+                self.noria.explain_materializations().await
             }
             SqlQuery::CreateCache(CreateCacheStatement {
                 name,

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -24,7 +24,7 @@ use tracing::{debug, trace};
 use url::Url;
 
 use crate::consensus::{Authority, AuthorityControl};
-use crate::debug::info::{GraphInfo, NodeSize};
+use crate::debug::info::{GraphInfo, MaterializationInfo, NodeSize};
 use crate::debug::stats;
 use crate::internal::{DomainIndex, ReplicaAddress};
 use crate::metrics::MetricsDump;
@@ -891,6 +891,11 @@ impl ReadySetHandle {
         ///
         /// `Self::poll_ready` must have returned `Async::Ready` before you call this method.
         domains() -> HashMap<DomainIndex, Vec<Vec<Option<Url>>>>
+    );
+
+    simple_request!(
+        /// Get information about all materializations (stateful nodes) within the graph
+        materialization_info() -> Vec<MaterializationInfo>
     );
 
     simple_request!(

--- a/readyset-client/src/debug/info.rs
+++ b/readyset-client/src/debug/info.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Display};
 use std::ops::{AddAssign, Deref};
 
+use nom_sql::Relation;
 use petgraph::graph::NodeIndex;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -39,17 +40,40 @@ pub enum KeyCount {
     ExternalMaterialization,
 }
 
+impl Default for KeyCount {
+    fn default() -> Self {
+        Self::ExactKeyCount(0)
+    }
+}
+
 /// Used to wrap the materialized size of a node's state
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeMaterializedSize(usize);
 
 /// Use to aggregate various node stats that describe its size
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NodeSize {
     /// The number of keys materialized for a node
     pub key_count: KeyCount,
     /// The approximate size of the materialized state in bytes
     pub bytes: NodeMaterializedSize,
+}
+
+/// Information about a single materialization (stateful node) in the graph
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MaterializationInfo {
+    /// The index of the materialized node
+    pub node_index: NodeIndex,
+    /// The node's name
+    pub node_name: Relation,
+    /// A string description of the node
+    pub node_description: String,
+    /// The size of the materialization
+    pub size: NodeSize,
+    /// Is the materialization partial?
+    pub partial: bool,
+    /// Set of ways the materialization is indexed
+    pub indexes: HashSet<Index>,
 }
 
 impl Display for KeyCount {

--- a/readyset-client/src/debug/info.rs
+++ b/readyset-client/src/debug/info.rs
@@ -47,8 +47,8 @@ impl Default for KeyCount {
 }
 
 /// Used to wrap the materialized size of a node's state
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct NodeMaterializedSize(usize);
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct NodeMaterializedSize(pub usize);
 
 /// Use to aggregate various node stats that describe its size
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -322,6 +322,10 @@ impl Leader {
                     .collect();
                 return_serialized!(res)
             }
+            (&Method::GET | &Method::POST, "/materialization_info") => {
+                let ds = self.dataflow_state_handle.read().await;
+                return_serialized!(ds.materialization_info().await?);
+            }
             (&Method::GET, "/allocated_bytes") => {
                 let alloc_bytes = tikv_jemalloc_ctl::epoch::mib()
                     .and_then(|m| m.advance())

--- a/readyset-server/src/controller/migrate/materialization/mod.rs
+++ b/readyset-server/src/controller/migrate/materialization/mod.rs
@@ -1220,6 +1220,7 @@ impl Materializations {
         }
 
         self.added.clear();
+        self.new_readers.clear();
         self.had.extend(self.have.keys().copied());
         Ok(())
     }


### PR DESCRIPTION
AWS spot instances are subject to reclamation, which causes
buildkite-agent to terminate with code 255.  This adds automatic retry
of jobs if it looks like the job failed because it was on a spot
instance that got yanked back.

Buildkite does not appear to support global retry settings at this time,
so we have to do it on a per job basis.  This update does not address
all pipelines, but it hits the main ones that are likely to be causing
immediate build pain.

