### PR TITLE
readyset-mysql: Store prepared statements in a Vec

### DIFF
--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -33,7 +33,7 @@ pub struct PostgreSqlUpstream {
     /// A tokio task that handles the connection, required by `tokio_postgres` to operate
     _connection_handle: tokio::task::JoinHandle<Result<(), pgsql::Error>>,
     /// Map from prepared statement IDs to prepared statements
-    prepared_statements: HashMap<u32, pgsql::Statement>,
+    prepared_statements: Vec<Option<pgsql::Statement>>,
     /// ID for the next prepared statement
     statement_id_counter: u32,
     /// The user used to connect to the upstream, if any

--- a/readyset-util/src/lib.rs
+++ b/readyset-util/src/lib.rs
@@ -19,6 +19,9 @@ pub mod progress;
 pub mod properties;
 pub mod redacted;
 pub mod shutdown;
+pub mod vec_map;
+
+pub use crate::vec_map::VecMap;
 
 /// Error (returned by [`Indices::indices`] and [`Indices::cloned_indices`]) for an out-of-bounds
 /// index access


### PR DESCRIPTION
Given that we have known-almost-sequential numbers as the ID for
prepared statements, it doesn't make much sense to store them in a
HashMap - instead it's much more efficient to just store them in a dense
Vec<Option<T>>.

