### PR TITLE
adapter: Don't lookup the same view twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883a5821d7d079fcf34ac55f27a833ee61678110f6b97637cc74513c0d0b42fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4368,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 4.3.2",
+ "crossbeam-skiplist",
  "database-utils",
  "fail",
  "failpoint-macros",
@@ -4404,6 +4417,7 @@ dependencies = [
  "chrono",
  "clap 4.3.2",
  "criterion",
+ "crossbeam-skiplist",
  "dashmap 4.0.2",
  "database-utils",
  "dataflow-expression",

--- a/benchmarks/src/bin/write_propagation.rs
+++ b/benchmarks/src/bin/write_propagation.rs
@@ -106,7 +106,8 @@ impl Writer {
         };
 
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache = SharedCache::new();
+        let view_name_cache = SharedCache::new();
+        let view_cache = SharedCache::new();
         let server_supports_pagination = ch.supports_pagination().await?;
         let (dialect, nom_sql_dialect) = match DatabaseURL::from_str(&self.database_url)? {
             DatabaseURL::MySQL(_) => (Dialect::DEFAULT_MYSQL, nom_sql::Dialect::MySQL),
@@ -117,7 +118,8 @@ impl Writer {
         let noria = NoriaConnector::new(
             ch.clone(),
             auto_increments,
-            query_cache,
+            view_name_cache.new_local(),
+            view_cache.new_local(),
             ReadBehavior::Blocking,
             dialect,
             nom_sql_dialect,

--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -17,7 +17,6 @@ values
 (1, 1),
 (1, 1);
 
-
 query I nosort
 select count(*) from t1 where x in (select x from t2);
 ----
@@ -74,4 +73,24 @@ from t1
 query I nosort
 select x from t1 where y in (select y from t2 where t2.x = t1.x)
 ----
+1
+
+query I rowsort
+select x from t1 where y not in (select y from t2 where t2.x = t1.x)
+----
+2
+3
+
+query I nosort
+select y in (select y from t2 where t2.x = t1.x) from t1 order by x asc
+----
+1
+0
+0
+
+query I nosort
+select y not in (select y from t2 where t2.x = t1.x) from t1 order by x asc
+----
+0
+1
 1

--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -68,3 +68,10 @@ from t1
 3
 0
 1
+
+# Correlated
+
+query I nosort
+select x from t1 where y in (select y from t2 where t2.x = t1.x)
+----
+1

--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -94,3 +94,21 @@ select y not in (select y from t2 where t2.x = t1.x) from t1 order by x asc
 0
 1
 1
+
+# Nulls
+
+statement ok
+create table t3 (x int, y int);
+
+statement ok
+create table t4 (x int, y int);
+
+statement ok
+insert into t3 (x, y) values (1, null);
+
+statement ok
+insert into t4 (x, y) values (1, 1);
+
+query I nosort
+select x from t3 where y not in (select y from t4 where t4.x = t3.x);
+----

--- a/nom-sql/src/show.rs
+++ b/nom-sql/src/show.rs
@@ -29,6 +29,7 @@ pub enum ShowStatement {
     ReadySetMigrationStatus(u64),
     ReadySetVersion,
     ReadySetTables,
+    Connections,
 }
 
 impl ShowStatement {
@@ -61,6 +62,7 @@ impl ShowStatement {
                 Self::ReadySetMigrationStatus(id) => write!(f, "READYSET MIGRATION STATUS {}", id),
                 Self::ReadySetVersion => write!(f, "READYSET VERSION"),
                 Self::ReadySetTables => write!(f, "READYSET TABLES"),
+                Self::Connections => write!(f, "CONNECTIONS"),
             }
         })
     }
@@ -169,6 +171,7 @@ pub fn show(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u
             ),
             map(show_tables(dialect), ShowStatement::Tables),
             value(ShowStatement::Events, tag_no_case("events")),
+            value(ShowStatement::Connections, tag_no_case("connections")),
         ))(i)?;
         Ok((i, statement))
     }
@@ -487,5 +490,13 @@ mod tests {
             b"SHOW\t READYSET\t MIGRATION\t STATUS\t 123456"
         );
         assert_eq!(res, ShowStatement::ReadySetMigrationStatus(123456))
+    }
+
+    #[test]
+    fn show_connections() {
+        assert_eq!(
+            test_parse!(show(Dialect::MySQL), b"SHOW CONNECTIONS"),
+            ShowStatement::Connections
+        );
     }
 }

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -48,6 +48,8 @@ parking_lot = "0.11.2"
 sqlformat = "0.2.1"
 indexmap = { version = "1", default-features = false }
 quanta = { version = "0.11", default-features = false }
