### PR TITLE
Revert "adapter: Create caches for aliased queries"

### DIFF
--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -598,15 +598,6 @@ impl QueryStatusCache {
             .into()
     }
 
-    pub fn dry_run_succeeded(&self) -> QueryList {
-        self.statuses
-            .iter()
-            .filter(|r| r.is_dry_run_succeeded())
-            .map(|r| ((*r.key()).clone().into(), r.value().clone()))
-            .collect::<Vec<(Query, QueryStatus)>>()
-            .into()
-    }
-
     /// Returns a list of queries that have a state of [`QueryState::Successful`].
     pub fn allow_list(&self) -> Vec<(QueryId, Arc<ViewCreateRequest>, QueryStatus)> {
         self.ids

--- a/readyset-adapter/src/views_synchronizer.rs
+++ b/readyset-adapter/src/views_synchronizer.rs
@@ -2,15 +2,12 @@ use std::sync::Arc;
 
 use dataflow_expression::Dialect;
 use readyset_client::query::MigrationState;
-use readyset_client::recipe::changelist::Change;
-use readyset_client::recipe::ChangeList;
 use readyset_client::ReadySetHandle;
 use readyset_util::shutdown::ShutdownReceiver;
 use tokio::select;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::query_status_cache::QueryStatusCache;
-use crate::utils;
 
 pub struct ViewsSynchronizer {
     /// The noria connector used to query
@@ -70,7 +67,6 @@ impl ViewsSynchronizer {
             .query_status_cache
             .pending_migration()
             .into_iter()
-            .chain(self.query_status_cache.dry_run_succeeded().into_iter())
             .filter_map(|(q, _)| q.into_parsed().map(Arc::unwrap_or_clone))
             .collect::<Vec<_>>();
 
@@ -88,42 +84,8 @@ impl ViewsSynchronizer {
                         "Loaded query status from controller"
                     );
                     if migrated {
-                        // Explicitly migrate the query.
-                        // This adds the query hash as an alias for the existing cache, allowing
-                        // it to be treated as a cache name e.g. for use in a `DROP CACHE`
-                        // statement.
-                        // We don't need to do any rewrites here, as they have already been done on
-                        // the statements in the QueryStatusCache.
-                        // The value for `always` is ignored, as any statements we cache here are
-                        // guaranteed to alias to an existing cached statement.
-                        match self
-                            .controller
-                            .extend_recipe(
-                                ChangeList::from_change(
-                                    Change::create_cache(
-                                        // Rehashing the query here is simpler
-                                        // than a reverse-lookup into
-                                        // `self.query_status_cache.ids`.
-                                        utils::generate_query_name(
-                                            &query.statement,
-                                            &query.schema_search_path,
-                                        ),
-                                        query.statement.clone(),
-                                        false,
-                                    ),
-                                    self.dialect,
-                                )
-                                .with_schema_search_path(query.schema_search_path.clone()),
-                            )
-                            .await
-                        {
-                            Ok(_) => self
-                                .query_status_cache
-                                .update_query_migration_state(&query, MigrationState::Successful),
-                            Err(_) => self
-                                .query_status_cache
-                                .update_query_migration_state(&query, MigrationState::Unsupported),
-                        }
+                        self.query_status_cache
+                            .update_query_migration_state(&query, MigrationState::Successful)
                     }
                 }
             }

--- a/readyset-clustertest/src/readyset_mysql.rs
+++ b/readyset-clustertest/src/readyset_mysql.rs
@@ -1746,44 +1746,6 @@ async fn enable_experimental_placeholder_inlining() {
 }
 
 #[clustertest]
-async fn aliased_query_explicitly_cached() {
-    readyset_tracing::init_test_logging();
-    let mut deployment = readyset_mysql("aliased_query_explicitly_cached")
-        .add_server(ServerParams::default())
-        .explicit_migrations(1000)
-        .start()
-        .await
-        .unwrap();
-    let mut adapter = deployment.first_adapter().await;
-
-    adapter.query_drop("CREATE TABLE t (c INT)").await.unwrap();
-
-    // Confirm that the query is proxied to begin with
-    adapter.query_drop("SELECT c FROM t").await.unwrap();
-    assert_eq!(
-        last_statement_destination(adapter.as_mysql_conn().unwrap()).await,
-        QueryDestination::Upstream
-    );
-
-    // Cache an equivalent query
-    eventually! {
-        adapter
-            .query_drop("CREATE CACHE FROM SELECT * FROM t")
-            .await
-            .is_ok()
-    }
-
-    // Run the query again. It should get cached automatically, as it aliases to
-    // the previously cached query.
-    eventually! {
-        adapter.query_drop("SELECT c FROM t").await.unwrap();
-        last_statement_destination(adapter.as_mysql_conn().unwrap()).await == QueryDestination::Readyset
-    }
-
-    deployment.teardown().await.unwrap();
-}
-
-#[clustertest]
 async fn show_query_metrics() {
     readyset_tracing::init_test_logging();
     let mut deployment = readyset_mysql("show_query_metrics")


### PR DESCRIPTION
This reverts commit b384723f7999778e0e7c84df6a423c85412e41ee.

Reason for revert: This change adds an expensive extend_recipe call that
is periodically run and causes controller congestion. While
`extend_recipe` doesn't need to do more work than registering an alias,
that still involves a dfstate.commit() which adds contention to the
dfstate lock.

