### PR TITLE
adapter: Limit the number of stored queries in QSC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,6 +2067,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,6 +2719,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
  "hashbrown 0.13.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efa59af2ddfad1854ae27d75009d538d0998b4b2fd47083e743ac1a10e46c60"
+dependencies = [
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -4392,6 +4417,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "lazy_static",
+ "lru 0.12.0",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -63,6 +63,7 @@ readyset-sql-passes = { path = "../readyset-sql-passes" }
 readyset-version = { path = "../readyset-version" }
 health-reporter = { path = "../health-reporter" }
 database-utils = { path = "../database-utils" }
+lru = "0.12.0"
 
 [dev-dependencies]
 proptest = "1.0.0"


### PR DESCRIPTION
This is a temporary measure in order to limit the memory usage of the
query status cache by changing the persistent handle (which still isn't
actually persistent yet, but will be) to use an LRUCache as its
underlying store with a limit of 100_000. The id_to_status map is able
to "remember" the query status for more than this number of queries, but
we will only keep the full query for 100_000 queries.

The main goal of this is to remove this as a variable in our locust
testing before the fully persistent refactor can be finished.

