### PR TITLE
readyset-adapter: Track live connections in a SkipSet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883a5821d7d079fcf34ac55f27a833ee61678110f6b97637cc74513c0d0b42fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4368,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 4.3.2",
+ "crossbeam-skiplist",
  "database-utils",
  "fail",
  "failpoint-macros",
@@ -4404,6 +4417,7 @@ dependencies = [
  "chrono",
  "clap 4.3.2",
  "criterion",
+ "crossbeam-skiplist",
  "dashmap 4.0.2",
  "database-utils",
  "dataflow-expression",

--- a/benchmarks/src/bin/write_propagation.rs
+++ b/benchmarks/src/bin/write_propagation.rs
@@ -31,8 +31,9 @@ use database_utils::DatabaseURL;
 use nom_sql::Relation;
 use readyset_adapter::backend::noria_connector::{NoriaConnector, ReadBehavior};
 use readyset_client::consensus::{Authority, AuthorityType};
-use readyset_client::{KeyComparison, ReadySetHandle, View, ViewCreateRequest, ViewQuery};
+use readyset_client::{KeyComparison, ReadySetHandle, View, ViewQuery};
 use readyset_data::{DfValue, Dialect};
+use readyset_util::shared_cache::SharedCache;
 use tokio::sync::RwLock;
 use vec1::Vec1;
 
@@ -105,7 +106,7 @@ impl Writer {
         };
 
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache: Arc<RwLock<HashMap<ViewCreateRequest, Relation>>> = Arc::default();
+        let query_cache = SharedCache::new();
         let server_supports_pagination = ch.supports_pagination().await?;
         let (dialect, nom_sql_dialect) = match DatabaseURL::from_str(&self.database_url)? {
             DatabaseURL::MySQL(_) => (Dialect::DEFAULT_MYSQL, nom_sql::Dialect::MySQL),

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -48,6 +48,8 @@ parking_lot = "0.11.2"
 sqlformat = "0.2.1"
 indexmap = { version = "1", default-features = false }
 quanta = { version = "0.11", default-features = false }
+lru = "0.12.0"
+crossbeam-skiplist = "0.1.1"
 
 readyset-alloc = { path = "../readyset-alloc/" }
 readyset-client = { path = "../readyset-client/" }
@@ -63,7 +65,6 @@ readyset-sql-passes = { path = "../readyset-sql-passes" }
 readyset-version = { path = "../readyset-version" }
 health-reporter = { path = "../health-reporter" }
 database-utils = { path = "../database-utils" }
-lru = "0.12.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1748,17 +1748,9 @@ where
         }
 
         let select_schema = if let Some(handle) = self.metrics_handle.as_mut() {
-            // Must snapshot histograms to get the latest metrics
-            handle.snapshot_histograms();
-            create_dummy_schema!(
-                "query id",
-                "proxied query",
-                "readyset supported",
-                "count",
-                "p50 (ms)",
-                "p90 (ms)",
-                "p99 (ms)"
-            )
+            // Must snapshot to get the latest metrics
+            handle.snapshot_counters(readyset_client_metrics::DatabaseType::MySql);
+            create_dummy_schema!("query id", "proxied query", "readyset supported", "count")
         } else {
             create_dummy_schema!("query id", "proxied query", "readyset supported")
         };
@@ -1785,16 +1777,9 @@ where
 
                 // Append metrics if we have them
                 if let Some(handle) = self.metrics_handle.as_ref() {
-                    let MetricsSummary {
-                        sample_count,
-                        p50_us,
-                        p90_us,
-                        p99_us,
-                    } = handle.metrics_summary(id.to_string()).unwrap_or_default();
+                    let MetricsSummary { sample_count } =
+                        handle.metrics_summary(id.to_string()).unwrap_or_default();
                     row.push(DfValue::from(format!("{sample_count}")));
-                    row.push(DfValue::from(format!("{:.3}", 1000.0 * p50_us)));
-                    row.push(DfValue::from(format!("{:.3}", 1000.0 * p90_us)));
-                    row.push(DfValue::from(format!("{:.3}", 1000.0 * p99_us)));
                 }
 
                 row
@@ -1831,16 +1816,13 @@ where
 
         let select_schema = if let Some(handle) = self.metrics_handle.as_mut() {
             // Must snapshot histograms to get the latest metrics
-            handle.snapshot_histograms();
+            handle.snapshot_counters(readyset_client_metrics::DatabaseType::ReadySet);
             create_dummy_schema!(
                 "query id",
                 "cache name",
                 "query text",
                 "fallback behavior",
-                "count",
-                "p50 (ms)",
-                "p90 (ms)",
-                "p99 (ms)"
+                "count"
             )
         } else {
             create_dummy_schema!("query id", "cache name", "query text", "fallback behavior")
@@ -1867,16 +1849,9 @@ where
 
             // Append metrics if we have them
             if let Some(handle) = self.metrics_handle.as_ref() {
-                let MetricsSummary {
-                    sample_count,
-                    p50_us,
-                    p90_us,
-                    p99_us,
-                } = handle.metrics_summary(id.to_string()).unwrap_or_default();
+                let MetricsSummary { sample_count } =
+                    handle.metrics_summary(id.to_string()).unwrap_or_default();
                 row.push(DfValue::from(format!("{sample_count}")));
-                row.push(DfValue::from(format!("{:.3}", 1000.0 * p50_us)));
-                row.push(DfValue::from(format!("{:.3}", 1000.0 * p90_us)));
-                row.push(DfValue::from(format!("{:.3}", 1000.0 * p99_us)));
             }
 
             results.push(row);

--- a/readyset-adapter/src/metrics_handle.rs
+++ b/readyset-adapter/src/metrics_handle.rs
@@ -1,28 +1,24 @@
 use std::collections::HashMap;
 
 use indexmap::IndexMap;
+use metrics::SharedString;
 use metrics_exporter_prometheus::formatting::{sanitize_label_key, sanitize_label_value};
 use metrics_exporter_prometheus::{Distribution, PrometheusHandle};
-use metrics_util::Summary;
-use quanta::Instant;
 // adding an alias to disambiguate vs readyset_client_metrics::recorded
 use readyset_client::metrics::recorded as client_recorded;
-use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_TIME;
+use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_COUNT;
+use readyset_client_metrics::DatabaseType;
 use readyset_data::TimestampTz;
 
 #[derive(Debug, Default, Clone)]
 pub struct MetricsSummary {
-    // i64 because Postgres doesn't have unsigned ints
-    pub sample_count: i64,
-    pub p50_us: f64,
-    pub p90_us: f64,
-    pub p99_us: f64,
+    pub sample_count: u64,
 }
 
 #[derive(Clone)]
 pub struct MetricsHandle {
     inner: PrometheusHandle,
-    snapshot: Option<HashMap<String, Summary>>,
+    snapshot: Option<HashMap<String, u64>>,
 }
 
 impl MetricsHandle {
@@ -59,54 +55,51 @@ impl MetricsHandle {
         self.inner.distributions(filter)
     }
 
-    /// Clone a snapshot of all QUERY_LOG_EXECUTION_TIME histograms.
-    pub fn snapshot_histograms(&mut self) {
+    /// Clone a snapshot of all QUERY_LOG_EXECUTION_COUNT counters.
+    pub fn snapshot_counters(&mut self, database_type: DatabaseType) {
         fn filter(key: &str) -> bool {
-            key == QUERY_LOG_EXECUTION_TIME
+            key == QUERY_LOG_EXECUTION_COUNT
         }
 
-        let histograms = self
-            .histograms(Some(filter))
-            .get(QUERY_LOG_EXECUTION_TIME)
+        let db_type = SharedString::from(database_type).to_string();
+
+        let counters = self
+            .counters(Some(filter))
+            .get(QUERY_LOG_EXECUTION_COUNT)
             .cloned()
             .map(|h| {
                 h.into_iter()
-                    .filter_map(|(k, dist)| {
-                        k.into_iter()
-                            .find(|k| k.starts_with("query_id"))
-                            .and_then(|k| {
-                                let summary = match dist {
-                                    Distribution::Summary(summary, _, _) => {
-                                        Some(summary.snapshot(Instant::now()))
-                                    }
-                                    _ => None,
-                                };
-                                summary.map(|s| (k, s))
-                            })
+                    .filter_map(|(k, count)| {
+                        let mut query_id_tag = None;
+                        for tag in k {
+                            if tag.starts_with("query_id") {
+                                query_id_tag = Some(tag);
+                            } else if tag.starts_with("database_type") && !tag.contains(&db_type) {
+                                return None;
+                            }
+                        }
+
+                        query_id_tag.map(|k| (k, count))
                     })
                     .collect::<HashMap<_, _>>()
             });
-        self.snapshot = histograms;
+        self.snapshot = counters;
     }
 
-    /// Return the count (number of samples), 0.5, 0.9 and 0.99 quantiles for the query specified by
-    /// `query_id`.
+    /// Returns the execution count query specified by `query_id`.
     ///
-    /// NOTE: Quantiles are queried from the last snapshot obtained by calling
-    /// [`Self::snapshot_histograms`]
+    /// NOTE: Values are queried from the last snapshot obtained by calling
+    /// [`Self::snapshot_counters`]
     pub fn metrics_summary(&self, query_id: String) -> Option<MetricsSummary> {
         let label = format!(
             "{}=\"{}\"",
             sanitize_label_key("query_id"),
             sanitize_label_value(&query_id)
         );
-        let summary = self.snapshot.as_ref()?.get(&label)?;
+        let summary = self.snapshot.as_ref()?.get(&label).or(Some(&0))?;
 
         Some(MetricsSummary {
-            sample_count: summary.count().try_into().unwrap_or_default(),
-            p50_us: summary.quantile(0.5).unwrap_or_default(),
-            p90_us: summary.quantile(0.90).unwrap_or_default(),
-            p99_us: summary.quantile(0.99).unwrap_or_default(),
+            sample_count: *summary,
         })
     }
 

--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -12,6 +12,7 @@
 ///
 /// [`DatabaseType`]: crate::DatabaseType
 pub const QUERY_LOG_EXECUTION_TIME: &str = "readyset_query_log_execution_time";
+pub const QUERY_LOG_EXECUTION_COUNT: &str = "readyset_query_log_execution_count";
 
 /// Histogram: The time in seconds that the database spent executing a
 /// query.

--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -15,8 +15,8 @@ use readyset_adapter::backend::{BackendBuilder, MigrationMode};
 use readyset_adapter::query_status_cache::QueryStatusCache;
 use readyset_adapter::{Backend, QueryHandler, UpstreamConfig, UpstreamDatabase};
 use readyset_client::consensus::{Authority, LocalAuthorityStore};
-use readyset_client::ViewCreateRequest;
 use readyset_server::{Builder, Handle, LocalAuthority, ReadySetHandle};
+use readyset_util::shared_cache::SharedCache;
 use readyset_util::shutdown::ShutdownSender;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::RwLock;
@@ -218,7 +218,7 @@ impl TestBuilder {
         }
 
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache: Arc<RwLock<HashMap<ViewCreateRequest, Relation>>> = Arc::default();
+        let query_cache = SharedCache::new();
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 

--- a/readyset-clustertest/src/readyset_mysql.rs
+++ b/readyset-clustertest/src/readyset_mysql.rs
@@ -1776,7 +1776,7 @@ async fn show_query_metrics() {
     }
 
     // Check `SHOW PROXIED QUERIES`
-    let proxied_result: Vec<(String, String, String, String, String, String, String)> = adapter
+    let proxied_result: Vec<(String, String, String, String)> = adapter
         .as_mysql_conn()
         .unwrap()
         .query(r"SHOW PROXIED QUERIES")
@@ -1785,22 +1785,10 @@ async fn show_query_metrics() {
 
     // Assert that we get a non-zero value for the metrics
     assert!(&proxied_result[0].3 != "0");
-    assert!(&proxied_result[0].4 != "0.0");
-    assert!(&proxied_result[0].5 != "0.0");
-    assert!(&proxied_result[0].6 != "0.0");
 
     // Check `SHOW CACHES`
     #[allow(clippy::type_complexity)]
-    let caches_result: Vec<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )> = adapter
+    let caches_result: Vec<(String, String, String, String, String)> = adapter
         .as_mysql_conn()
         .unwrap()
         .query(r"SHOW CACHES")
@@ -1809,7 +1797,4 @@ async fn show_query_metrics() {
 
     // Assert that we get a non-zero value for the metrics
     assert!(&caches_result[0].3 != "0");
-    assert!(&caches_result[0].4 != "0.0");
-    assert!(&caches_result[0].5 != "0.0");
-    assert!(&caches_result[0].6 != "0.0");
 }

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -21,10 +21,11 @@ use readyset_adapter::query_status_cache::QueryStatusCache;
 use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_adapter::{UpstreamConfig, UpstreamDatabase};
 use readyset_client::consensus::{Authority, LocalAuthorityStore};
-use readyset_client::{ReadySetHandle, ViewCreateRequest};
+use readyset_client::ReadySetHandle;
 use readyset_mysql::{MySqlQueryHandler, MySqlUpstream};
 use readyset_psql::{PostgreSqlQueryHandler, PostgreSqlUpstream};
 use readyset_server::{Builder, LocalAuthority, ReuseConfigType};
+use readyset_util::shared_cache::SharedCache;
 use readyset_util::shutdown::ShutdownSender;
 use tokio::sync::RwLock;
 use tokio::time::sleep;
@@ -529,7 +530,7 @@ impl TestScript {
         let database_type = run_opts.database_type;
         let replication_url = run_opts.replication_url.clone();
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache: Arc<RwLock<HashMap<ViewCreateRequest, Relation>>> = Arc::default();
+        let query_cache = SharedCache::new();
         let mut retry: usize = 0;
         let listener = loop {
             retry += 1;

--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -303,21 +303,23 @@ mod types {
             .await
             .unwrap();
 
-        sleep().await;
-
-        let mut project_eq_res = client
-            .query("SELECT x = 'a' FROM t", &[])
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|r| r.get(0))
-            .collect::<Vec<bool>>();
-        project_eq_res.sort();
-        assert_eq!(project_eq_res, vec![false, false, true, true]);
-
-        assert_eq!(
-            last_query_info(&client).await.destination,
-            QueryDestination::Readyset
+        eventually!(
+            run_test: {
+                let mut project_eq_res = client
+                    .query("SELECT x = 'a' FROM t", &[])
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|r| r.get(0))
+                    .collect::<Vec<bool>>();
+                project_eq_res.sort();
+                let dest = last_query_info(&client).await.destination;
+                (project_eq_res, dest)
+            },
+            then_assert: |(project_eq_res, dest)| {
+                assert_eq!(project_eq_res, vec![false, false, true, true]);
+                assert_eq!(dest, QueryDestination::Readyset);
+            }
         );
 
         let where_eq_res: i64 = client
@@ -691,18 +693,23 @@ mod types {
             .await
             .unwrap();
 
-        let post_rename_res = client
-            .query("SELECT x FROM t2", &[])
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|r| r.get(0))
-            .collect::<Vec<Cba2>>();
-        assert_eq!(post_rename_res, vec![Cba2::C]);
+        eventually!(
+            run_test: {
+                let post_rename_res = client
+                    .query("SELECT x FROM t2", &[])
+                    .await
+                    .unwrap()
+                    .into_iter()
+                    .map(|r| r.get(0))
+                    .collect::<Vec<Cba2>>();
+                let dest = last_query_info(&client).await.destination;
 
-        assert_eq!(
-            last_query_info(&client).await.destination,
-            QueryDestination::Readyset
+                (post_rename_res, dest)
+            },
+            then_assert: |(post_rename_res, dest)| {
+                assert_eq!(post_rename_res, vec![Cba2::C]);
+                assert_eq!(dest, QueryDestination::Readyset);
+            }
         );
 
         shutdown_tx.shutdown().await;

--- a/readyset-util/src/lib.rs
+++ b/readyset-util/src/lib.rs
@@ -18,6 +18,7 @@ pub mod nonmaxusize;
 pub mod progress;
 pub mod properties;
 pub mod redacted;
+pub mod shared_cache;
 pub mod shutdown;
 
 /// Error (returned by [`Indices::indices`] and [`Indices::cloned_indices`]) for an out-of-bounds

--- a/readyset-util/src/shared_cache.rs
+++ b/readyset-util/src/shared_cache.rs
@@ -1,0 +1,335 @@
+//! Data structures providing a shared cache with thread-local memoization
+
+use std::borrow::Borrow;
+use std::collections::hash_map::RandomState;
+use std::collections::HashMap;
+use std::hash::{BuildHasher, Hash};
+use std::sync::Arc;
+
+use futures::Future;
+use tokio::sync::RwLock;
+
+/// A shared cache providing a map from keys of type K to values of type V
+///
+/// This is implemented internally via a [`HashMap`] from `K` to `V`, which can be configured using
+/// the hasher `S`.
+///
+/// New thread-local versions of this shared cache can be created using [`new_local`],
+/// [`into_local`], etc. These local versions allow memoized lookup of cached values for keys
+#[derive(Debug)]
+pub struct SharedCache<K, V, S = RandomState> {
+    inner: Arc<RwLock<HashMap<K, V, S>>>,
+}
+
+impl<K, V, S> Clone for SharedCache<K, V, S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<K, V, S> Default for SharedCache<K, V, S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V, S> SharedCache<K, V, S> {
+    /// Creates an empty [`SharedCache`] which will use the given hash builder to hash
+    /// keys.
+    pub fn with_hasher(hash_builder: S) -> Self {
+        SharedCache {
+            inner: Arc::new(RwLock::new(HashMap::with_hasher(hash_builder))),
+        }
+    }
+
+    /// Creates an empty [`SharedCache`] with at least the specified capacity, using
+    /// hasher to hash the keys.
+    pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
+        SharedCache {
+            inner: Arc::new(RwLock::new(HashMap::with_capacity_and_hasher(
+                capacity,
+                hash_builder,
+            ))),
+        }
+    }
+
+    /// Creates a new local version of the given [`SharedCache`] which will use the given hash
+    /// builder to hash keys.
+    pub fn new_local_with_hasher(&self, hash_builder: S) -> LocalCache<K, V, S> {
+        LocalCache {
+            shared: self.clone(),
+            local: HashMap::with_hasher(hash_builder),
+        }
+    }
+
+    /// Convert this [`SharedCache`] into a new local version which will use the given hash builder
+    /// to hash keys.
+    pub fn into_local_with_hasher(self, hash_builder: S) -> LocalCache<K, V, S> {
+        LocalCache {
+            shared: self,
+            local: HashMap::with_hasher(hash_builder),
+        }
+    }
+}
+
+impl<K, V, S> SharedCache<K, V, S>
+where
+    S: Default,
+{
+    /// Create a new empty [`SharedCache`]
+    pub fn new() -> Self {
+        SharedCache {
+            inner: Arc::new(RwLock::new(HashMap::default())),
+        }
+    }
+
+    /// Create a new [`SharedCache`] with the given capacity
+    pub fn with_capacity(capacity: usize) -> Self {
+        SharedCache {
+            inner: Arc::new(RwLock::new(HashMap::with_capacity_and_hasher(
+                capacity,
+                Default::default(),
+            ))),
+        }
+    }
+
+    /// Creates a new local version of the given [`SharedCache`].
+    pub fn new_local(&self) -> LocalCache<K, V, S>
+    where
+        S: Default,
+    {
+        LocalCache {
+            shared: self.clone(),
+            local: Default::default(),
+        }
+    }
+
+    /// Convert this [`SharedCache`] into a new local version
+    pub fn into_local(self) -> LocalCache<K, V, S>
+    where
+        S: Default,
+    {
+        LocalCache {
+            shared: self,
+            local: Default::default(),
+        }
+    }
+
+    /// Creates a new local version of the given [`SharedCache`] with at least the given capacity.
+    pub fn new_local_with_capacity(&self, capacity: usize) -> LocalCache<K, V, S>
+    where
+        S: Default,
+    {
+        LocalCache {
+            shared: self.clone(),
+            local: HashMap::with_capacity_and_hasher(capacity, Default::default()),
+        }
+    }
+
+    /// Convert this [`SharedCache`] into a new local version with at least the given capacity.
+    pub fn into_local_with_capacity(self, capacity: usize) -> LocalCache<K, V, S>
+    where
+        S: Default,
+    {
+        LocalCache {
+            shared: self,
+            local: HashMap::with_capacity_and_hasher(capacity, Default::default()),
+        }
+    }
+}
+
+/// Mode to use when inserting missing values in the cache as part of
+/// [`LocalCache::get_mut_or_try_insert_with`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertMode {
+    /// Multiple tasks may try to call the function to obtain a new value at once, and whichever
+    /// finishes first wins.
+    Shared,
+    /// Only one task per key may try to call the function to obtain a new value at once
+    Locked,
+}
+
+/// A thread-local version of a [`SharedCache`].
+///
+/// This data structure allows looking up values which are present in the associated
+/// [`SharedCache`], after which subsequent lookups of the same key will not use synchronization.
+#[derive(Debug, Clone)]
+pub struct LocalCache<K, V, S = RandomState> {
+    shared: SharedCache<K, V, S>,
+    local: HashMap<K, V, S>,
+}
+
+impl<K, V, S> LocalCache<K, V, S>
+where
+    K: Hash + Eq,
+    V: Clone,
+    S: BuildHasher,
+{
+    /// Obtain an exclusive reference to the value associated with the given key.
+    ///
+    /// The first time this method is called per-[`LocalCache`], it will use synchronization to
+    /// access the key in the shared cache. After that, subsequent lookups will be local
+    ///
+    /// Note that any mutations to the value will only be reflected in this thread's local version.
+    pub async fn get_mut<'a, Q>(&'a mut self, key: &Q) -> Option<&'a mut V>
+    where
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = K>,
+        K: Borrow<Q>,
+    {
+        if !self.local.contains_key(key) {
+            let shared = self.shared.inner.read().await;
+            let v = shared.get(key)?;
+            self.local.insert(key.to_owned(), v.clone());
+        }
+
+        self.local.get_mut(key)
+    }
+
+    /// Insert a new key-value pair into the shared and local versions of this cache.
+    pub async fn insert(&mut self, key: K, val: V)
+    where
+        K: Clone,
+    {
+        self.local.insert(key.clone(), val.clone());
+        self.shared.inner.write().await.insert(key, val);
+    }
+
+    /// Remove a key from the shared and local versions of this cache
+    pub async fn remove<Q>(&mut self, key: &Q)
+    where
+        Q: ?Sized + Hash + Eq,
+        K: Borrow<Q>,
+    {
+        self.local.remove(key);
+        self.shared.inner.write().await.remove(key);
+    }
+
+    /// Remove the entry associated with the given value from the shared and local versions of this
+    /// cache. O(size).
+    pub async fn remove_val<U>(&mut self, val: &U)
+    where
+        V: PartialEq<U>,
+    {
+        self.local.retain(|_, v| v != val);
+        self.shared.inner.write().await.retain(|_, v| v != val);
+    }
+
+    /// Completely clear the shared and local versions of this cache
+    pub async fn clear(&mut self) {
+        self.local.clear();
+        self.shared.inner.write().await.clear();
+    }
+
+    /// Return the *key* associated with the given value within either the local, or the shared
+    /// versions of this cache. O(size), and performs no memoization
+    pub async fn key_for_val<'a, U>(&'a self, val: &U) -> Option<K>
+    where
+        V: PartialEq<U>,
+        K: Clone,
+    {
+        if let Some((k, _)) = self.local.iter().find(|(_, v)| *v == val) {
+            return Some(k.clone());
+        }
+
+        self.shared
+            .inner
+            .read()
+            .await
+            .iter()
+            .find(|(_, v)| *v == val)
+            .map(|(k, _)| k.clone())
+    }
+
+    /// Look up the value associated with the given key, and if it is not present, insert the value
+    /// returned by the given future into the shared and local versions of the cache.
+    ///
+    /// `mode` controls the behavior if multiple simultaneous tasks call this method on different
+    /// local versions of the same cache. See the documentation for [`InsertMode`] for the supported
+    /// options.
+    pub async fn get_mut_or_try_insert_with<'a, Q, F, E>(
+        &'a mut self,
+        key: &Q,
+        mode: InsertMode,
+        f: F,
+    ) -> Result<&'a mut V, E>
+    where
+        Q: ?Sized + Hash + Eq + ToOwned<Owned = K>,
+        K: Borrow<Q>,
+        F: Future<Output = Result<V, E>>,
+    {
+        if !self.local.contains_key(key) {
+            let shared = self.shared.inner.read().await;
+            if let Some(v) = shared.get(key) {
+                self.local.insert(key.to_owned(), v.clone());
+            }
+        }
+
+        if !self.local.contains_key(key) {
+            match mode {
+                InsertMode::Shared => {
+                    let val = f.await?;
+                    let val = self
+                        .shared
+                        .inner
+                        .write()
+                        .await
+                        .entry(key.to_owned())
+                        .or_insert(val)
+                        .clone();
+                    self.local.insert(key.to_owned(), val);
+                }
+                InsertMode::Locked => {
+                    let mut shared = self.shared.inner.write().await;
+                    let val = f.await?;
+                    let val = shared.entry(key.to_owned()).or_insert(val).clone();
+                    self.local.insert(key.to_owned(), val);
+                }
+            }
+        }
+
+        Ok(self.local.get_mut(key).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU8, Ordering};
+
+    use futures::stream::FuturesUnordered;
+    use futures::StreamExt;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_mut_or_try_insert_with_locked() {
+        let futures_run = Arc::new(AtomicU8::new(0));
+        let shared: SharedCache<String, i32> = SharedCache::new();
+        let mut tasks = (0..1)
+            .map(|_| {
+                let mut local = shared.new_local();
+                let futures_run = futures_run.clone();
+                tokio::spawn(async move {
+                    local
+                        .get_mut_or_try_insert_with("a", InsertMode::Locked, async move {
+                            futures_run.fetch_add(1, Ordering::Relaxed);
+                            Result::<i32, String>::Ok(1)
+                        })
+                        .await
+                        .unwrap();
+                })
+            })
+            .collect::<FuturesUnordered<_>>();
+
+        while let Some(res) = tasks.next().await {
+            res.unwrap();
+        }
+
+        assert_eq!(futures_run.load(Ordering::Relaxed), 1);
+        assert_eq!(*shared.new_local().get_mut("a").await.unwrap(), 1);
+    }
+}

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = "0.3.9"
 tracing-futures = "0.2.5"
 reqwest = { version = "0.11", features = ["json"] }
 chrono = "0.4"
+crossbeam-skiplist = "0.1.1"
 
 # Local dependencies
 health-reporter = { path = "../health-reporter" }

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -41,7 +41,7 @@ use readyset_client::consensus::AuthorityType;
 #[cfg(feature = "failure_injection")]
 use readyset_client::failpoints;
 use readyset_client::metrics::recorded;
-use readyset_client::{ReadySetHandle, ViewCreateRequest};
+use readyset_client::ReadySetHandle;
 use readyset_common::ulimit::maybe_increase_nofile_limit;
 use readyset_dataflow::Readers;
 use readyset_errors::{internal_err, ReadySetError};
@@ -50,6 +50,7 @@ use readyset_server::worker::readers::{retry_misses, Ack, BlockingRead, ReadRequ
 use readyset_telemetry_reporter::{TelemetryBuilder, TelemetryEvent, TelemetryInitializer};
 use readyset_util::futures::abort_on_panic;
 use readyset_util::redacted::RedactedString;
+use readyset_util::shared_cache::SharedCache;
 use readyset_util::shutdown;
 use readyset_version::*;
 use tokio::net;
@@ -611,7 +612,7 @@ where
         info!(%listen_address, "Listening for new connections");
 
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
-        let query_cache: Arc<RwLock<HashMap<ViewCreateRequest, Relation>>> = Arc::default();
+        let query_cache = SharedCache::new();
         let mut health_reporter = AdapterHealthReporter::new();
 
         let rs_connect = span!(Level::INFO, "Connecting to RS server");


### PR DESCRIPTION
Pass around an Arc<SkipSet<SocketAddr>> to each readyset-adapter
Backend, which tracks the set of active connections to the adapter. Each
Backend adds its own addr to the set on startup, and removes itself from
the set on Drop.

This is currently not read from, but will be used to provide a command
to list the currently active connections to the adapter

