### PR TITLE
readyset-adapter: Remove unnessecary get_view() call

### DIFF
--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -1570,14 +1570,9 @@ impl NoriaConnector {
 
         // check if we already have this query prepared
         trace!("select::access view");
-        let qname = self
-            .get_view(
-                &statement,
-                true,
-                create_if_not_exist,
-                override_schema_search_path,
-            )
-            .await?;
+        let search_path =
+            override_schema_search_path.unwrap_or_else(|| self.schema_search_path().to_vec());
+        let qname: Relation = utils::generate_query_name(&statement, &search_path).into();
 
         let view_failed = self.failed_views.take(&qname).is_some();
         let getter = self


### PR DESCRIPTION
We were calling `get_view()` when we really only needed the query name
since we end up calling `get_noria_view()` a few lines down. get_view()
is a lot more expensive than just generating the name, so swap it out
with the logic that just determines the name.

