### PR TITLE
readyset-psql: Adjust types::citext test assertion

### DIFF
--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -886,12 +886,12 @@ mod types {
             .await
             .unwrap();
 
+        let stmt = client
+            .prepare("SELECT * FROM t WHERE x = $1")
+            .await
+            .unwrap();
         eventually!(
             run_test: {
-                let stmt = client
-                    .prepare("SELECT * FROM t WHERE x = $1")
-                    .await
-                    .unwrap();
                 let res = client.query_one(&stmt, &[&"A"]).await.unwrap();
                 let dest = last_query_info(&client).await.destination;
                 AssertUnwindSafe(move || (res, dest))


### PR DESCRIPTION
The eventaully! assertion in the types::citext test was doing both the
prepare and the query in the `eventually!` setup. This was a race
condition and citext has been historically flakey. Now it is more flakey
because the prepare is faster thanks to 1fd7fa2a. We can fix this by
moving the prepare outside of the `eventually!` so that only the query
is polled for consistency.

