### PR TITLE
buildkite: DRY out the agent-kill retry blocks

### DIFF
--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -1,3 +1,12 @@
+# Non-buildkite nodes to re-use:
+common_values:
+  retry: &retry_on_agent_kill
+    automatic: &agent_kill_conditions
+      - exit_status: -1  # Agent was lost
+        limit: 2
+      - exit_status: 255 # Forced agent shutdown
+        limit: 2
+
 steps:
   - label: ':clojure: Run jepsen test with --help'
     key: lein-run-test-help
@@ -11,6 +20,7 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
+    retry: *retry_on_agent_kill
 
   - label: ':clojure: Run clojure tests'
     key: lein-test
@@ -24,6 +34,7 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
+    retry: *retry_on_agent_kill
 
   - label: ':clojure: Run clj-kondo'
     key: lein-clj-kondo
@@ -37,3 +48,4 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
+    retry: *retry_on_agent_kill

--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -1,5 +1,14 @@
 # This file contains common build steps that can be included in other pipeline contexts.
 
+# Non-buildkite nodes to re-use:
+common_values:
+  retry: &retry_on_agent_kill
+    automatic: &agent_kill_conditions
+      - exit_status: -1  # Agent was lost
+        limit: 2
+      - exit_status: 255 # Forced agent shutdown
+        limit: 2
+
 steps:
 
   - label: ':rust: Check rustfmt'
@@ -22,12 +31,7 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: ':rust: :lock: Check cargo-deny'
     commands:
@@ -47,12 +51,7 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: ':clippy: Check clippy'
     key: check-clippy
@@ -75,12 +74,7 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: ':rust: Run tests'
     key: rust-tests
@@ -113,12 +107,7 @@ steps:
           retries: 3
     agents:
       queue: c6a-4xlarge
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: 'Run logictest'
     key: logictest
@@ -146,12 +135,7 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: 'Run clustertests'
     key: readyset-clustertest
@@ -183,12 +167,7 @@ steps:
           mount-buildkite-agent: true
       - ecr#v2.2.0:
           login: true
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: 'Test benchmark framework'
     key: test-benchmark
@@ -217,9 +196,4 @@ steps:
       - ecr#v2.5.0:
           login: true
           retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,6 +2,15 @@
 # steps required by the public build specifically, then includes the pipeline
 # file containing common build steps.
 
+# Non-buildkite nodes to re-use:
+common_values:
+  retry: &retry_on_agent_kill
+    automatic: &agent_kill_conditions
+      - exit_status: -1  # Agent was lost
+        limit: 2
+      - exit_status: 255 # Forced agent shutdown
+        limit: 2
+
 steps:
   # TODO: ronh: decide what kind of linting we want in the OSS pipeline
   # - label: ':git: Lint commits'
@@ -20,12 +29,7 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: ':docker: Build cargo-deny image'
     key: cargo-deny-image
@@ -37,12 +41,7 @@ steps:
       ecr#v2.5.0:
         login: true
         retries: 3
-    retry:
-      automatic:
-        - exit_status: -1  # Agent was lost
-          limit: 2
-        - exit_status: 255 # Forced agent shutdown
-          limit: 2
+    retry: *retry_on_agent_kill
 
   - label: ':pipeline: Upload public-common pipeline'
     commands:


### PR DESCRIPTION
The first pass at implementing agent-failure retry (c7396b9) was full of
ugly duplication.  This update uses YAML anchors to clean that up a
little bit.  Unfortunately, the anchors have to be duplicated once in
each pipeline file, but...  YAML.