+lru = "0.12.0"
+crossbeam-skiplist = "0.1.1"
 
 readyset-alloc = { path = "../readyset-alloc/" }
 readyset-client = { path = "../readyset-client/" }
@@ -63,7 +65,6 @@ readyset-sql-passes = { path = "../readyset-sql-passes" }
 readyset-version = { path = "../readyset-version" }
 health-reporter = { path = "../health-reporter" }
 database-utils = { path = "../database-utils" }
-lru = "0.12.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1889,7 +1889,7 @@ where
             let mut row = vec![
                 id.to_string().into(),
                 self.noria
-                    .get_view(&view.statement, false, false, None)
+                    .get_view_name(&view.statement, false, false, None)
                     .await?
                     .display_unquoted()
                     .to_string()

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -223,7 +223,6 @@ impl MigrationHandler {
             .noria
             .prepare_select(
                 view_request.statement.clone(),
-                0,
                 true,
                 Some(view_request.schema_search_path.clone()),
             )

--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -218,7 +218,8 @@ impl TestBuilder {
         }
 
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache = SharedCache::new();
+        let view_name_cache = SharedCache::new();
+        let view_cache = SharedCache::new();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
@@ -229,7 +230,6 @@ impl TestBuilder {
             let connection_fut = async move {
                 loop {
                     let (s, _) = listener.accept().await.unwrap();
-                    let query_cache = query_cache.clone();
                     let backend_builder = self.backend_builder.clone();
                     let auto_increments = auto_increments.clone();
 
@@ -251,7 +251,8 @@ impl TestBuilder {
                     let noria = NoriaConnector::new(
                         rh,
                         auto_increments,
-                        query_cache,
+                        view_name_cache.new_local(),
+                        view_cache.new_local(),
                         self.read_behavior,
                         A::EXPR_DIALECT,
                         A::DIALECT,

--- a/readyset-client/src/view.rs
+++ b/readyset-client/src/view.rs
@@ -1101,7 +1101,7 @@ impl fmt::Debug for ReaderHandle {
 ///
 /// A query can reuse a [`ReaderHandle`] for a cached query if the cached query is equivalent for
 /// some set of parameter values passed at execution.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReusedReaderHandle {
     /// The [`ReaderHandle`] that reuses the reader of another query for this query.
     reader_handle: ReaderHandle,
@@ -1117,7 +1117,7 @@ pub struct ReusedReaderHandle {
 }
 
 /// A wrapper to hold either a [`ReaderHandle`] or collection of [`ReusedReaderHandle`]s.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum View {
     /// A [`ReaderHandle`] for a cached query.
     Single(ReaderHandle),

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -530,7 +530,8 @@ impl TestScript {
         let database_type = run_opts.database_type;
         let replication_url = run_opts.replication_url.clone();
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache = SharedCache::new();
+        let view_name_cache = SharedCache::new();
+        let view_cache = SharedCache::new();
         let mut retry: usize = 0;
         let listener = loop {
             retry += 1;
@@ -556,7 +557,8 @@ impl TestScript {
             let noria = NoriaConnector::new(
                 rh,
                 auto_increments,
-                query_cache,
+                view_name_cache.new_local(),
+                view_cache.new_local(),
                 ReadBehavior::Blocking,
                 match database_type {
                     DatabaseType::MySQL => readyset_data::Dialect::DEFAULT_MYSQL,

--- a/readyset-mir/src/rewrite/decorrelate.rs
+++ b/readyset-mir/src/rewrite/decorrelate.rs
@@ -19,8 +19,8 @@ use crate::{Column, NodeIndex};
 /// - [`Project`], [`Join`], [`LeftJoin`], and dependent left or inner joins *other* than the one
 ///   this filter depends on are all totally commutative with filters, so can be swapped in position
 ///   with those filters with impunity
-/// - Grouped nodes ([`Aggregation`] and [`Extremum`]) require adding any *non* dependent columns
-///   mentioned in the filter to the group-by of the node.
+/// - Grouped nodes ([`Aggregation`], [`Extremum`] and [`Distinct`]) require adding any *non*
+///   dependent columns mentioned in the filter to the group-by of the node.
 /// - All other nodes currently return an [unsupported error][] - it *is* theoretically possible to
 ///   push below any node, but currently we don't have that ability
 ///
@@ -103,7 +103,9 @@ fn push_dependent_filter(
         | MirNodeInner::LeftJoin { .. }
         | MirNodeInner::DependentJoin { .. }
         | MirNodeInner::AliasTable { .. } => true,
-        MirNodeInner::Aggregation { .. } | MirNodeInner::Extremum { .. } => {
+        MirNodeInner::Aggregation { .. }
+        | MirNodeInner::Extremum { .. }
+        | MirNodeInner::Distinct { .. } => {
             for col in dependency.non_dependent_columns() {
                 query.graph.add_column(child_idx, col.clone())?;
             }

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -24,20 +24,22 @@ impl<'a> PrepareResponse<'a> {
     pub fn try_into_ps(self, prepared_statement_id: u32) -> Result<ps::PrepareResponse, ps::Error> {
         use readyset_adapter::backend::noria_connector::PrepareResult::*;
         use readyset_adapter::backend::noria_connector::{
-            SelectPrepareResult, SelectPrepareResultInner,
+            PreparedSelectTypes, SelectPrepareResultInner,
         };
 
         match self.0.upstream_biased() {
-            SinglePrepareResult::Noria(Select(SelectPrepareResult::Schema(
-                SelectPrepareResultInner { params, schema, .. },
-            ))) => Ok(ps::PrepareResponse {
+            SinglePrepareResult::Noria(Select {
+                types: PreparedSelectTypes::Schema(SelectPrepareResultInner { params, schema, .. }),
+                ..
+            }) => Ok(ps::PrepareResponse {
                 prepared_statement_id,
                 param_schema: NoriaSchema(params).try_into()?,
                 row_schema: NoriaSchema(schema).try_into()?,
             }),
-            SinglePrepareResult::Noria(Select(SelectPrepareResult::NoSchema(_))) => {
-                Err(ps::Error::InternalError("Unreachable".into()))
-            }
+            SinglePrepareResult::Noria(Select {
+                types: PreparedSelectTypes::NoSchema,
+                ..
+            }) => Err(ps::Error::InternalError("Unreachable".into())),
             SinglePrepareResult::Noria(Insert { params, schema, .. }) => Ok(ps::PrepareResponse {
                 prepared_statement_id,
                 param_schema: NoriaSchema(params).try_into()?,

--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -899,13 +899,13 @@ mod types {
             .unwrap();
         eventually!(
             run_test: {
-                let res = client.query_one(&stmt, &[&"A"]).await.unwrap();
+                let res = client.query_one(&stmt, &[&"A"]).await;
                 let dest = last_query_info(&client).await.destination;
                 AssertUnwindSafe(move || (res, dest))
             },
             then_assert: |res| {
                 let (res, dest) = res();
-                assert_eq!(res.get::<_, String>(0), "a");
+                assert_eq!(res.unwrap().get::<_, String>(0), "a");
                 assert_eq!(dest, QueryDestination::Readyset);
             }
         );

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -1138,6 +1138,7 @@ impl SqlToMirConverter {
             }
         };
 
+        let is_correlated = is_correlated(&subquery);
         let query_graph = to_query_graph(subquery)?;
         let subquery_leaf = self.named_query_to_mir(
             query_name,
@@ -1185,7 +1186,11 @@ impl SqlToMirConverter {
             }],
             parent,
             right_mark,
-            JoinKind::Left,
+            if is_correlated {
+                JoinKind::DependentLeft
+            } else {
+                JoinKind::Left
+            },
         )?;
 
         Ok(self.make_project_node(

--- a/readyset-sql-passes/src/anonymize.rs
+++ b/readyset-sql-passes/src/anonymize.rs
@@ -202,7 +202,8 @@ impl<'ast> VisitorMut<'ast> for AnonymizeVisitor<'_> {
             | nom_sql::ShowStatement::ReadySetStatusAdapter
             | nom_sql::ShowStatement::ReadySetMigrationStatus(..)
             | nom_sql::ShowStatement::ReadySetVersion
-            | nom_sql::ShowStatement::ReadySetTables => {}
+            | nom_sql::ShowStatement::ReadySetTables
+            | nom_sql::ShowStatement::Connections => {}
         }
         Ok(())
     }

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = "0.3.9"
 tracing-futures = "0.2.5"
 reqwest = { version = "0.11", features = ["json"] }
 chrono = "0.4"
+crossbeam-skiplist = "0.1.1"
 
 # Local dependencies
 health-reporter = { path = "../health-reporter" }


### PR DESCRIPTION
Use the new `global_local` module in readyset-util for Views in addition
to the map from select statement to view name, to avoid making
controller RPCs to lookup the same View more than once. For many
workloads this ought to save *significantly* on controller RPCs, since
this allows us to only ever look up the View for a particular query
once.

