### PR TITLE
mysql-srv: Add CONNECT_WITH_DB capability.

### DIFF
--- a/mysql-srv/src/lib.rs
+++ b/mysql-srv/src/lib.rs
@@ -164,7 +164,7 @@ use std::io;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use constants::{CLIENT_PLUGIN_AUTH, PROTOCOL_41, RESERVED, SECURE_CONNECTION};
+use constants::{CLIENT_PLUGIN_AUTH, CONNECT_WITH_DB, PROTOCOL_41, RESERVED, SECURE_CONNECTION};
 use error::{other_error, OtherErrorKind};
 use mysql_common::constants::CapabilityFlags;
 use readyset_data::DfType;
@@ -356,7 +356,7 @@ struct StatementData {
     params: u16,
 }
 
-const CAPABILITIES: u32 = PROTOCOL_41 | SECURE_CONNECTION | RESERVED | CLIENT_PLUGIN_AUTH;
+const CAPABILITIES: u32 = PROTOCOL_41 | SECURE_CONNECTION | RESERVED | CLIENT_PLUGIN_AUTH | CONNECT_WITH_DB;
 
 impl<B: MySqlShim<W> + Send, R: AsyncRead + Unpin, W: AsyncWrite + Unpin + Send>
     MySqlIntermediary<B, R, W>


### PR DESCRIPTION
If the client replies to an initial handshake packet with CapabilityFlags::CLIENT_CONNECT_WITH_DB set, RS attempts to parse the database. The problem relies on this flag being set if the client wants to connect to a specific database. Still, the database name is only sent as part of the initial handshake packet if the server initially informs it supports this capability via the CONNECT_WITH_DB flag.
In this case, we might end up reading the next field in the handshake.