### PR TITLE
adapter: Store prepared statements in a Slab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,6 +4442,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "slab",
  "sqlformat",
  "test-strategy",
  "thiserror",
@@ -5863,9 +5864,12 @@ checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slotmap"

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -48,6 +48,7 @@ parking_lot = "0.11.2"
 sqlformat = "0.2.1"
 indexmap = { version = "1", default-features = false }
 quanta = { version = "0.11", default-features = false }
+slab = "0.4"
 
 readyset-alloc = { path = "../readyset-alloc/" }
 readyset-client = { path = "../readyset-client/" }

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -71,7 +71,6 @@
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -97,6 +96,7 @@ use readyset_errors::{internal, internal_err, unsupported, unsupported_err, Read
 use readyset_telemetry_reporter::{TelemetryBuilder, TelemetryEvent, TelemetrySender};
 use readyset_util::redacted::Sensitive;
 use readyset_version::READYSET_VERSION;
+use slab::Slab;
 use timestamp_service::client::{TimestampClient, WriteId, WriteKey};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, instrument, trace, warn};
@@ -324,7 +324,7 @@ impl BackendBuilder {
             state: BackendState {
                 proxy_state,
                 parsed_query_cache: HashMap::new(),
-                prepared_statements: Vec::new(),
+                prepared_statements: Default::default(),
                 query_status_cache,
                 ticket: self.ticket,
                 timestamp_client: self.timestamp_client,
@@ -538,7 +538,7 @@ where
     // a cache of all previously parsed queries
     parsed_query_cache: HashMap<String, SqlQuery>,
     // all queries previously prepared on noria or upstream, mapped by their ID.
-    prepared_statements: Vec<PreparedStatement<DB>>,
+    prepared_statements: Slab<PreparedStatement<DB>>,
     /// Current RYW ticket. `None` if RYW is not enabled. This `ticket` will
     /// be updated as the client makes writes so as to be an accurate low watermark timestamp
     /// required to make RYW-consistent reads. On reads, the client will pass in this ticket to be
@@ -685,35 +685,14 @@ pub struct PrepareResult<DB: UpstreamDatabase> {
     inner: PrepareResultInner<DB>,
 }
 
-/// # Constructors
 impl<DB: UpstreamDatabase> PrepareResult<DB> {
-    pub fn noria(statement_id: StatementId, noria_res: noria_connector::PrepareResult) -> Self {
+    pub fn new(statement_id: StatementId, inner: PrepareResultInner<DB>) -> Self {
         Self {
             statement_id,
-            inner: PrepareResultInner::Noria(noria_res),
+            inner,
         }
     }
 
-    pub fn upstream(statement_id: StatementId, upstream_res: UpstreamPrepare<DB>) -> Self {
-        Self {
-            statement_id,
-            inner: PrepareResultInner::Upstream(upstream_res),
-        }
-    }
-
-    pub fn both(
-        statement_id: StatementId,
-        noria_res: noria_connector::PrepareResult,
-        upstream_res: UpstreamPrepare<DB>,
-    ) -> Self {
-        Self {
-            statement_id,
-            inner: PrepareResultInner::Both(noria_res, upstream_res),
-        }
-    }
-}
-
-impl<DB: UpstreamDatabase> PrepareResult<DB> {
     pub fn noria_biased(&self) -> SinglePrepareResult<'_, DB> {
         match &self.inner {
             PrepareResultInner::Noria(res) | PrepareResultInner::Both(res, _) => {
@@ -793,13 +772,6 @@ where
             .unwrap_or_else(|| DB::DEFAULT_DB_VERSION.to_string())
     }
 
-    /// The identifier we can reserve for the next prepared statement
-    pub fn next_prepared_id(&self) -> u32 {
-        (self.state.prepared_statements.len())
-            .try_into()
-            .expect("Too many prepared statements")
-    }
-
     /// Switch the active database for this backend to the given named database.
     ///
     /// Internally, this will set the schema search path to a single-element vector with the
@@ -864,9 +836,7 @@ where
         query: &str,
         data: DB::PrepareData<'_>,
         event: &mut QueryExecutionEvent,
-    ) -> Result<PrepareResult<DB>, DB::Error> {
-        let statement_id = self.next_prepared_id();
-
+    ) -> Result<PrepareResultInner<DB>, DB::Error> {
         let do_noria = select_meta.should_do_noria;
         let do_migrate = select_meta.must_migrate;
 
@@ -938,7 +908,7 @@ where
 
         let prep_result = match (upstream_res, noria_res) {
             (Some(upstream_res), Some(Ok(noria_res))) => {
-                PrepareResult::both(statement_id, noria_res, upstream_res?)
+                PrepareResultInner::Both(noria_res, upstream_res?)
             }
             (None, Some(Ok(noria_res))) => {
                 if matches!(
@@ -954,10 +924,10 @@ where
                         "Cannot create PrepareResult for borrowed cache without an upstream result"
                     );
                 }
-                PrepareResult::noria(statement_id, noria_res)
+                PrepareResultInner::Noria(noria_res)
             }
             (None, Some(Err(noria_err))) => return Err(noria_err.into()),
-            (Some(upstream_res), _) => PrepareResult::upstream(statement_id, upstream_res?),
+            (Some(upstream_res), _) => PrepareResultInner::Upstream(upstream_res?),
             (None, None) => return Err(ReadySetError::Unsupported(query.to_string()).into()),
         };
 
@@ -971,15 +941,14 @@ where
         stmt: &SqlQuery,
         data: DB::PrepareData<'_>,
         event: &mut QueryExecutionEvent,
-    ) -> Result<PrepareResult<DB>, DB::Error> {
-        let statement_id = self.next_prepared_id();
+    ) -> Result<PrepareResultInner<DB>, DB::Error> {
         event.sql_type = SqlQueryType::Write;
         if let Some(ref mut upstream) = self.upstream {
             let _t = event.start_upstream_timer();
             let res = upstream
                 .prepare(query, data)
                 .await
-                .map(|ur| PrepareResult::upstream(statement_id, ur));
+                .map(PrepareResultInner::Upstream);
             self.last_query = Some(QueryInfo {
                 destination: QueryDestination::Upstream,
                 noria_error: String::new(),
@@ -998,7 +967,7 @@ where
                 destination: QueryDestination::Readyset,
                 noria_error: String::new(),
             });
-            Ok(PrepareResult::noria(statement_id, res))
+            Ok(PrepareResultInner::Noria(res))
         }
     }
 
@@ -1107,8 +1076,7 @@ where
         query: &str,
         data: DB::PrepareData<'_>,
         event: &mut QueryExecutionEvent,
-    ) -> Result<PrepareResult<DB>, DB::Error> {
-        let statement_id = self.next_prepared_id();
+    ) -> Result<PrepareResultInner<DB>, DB::Error> {
         match meta {
             PrepareMeta::Proxy
             | PrepareMeta::FailedToParse
@@ -1120,7 +1088,7 @@ where
                 let res = self
                     .prepare_fallback(query, data)
                     .await
-                    .map(|res| PrepareResult::upstream(statement_id, res));
+                    .map(PrepareResultInner::Upstream);
 
                 self.last_query = Some(QueryInfo {
                     destination: QueryDestination::Upstream,
@@ -1154,11 +1122,11 @@ where
         let mut query_event = QueryExecutionEvent::new(EventType::Prepare);
 
         let meta = self.plan_prepare(query).await;
-        let res = self
+        let prep = self
             .do_prepare(&meta, query, data, &mut query_event)
             .await?;
 
-        let (id, parsed_query, migration_state, view_request, always) = match meta {
+        let (query_id, parsed_query, migration_state, view_request, always) = match meta {
             PrepareMeta::Write { stmt } => (
                 None,
                 Some(Arc::new(stmt)),
@@ -1192,21 +1160,31 @@ where
         if let Some(parsed) = &parsed_query {
             query_event.query = Some(parsed.clone());
         }
-        query_event.query_id = id;
+        query_event.query_id = query_id;
 
-        let cache_entry = PreparedStatement {
-            query_id: id,
-            prep: res,
+        let statement_id = self.state.prepared_statements.insert(PreparedStatement {
+            query_id,
+            prep: PrepareResult::new(
+                self.state
+                    .prepared_statements
+                    .vacant_key()
+                    .try_into()
+                    .expect(
+                        "Cannot prepare more than u32::MAX statements with a single connection",
+                    ),
+                prep,
+            ),
             migration_state,
             execution_info: None,
             parsed_query,
             view_request,
             always,
-        };
+        });
 
-        self.state.prepared_statements.push(cache_entry);
-
-        Ok(&self.state.prepared_statements.last().unwrap().prep)
+        Ok(
+            // SAFETY: Just inserted!
+            &unsafe { self.state.prepared_statements.get_unchecked(statement_id) }.prep,
+        )
     }
 
     /// Executes a prepared statement on ReadySet
@@ -1374,8 +1352,10 @@ where
 
         // At this point we got a successful noria prepare, so we want to replace the Upstream
         // result with a Both result
-        cached_entry.prep =
-            PrepareResult::both(cached_entry.prep.statement_id, noria_prep, upstream_prep);
+        cached_entry.prep = PrepareResult::new(
+            cached_entry.prep.statement_id,
+            PrepareResultInner::Both(noria_prep, upstream_prep),
+        );
         // If the query was previously `Pending`, update to `Successful`. If it was inlined, we do
         // not update the migration state.
         if cached_entry.migration_state == MigrationState::Pending {
@@ -1393,12 +1373,15 @@ where
             .prepared_statements
             .iter_mut()
             .filter_map(
-                |PreparedStatement {
-                     prep,
-                     migration_state,
-                     view_request,
-                     ..
-                 }| {
+                |(
+                    _,
+                    PreparedStatement {
+                        prep,
+                        migration_state,
+                        view_request,
+                        ..
+                    },
+                )| {
                     if *migration_state == MigrationState::Successful
                         && view_request.as_ref() == Some(stmt)
                     {
@@ -1429,7 +1412,7 @@ where
         let cached_statement = self
             .state
             .prepared_statements
-            .get_mut(id as usize)
+            .get_mut(id as _)
             .ok_or(PreparedStatementMissing { statement_id: id })?;
 
         let mut event = QueryExecutionEvent::new(EventType::Execute);
@@ -1745,11 +1728,14 @@ where
         self.noria.drop_all_caches().await?;
         self.state.query_status_cache.clear();
         self.state.prepared_statements.iter_mut().for_each(
-            |PreparedStatement {
-                 prep,
-                 migration_state,
-                 ..
-             }| {
+            |(
+                _,
+                PreparedStatement {
+                    prep,
+                    migration_state,
+                    ..
+                },
+            )| {
                 if *migration_state == MigrationState::Successful {
                     *migration_state = MigrationState::Pending;
                 }

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -143,10 +143,9 @@ impl ps::PsqlBackend for Backend {
         query: &str,
         parameter_data_types: &[Type],
     ) -> Result<ps::PrepareResponse, ps::Error> {
-        let statement_id = self.next_prepared_id(); // If prepare succeeds it will get this id
         self.prepare(query, parameter_data_types)
             .await?
-            .try_into_ps(statement_id)
+            .try_into_ps()
     }
 
     async fn on_execute(

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -21,12 +21,13 @@ use crate::{upstream, PostgreSqlUpstream};
 pub struct PrepareResponse<'a>(pub &'a cl::PrepareResult<LazyUpstream<PostgreSqlUpstream>>);
 
 impl<'a> PrepareResponse<'a> {
-    pub fn try_into_ps(self, prepared_statement_id: u32) -> Result<ps::PrepareResponse, ps::Error> {
+    pub fn try_into_ps(self) -> Result<ps::PrepareResponse, ps::Error> {
         use readyset_adapter::backend::noria_connector::PrepareResult::*;
         use readyset_adapter::backend::noria_connector::{
             PreparedSelectTypes, SelectPrepareResultInner,
         };
 
+        let prepared_statement_id = self.0.statement_id;
         match self.0.upstream_biased() {
             SinglePrepareResult::Noria(Select {
                 types: PreparedSelectTypes::Schema(SelectPrepareResultInner { params, schema, .. }),


### PR DESCRIPTION
Store prepared statements in the adapter Backend in a Slab rather than
in a Vec, to allow for eventual efficient removal and reuse of space for
information about prepared statements. While this involves moving the
generation of the ID up to insertion time, other than that not much is
changing here.

An earlier iteration of this (I0e393fd87d166a48f073287130d610f8afabf7c6)
used a SlotMap instead, but I decided to go with Slab because it's
difficult to convince a SlotMap to use u32-compatible keys, and the
extra behavior of globally unique IDs that SlotMap provides is probably
not necessary for our use case.

