### PR TITLE
adapter: Dont perform dryruns on queries that failed to parse

### DIFF
--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -588,12 +588,6 @@ impl QueryStatusCache {
             .iter()
             .filter(|r| r.is_pending())
             .map(|r| ((*r.key()).clone().into(), r.value().clone()))
-            .chain(
-                self.failed_parses
-                    .iter()
-                    .filter(|r| r.is_pending())
-                    .map(|r| ((*r.key()).clone().into(), r.value().clone())),
-            )
             .collect::<Vec<(Query, QueryStatus)>>()
             .into()
     }


### PR DESCRIPTION
In order for a dry run of a query to succeed, we need to be able to
parse the query, so we can avoid running dry runs on queries that we
failed to parse and just consider them as Unsupported (which we already
did, making the dry run which would never succeed unnecessary).

