### PR TITLE
sql: Filter lhs NULLs from WHERE [NOT] IN (subquery)

### DIFF
--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -94,3 +94,21 @@ select y not in (select y from t2 where t2.x = t1.x) from t1 order by x asc
 0
 1
 1
+
+# Nulls
+
+statement ok
+create table t3 (x int, y int);
+
+statement ok
+create table t4 (x int, y int);
+
+statement ok
+insert into t3 (x, y) values (1, null);
+
+statement ok
+insert into t4 (x, y) values (1, 1);
+
+query I nosort
+select x from t3 where y not in (select y from t4 where t4.x = t3.x);
+----


### PR DESCRIPTION
lhs IN (subquery) and lhs NOT IN (subquery) both have NULL as the value
if the lhs is NULL, even if the expr would otherwise be true - this is
most notable for NOT IN, where the expr is NULL and therefore the row is
omitted even if the NULL value is not in the rhs subquery at all.

This was previously not implemented correctly for our implementation of
NOT IN - we'd project out a row for the lhs, then keep it in the filter
due to the rhs mark column being NULL. To correct that, this commit adds
a filter node to the lhs of the join to omit any rows where the lhs expr
evaluates to null before joining.

