### PR TITLE
readyset-psql: Add eventually! to flaky test

### DIFF
--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -156,8 +156,12 @@ async fn prepare_typed_insert() {
         .prepare_typed("select count(*) from t1 where x = $1", &[Type::INT8])
         .await
         .unwrap();
-    let res = conn.query(&stmt, &[&1i64]).await.unwrap();
-    assert_eq!(res.get(0).unwrap().get::<_, i64>(0), 1);
+    eventually!(run_test: {
+        let result = conn.query(&stmt, &[&1i64]).await.unwrap();
+        AssertUnwindSafe(|| result)
+    }, then_assert: |result| {
+        assert_eq!(result().get(0).unwrap().get::<_, i64>(0), 1);
+    });
 
     shutdown_tx.shutdown().await;
 }


### PR DESCRIPTION
This test was flaking in CI but passing reliably locally--add an
eventually! to allow it to converge to the expected value.

