### PR TITLE
adapter: Don't send pending queries to RS

### DIFF
--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -939,7 +939,9 @@ where
             rt.handle().spawn(abort_on_panic(fut));
         }
 
-        if matches!(migration_style, MigrationStyle::Explicit) {
+        // For MigrationStyles other than InRequestPath, we rely on the ViewsSyncronizer to learn
+        // that a query is supported or not
+        if !matches!(migration_style, MigrationStyle::InRequestPath) {
             rs_connect.in_scope(|| info!("Spawning explicit migrations task"));
             let rh = rh.clone();
             let loop_interval = options.views_polling_interval;


### PR DESCRIPTION
Many applications, such as Rails, have a lifecycle that looks like:

  1. get a request
  2. make a new connection to DB
  3. prepare statement
  4. execute statement
  5. disconnect from DB

In addition, if in Rails the `db_prepared_statements` flag is set to
`false`, the app will *inline* all values for query parameters (but
still use the extended query protocol, confusingly). This can mean
that *every* query sent to us by an application is a "new" query
according to the query status cache, meaning it'd get the status of
Pending - and currently, ReadySet always tries to prepare queries with a
Pending status in the query-status-cache against ReadySet.

What this means when all taken together is that Discourse, a Rails
application which sets `db_prepared_statements` to `false`,
sends *thousands* of requests to the `view_builder` controller RPC when
run under load - basically one per proxied query! This significantly
impacts performance of these workloads as it creates a significant
amount of load on the controller.

Fixes: REA-3533
Co-Authored-By: Luke Osborne <luke@readyset.io>
