### PR TITLE
metrics: Fix database_type label

### DIFF
--- a/readyset-client-metrics/src/lib.rs
+++ b/readyset-client-metrics/src/lib.rs
@@ -121,16 +121,14 @@ impl From<SqlQueryType> for SharedString {
 /// Identifies the database that this metric corresponds to.
 #[derive(Debug)]
 pub enum DatabaseType {
-    MySql,
-    Psql,
+    Upstream,
     ReadySet,
 }
 
 impl From<DatabaseType> for SharedString {
     fn from(database_type: DatabaseType) -> Self {
         match database_type {
-            DatabaseType::MySql => SharedString::const_str("mysql"),
-            DatabaseType::Psql => SharedString::const_str("psql"),
+            DatabaseType::Upstream => SharedString::const_str("upstream"),
             DatabaseType::ReadySet => SharedString::const_str("readyset"),
         }
     }

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -681,13 +681,9 @@ where
         let mut recorders = Vec::new();
         let prometheus_handle = if options.prometheus_metrics {
             let _guard = rt.enter();
-            let database_label = match self.database_type {
-                DatabaseType::MySQL => readyset_client_metrics::DatabaseType::MySql,
-                DatabaseType::PostgreSQL => readyset_client_metrics::DatabaseType::Psql,
-            };
 
             let recorder = PrometheusBuilder::new()
-                .add_global_label("upstream_db_type", database_label)
+                .add_global_label("upstream_db_type", self.database_type.to_string())
                 .add_global_label("deployment", &options.deployment)
                 .build_recorder();
 

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -90,7 +90,7 @@ impl QueryMetrics {
                     ("query", self.query.clone()),
                     ("event_type", SharedString::from(kind.0)),
                     ("query_type", SharedString::from(kind.1)),
-                    ("database_type", SharedString::from(DatabaseType::MySql)),
+                    ("database_type", SharedString::from(DatabaseType::Upstream)),
                 ];
 
                 if let Some(id) = &self.query_id {


### PR DESCRIPTION
We were setting the `database_type` label on our Prometheus metrics to
"mysql" any time the metric was for a query upstream. This commit
changes that label to read "upstream," since we already have an
`upstream_db_type` label that specifies whether the upstream DB is MySQL
or Postgres.

