### PR TITLE
readyset-psql: Improve upstream connectivity check

### DIFF
--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -221,7 +221,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
     }
 
     async fn is_connected(&mut self) -> Result<bool, Self::Error> {
-        Ok(!self.client.is_closed())
+        Ok(!self.client.simple_query("select 1").await?.is_empty())
     }
 
     // Returns the upstream server's version, with ReadySet's info appended, to indicate to clients


### PR DESCRIPTION
`UpstreamDatabase.is_connected()` currently just calls
`tokio_postgres::Client::is_closed()`. That function simply checks
that it's inner `mpsc::UnboundedSender` is not closed. That's not
a sufficient check as if the database is down, we don't actually
check that it is available, we only look at that sender. The sender
won't be shutdown by some background task (ala keep-alives). Thus,
we actually need to issue a probing query to the database.

This patch switches to issuing a simple `select 1` query to the
upstream PG to make sure we can connect.

