### PR TITLE
dataflow: Remove Ingredient::take

### DIFF
--- a/readyset-dataflow/src/node/ntype.rs
+++ b/readyset-dataflow/src/node/ntype.rs
@@ -27,7 +27,7 @@ impl NodeType {
             NodeType::Reader(ref mut r) => NodeType::Reader(r.take()),
             NodeType::Sharder(ref mut s) => NodeType::Sharder(s.take()),
             NodeType::Ingress => NodeType::Ingress,
-            NodeType::Internal(ref mut i) => NodeType::Internal(i.take()),
+            NodeType::Internal(ref mut i) => NodeType::Internal(i.clone()),
             NodeType::Source => NodeType::Source,
             NodeType::Dropped => NodeType::Dropped,
         }

--- a/readyset-dataflow/src/ops/filter.rs
+++ b/readyset-dataflow/src/ops/filter.rs
@@ -30,10 +30,6 @@ impl Filter {
 }
 
 impl Ingredient for Filter {
-    fn take(&mut self) -> NodeOperator {
-        Clone::clone(self).into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.src.as_global()]
     }

--- a/readyset-dataflow/src/ops/grouped/mod.rs
+++ b/readyset-dataflow/src/ops/grouped/mod.rs
@@ -156,10 +156,6 @@ impl<T: GroupedOperation + Send + 'static> Ingredient for GroupedOperator<T>
 where
     Self: Into<NodeOperator>,
 {
-    fn take(&mut self) -> NodeOperator {
-        Clone::clone(self).into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.src.as_global()]
     }

--- a/readyset-dataflow/src/ops/identity.rs
+++ b/readyset-dataflow/src/ops/identity.rs
@@ -22,10 +22,6 @@ impl Identity {
 }
 
 impl Ingredient for Identity {
-    fn take(&mut self) -> NodeOperator {
-        Clone::clone(self).into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.src.as_global()]
     }

--- a/readyset-dataflow/src/ops/join.rs
+++ b/readyset-dataflow/src/ops/join.rs
@@ -201,10 +201,6 @@ impl Join {
 }
 
 impl Ingredient for Join {
-    fn take(&mut self) -> NodeOperator {
-        Clone::clone(self).into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.left.as_global(), self.right.as_global()]
     }

--- a/readyset-dataflow/src/ops/mod.rs
+++ b/readyset-dataflow/src/ops/mod.rs
@@ -109,9 +109,6 @@ macro_rules! impl_ingredient_fn_ref {
 }
 
 impl Ingredient for NodeOperator {
-    fn take(&mut self) -> NodeOperator {
-        impl_ingredient_fn_mut!(self, take,)
-    }
     fn ancestors(&self) -> Vec<NodeIndex> {
         impl_ingredient_fn_ref!(self, ancestors,)
     }

--- a/readyset-dataflow/src/ops/paginate.rs
+++ b/readyset-dataflow/src/ops/paginate.rs
@@ -156,10 +156,6 @@ impl Paginate {
 }
 
 impl Ingredient for Paginate {
-    fn take(&mut self) -> NodeOperator {
-        self.clone().into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.src.as_global()]
     }

--- a/readyset-dataflow/src/ops/project.rs
+++ b/readyset-dataflow/src/ops/project.rs
@@ -34,10 +34,6 @@ impl Project {
 }
 
 impl Ingredient for Project {
-    fn take(&mut self) -> NodeOperator {
-        Clone::clone(self).into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.src.as_global()]
     }

--- a/readyset-dataflow/src/ops/topk.rs
+++ b/readyset-dataflow/src/ops/topk.rs
@@ -227,10 +227,6 @@ impl TopK {
 }
 
 impl Ingredient for TopK {
-    fn take(&mut self) -> NodeOperator {
-        self.clone().into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         vec![self.src.as_global()]
     }

--- a/readyset-dataflow/src/ops/union.rs
+++ b/readyset-dataflow/src/ops/union.rs
@@ -398,10 +398,6 @@ impl Union {
 }
 
 impl Ingredient for Union {
-    fn take(&mut self) -> NodeOperator {
-        Clone::clone(self).into()
-    }
-
     fn ancestors(&self) -> Vec<NodeIndex> {
         match self.emit {
             Emit::AllFrom(p, _) => vec![p.as_global()],

--- a/readyset-dataflow/src/processing.rs
+++ b/readyset-dataflow/src/processing.rs
@@ -12,7 +12,6 @@ use readyset_util::Indices;
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
 
-use crate::ops;
 use crate::prelude::*;
 
 // TODO: make a Key type that is an ArrayVec<DfValue>
@@ -596,10 +595,6 @@ pub(crate) trait Ingredient
 where
     Self: Send,
 {
-    /// Construct a new node from this node that will be given to the domain running this node.
-    /// Whatever is left behind in self is what remains observable in the graph.
-    fn take(&mut self) -> ops::NodeOperator;
-
     fn ancestors(&self) -> Vec<NodeIndex>;
 
     /// Dictate which parents are replayed through in the case of full materialization.


### PR DESCRIPTION
This method seems to have only existed to clean out any internal
node-specific state from the node before sending it to a domain to run -
but now that as of 92b57138d (dataflow: Make DfState auto-impl Send +
Sync, 2023-05-17) we don't actually store that state on the node itself,
we don't need it - and in fact it always just called clone().

