### PR TITLE
adapter: Add a remove_statement method to UpstreamDatabase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883a5821d7d079fcf34ac55f27a833ee61678110f6b97637cc74513c0d0b42fc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4356,6 +4368,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap 4.3.2",
+ "crossbeam-skiplist",
  "database-utils",
  "fail",
  "failpoint-macros",
@@ -4404,6 +4417,7 @@ dependencies = [
  "chrono",
  "clap 4.3.2",
  "criterion",
+ "crossbeam-skiplist",
  "dashmap 4.0.2",
  "database-utils",
  "dataflow-expression",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,6 +4456,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "slab",
  "sqlformat",
  "test-strategy",
  "thiserror",
@@ -5877,9 +5878,12 @@ checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slotmap"

--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -17,7 +17,6 @@ values
 (1, 1),
 (1, 1);
 
-
 query I nosort
 select count(*) from t1 where x in (select x from t2);
 ----
@@ -74,4 +73,24 @@ from t1
 query I nosort
 select x from t1 where y in (select y from t2 where t2.x = t1.x)
 ----
+1
+
+query I rowsort
+select x from t1 where y not in (select y from t2 where t2.x = t1.x)
+----
+2
+3
+
+query I nosort
+select y in (select y from t2 where t2.x = t1.x) from t1 order by x asc
+----
+1
+0
+0
+
+query I nosort
+select y not in (select y from t2 where t2.x = t1.x) from t1 order by x asc
+----
+0
+1
 1

--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -68,3 +68,10 @@ from t1
 3
 0
 1
+
+# Correlated
+
+query I nosort
+select x from t1 where y in (select y from t2 where t2.x = t1.x)
+----
+1

--- a/logictests/in_subquery.test
+++ b/logictests/in_subquery.test
@@ -94,3 +94,21 @@ select y not in (select y from t2 where t2.x = t1.x) from t1 order by x asc
 0
 1
 1
+
+# Nulls
+
+statement ok
+create table t3 (x int, y int);
+
+statement ok
+create table t4 (x int, y int);
+
+statement ok
+insert into t3 (x, y) values (1, null);
+
+statement ok
+insert into t4 (x, y) values (1, 1);
+
+query I nosort
+select x from t3 where y not in (select y from t4 where t4.x = t3.x);
+----

--- a/nom-sql/src/show.rs
+++ b/nom-sql/src/show.rs
@@ -29,6 +29,7 @@ pub enum ShowStatement {
     ReadySetMigrationStatus(u64),
     ReadySetVersion,
     ReadySetTables,
+    Connections,
 }
 
 impl ShowStatement {
@@ -61,6 +62,7 @@ impl ShowStatement {
                 Self::ReadySetMigrationStatus(id) => write!(f, "READYSET MIGRATION STATUS {}", id),
                 Self::ReadySetVersion => write!(f, "READYSET VERSION"),
                 Self::ReadySetTables => write!(f, "READYSET TABLES"),
+                Self::Connections => write!(f, "CONNECTIONS"),
             }
         })
     }
@@ -169,6 +171,7 @@ pub fn show(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u
             ),
             map(show_tables(dialect), ShowStatement::Tables),
             value(ShowStatement::Events, tag_no_case("events")),
+            value(ShowStatement::Connections, tag_no_case("connections")),
         ))(i)?;
         Ok((i, statement))
     }
@@ -487,5 +490,13 @@ mod tests {
             b"SHOW\t READYSET\t MIGRATION\t STATUS\t 123456"
         );
         assert_eq!(res, ShowStatement::ReadySetMigrationStatus(123456))
+    }
+
+    #[test]
+    fn show_connections() {
+        assert_eq!(
+            test_parse!(show(Dialect::MySQL), b"SHOW CONNECTIONS"),
+            ShowStatement::Connections
+        );
     }
 }

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -50,6 +50,7 @@ indexmap = { version = "1", default-features = false }
 quanta = { version = "0.11", default-features = false }
 lru = "0.12.0"
 crossbeam-skiplist = "0.1.1"
+slab = "0.4"
 
 readyset-alloc = { path = "../readyset-alloc/" }
 readyset-client = { path = "../readyset-client/" }

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -48,6 +48,8 @@ parking_lot = "0.11.2"
 sqlformat = "0.2.1"
 indexmap = { version = "1", default-features = false }
 quanta = { version = "0.11", default-features = false }
+lru = "0.12.0"
+crossbeam-skiplist = "0.1.1"
 
 readyset-alloc = { path = "../readyset-alloc/" }
 readyset-client = { path = "../readyset-client/" }
@@ -63,7 +65,6 @@ readyset-sql-passes = { path = "../readyset-sql-passes" }
 readyset-version = { path = "../readyset-version" }
 health-reporter = { path = "../health-reporter" }
 database-utils = { path = "../database-utils" }
-lru = "0.12.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -71,7 +71,6 @@
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -99,6 +98,7 @@ use readyset_errors::{internal, internal_err, unsupported, unsupported_err, Read
 use readyset_telemetry_reporter::{TelemetryBuilder, TelemetryEvent, TelemetrySender};
 use readyset_util::redacted::Sensitive;
 use readyset_version::READYSET_VERSION;
+use slab::Slab;
 use timestamp_service::client::{TimestampClient, WriteId, WriteKey};
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, error, instrument, trace, warn};
@@ -335,7 +335,7 @@ impl BackendBuilder {
             state: BackendState {
                 proxy_state,
                 parsed_query_cache: HashMap::new(),
-                prepared_statements: Vec::new(),
+                prepared_statements: Default::default(),
                 query_status_cache,
                 ticket: self.ticket,
                 timestamp_client: self.timestamp_client,
@@ -565,7 +565,7 @@ where
     // a cache of all previously parsed queries
     parsed_query_cache: HashMap<String, SqlQuery>,
     // all queries previously prepared on noria or upstream, mapped by their ID.
-    prepared_statements: Vec<PreparedStatement<DB>>,
+    prepared_statements: Slab<PreparedStatement<DB>>,
     /// Current RYW ticket. `None` if RYW is not enabled. This `ticket` will
     /// be updated as the client makes writes so as to be an accurate low watermark timestamp
     /// required to make RYW-consistent reads. On reads, the client will pass in this ticket to be
@@ -712,35 +712,14 @@ pub struct PrepareResult<DB: UpstreamDatabase> {
     inner: PrepareResultInner<DB>,
 }
 
-/// # Constructors
 impl<DB: UpstreamDatabase> PrepareResult<DB> {
-    pub fn noria(statement_id: StatementId, noria_res: noria_connector::PrepareResult) -> Self {
+    pub fn new(statement_id: StatementId, inner: PrepareResultInner<DB>) -> Self {
         Self {
             statement_id,
-            inner: PrepareResultInner::Noria(noria_res),
+            inner,
         }
     }
 
-    pub fn upstream(statement_id: StatementId, upstream_res: UpstreamPrepare<DB>) -> Self {
-        Self {
-            statement_id,
-            inner: PrepareResultInner::Upstream(upstream_res),
-        }
-    }
-
-    pub fn both(
-        statement_id: StatementId,
-        noria_res: noria_connector::PrepareResult,
-        upstream_res: UpstreamPrepare<DB>,
-    ) -> Self {
-        Self {
-            statement_id,
-            inner: PrepareResultInner::Both(noria_res, upstream_res),
-        }
-    }
-}
-
-impl<DB: UpstreamDatabase> PrepareResult<DB> {
     pub fn noria_biased(&self) -> SinglePrepareResult<'_, DB> {
         match &self.inner {
             PrepareResultInner::Noria(res) | PrepareResultInner::Both(res, _) => {
@@ -820,13 +799,6 @@ where
             .unwrap_or_else(|| DB::DEFAULT_DB_VERSION.to_string())
     }
 
-    /// The identifier we can reserve for the next prepared statement
-    pub fn next_prepared_id(&self) -> u32 {
-        (self.state.prepared_statements.len())
-            .try_into()
-            .expect("Too many prepared statements")
-    }
-
     /// Switch the active database for this backend to the given named database.
     ///
     /// Internally, this will set the schema search path to a single-element vector with the
@@ -891,9 +863,7 @@ where
         query: &str,
         data: DB::PrepareData<'_>,
         event: &mut QueryExecutionEvent,
-    ) -> Result<PrepareResult<DB>, DB::Error> {
-        let statement_id = self.next_prepared_id();
-
+    ) -> Result<PrepareResultInner<DB>, DB::Error> {
         let do_noria = select_meta.should_do_noria;
         let do_migrate = select_meta.must_migrate;
 
@@ -965,7 +935,7 @@ where
 
         let prep_result = match (upstream_res, noria_res) {
             (Some(upstream_res), Some(Ok(noria_res))) => {
-                PrepareResult::both(statement_id, noria_res, upstream_res?)
+                PrepareResultInner::Both(noria_res, upstream_res?)
             }
             (None, Some(Ok(noria_res))) => {
                 if matches!(
@@ -981,10 +951,10 @@ where
                         "Cannot create PrepareResult for borrowed cache without an upstream result"
                     );
                 }
-                PrepareResult::noria(statement_id, noria_res)
+                PrepareResultInner::Noria(noria_res)
             }
             (None, Some(Err(noria_err))) => return Err(noria_err.into()),
-            (Some(upstream_res), _) => PrepareResult::upstream(statement_id, upstream_res?),
+            (Some(upstream_res), _) => PrepareResultInner::Upstream(upstream_res?),
             (None, None) => return Err(ReadySetError::Unsupported(query.to_string()).into()),
         };
 
@@ -998,15 +968,14 @@ where
         stmt: &SqlQuery,
         data: DB::PrepareData<'_>,
         event: &mut QueryExecutionEvent,
-    ) -> Result<PrepareResult<DB>, DB::Error> {
-        let statement_id = self.next_prepared_id();
+    ) -> Result<PrepareResultInner<DB>, DB::Error> {
         event.sql_type = SqlQueryType::Write;
         if let Some(ref mut upstream) = self.upstream {
             let _t = event.start_upstream_timer();
             let res = upstream
                 .prepare(query, data)
                 .await
-                .map(|ur| PrepareResult::upstream(statement_id, ur));
+                .map(PrepareResultInner::Upstream);
             self.last_query = Some(QueryInfo {
                 destination: QueryDestination::Upstream,
                 noria_error: String::new(),
@@ -1025,7 +994,7 @@ where
                 destination: QueryDestination::Readyset,
                 noria_error: String::new(),
             });
-            Ok(PrepareResult::noria(statement_id, res))
+            Ok(PrepareResultInner::Noria(res))
         }
     }
 
@@ -1134,8 +1103,7 @@ where
         query: &str,
         data: DB::PrepareData<'_>,
         event: &mut QueryExecutionEvent,
-    ) -> Result<PrepareResult<DB>, DB::Error> {
-        let statement_id = self.next_prepared_id();
+    ) -> Result<PrepareResultInner<DB>, DB::Error> {
         match meta {
             PrepareMeta::Proxy
             | PrepareMeta::FailedToParse
@@ -1147,7 +1115,7 @@ where
                 let res = self
                     .prepare_fallback(query, data)
                     .await
-                    .map(|res| PrepareResult::upstream(statement_id, res));
+                    .map(PrepareResultInner::Upstream);
 
                 self.last_query = Some(QueryInfo {
                     destination: QueryDestination::Upstream,
@@ -1181,11 +1149,11 @@ where
         let mut query_event = QueryExecutionEvent::new(EventType::Prepare);
 
         let meta = self.plan_prepare(query).await;
-        let res = self
+        let prep = self
             .do_prepare(&meta, query, data, &mut query_event)
             .await?;
 
-        let (id, parsed_query, migration_state, view_request, always) = match meta {
+        let (query_id, parsed_query, migration_state, view_request, always) = match meta {
             PrepareMeta::Write { stmt } => (
                 None,
                 Some(Arc::new(stmt)),
@@ -1219,21 +1187,31 @@ where
         if let Some(parsed) = &parsed_query {
             query_event.query = Some(parsed.clone());
         }
-        query_event.query_id = id;
+        query_event.query_id = query_id;
 
-        let cache_entry = PreparedStatement {
-            query_id: id,
-            prep: res,
+        let statement_id = self.state.prepared_statements.insert(PreparedStatement {
+            query_id,
+            prep: PrepareResult::new(
+                self.state
+                    .prepared_statements
+                    .vacant_key()
+                    .try_into()
+                    .expect(
+                        "Cannot prepare more than u32::MAX statements with a single connection",
+                    ),
+                prep,
+            ),
             migration_state,
             execution_info: None,
             parsed_query,
             view_request,
             always,
-        };
+        });
 
-        self.state.prepared_statements.push(cache_entry);
-
-        Ok(&self.state.prepared_statements.last().unwrap().prep)
+        Ok(
+            // SAFETY: Just inserted!
+            &unsafe { self.state.prepared_statements.get_unchecked(statement_id) }.prep,
+        )
     }
 
     /// Executes a prepared statement on ReadySet
@@ -1401,8 +1379,10 @@ where
 
         // At this point we got a successful noria prepare, so we want to replace the Upstream
         // result with a Both result
-        cached_entry.prep =
-            PrepareResult::both(cached_entry.prep.statement_id, noria_prep, upstream_prep);
+        cached_entry.prep = PrepareResult::new(
+            cached_entry.prep.statement_id,
+            PrepareResultInner::Both(noria_prep, upstream_prep),
+        );
         // If the query was previously `Pending`, update to `Successful`. If it was inlined, we do
         // not update the migration state.
         if cached_entry.migration_state == MigrationState::Pending {
@@ -1420,12 +1400,15 @@ where
             .prepared_statements
             .iter_mut()
             .filter_map(
-                |PreparedStatement {
-                     prep,
-                     migration_state,
-                     view_request,
-                     ..
-                 }| {
+                |(
+                    _,
+                    PreparedStatement {
+                        prep,
+                        migration_state,
+                        view_request,
+                        ..
+                    },
+                )| {
                     if *migration_state == MigrationState::Successful
                         && view_request.as_ref() == Some(stmt)
                     {
@@ -1456,7 +1439,7 @@ where
         let cached_statement = self
             .state
             .prepared_statements
-            .get_mut(id as usize)
+            .get_mut(id as _)
             .ok_or(PreparedStatementMissing { statement_id: id })?;
 
         let mut event = QueryExecutionEvent::new(EventType::Execute);
@@ -1772,11 +1755,14 @@ where
         self.noria.drop_all_caches().await?;
         self.state.query_status_cache.clear();
         self.state.prepared_statements.iter_mut().for_each(
-            |PreparedStatement {
-                 prep,
-                 migration_state,
-                 ..
-             }| {
+            |(
+                _,
+                PreparedStatement {
+                    prep,
+                    migration_state,
+                    ..
+                },
+            )| {
                 if *migration_state == MigrationState::Successful {
                     *migration_state = MigrationState::Pending;
                 }

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -223,7 +223,6 @@ impl MigrationHandler {
             .noria
             .prepare_select(
                 view_request.statement.clone(),
-                0,
                 true,
                 Some(view_request.schema_search_path.clone()),
             )

--- a/readyset-adapter/src/upstream_database.rs
+++ b/readyset-adapter/src/upstream_database.rs
@@ -143,6 +143,12 @@ pub trait UpstreamDatabase: Sized + Send {
         exec_meta: Self::ExecMeta<'_>,
     ) -> Result<Self::QueryResult<'a>, Self::Error>;
 
+    /// Remove a prepared statement from the cache, and tell the upstream database to remove it and
+    /// free any resources associated with it.
+    ///
+    /// Returns an error if the statement doesn't exist
+    async fn remove_statement(&mut self, statement_id: u32) -> Result<(), Self::Error>;
+
     /// Execute a raw, un-prepared query
     async fn query<'a>(&'a mut self, query: &'a str) -> Result<Self::QueryResult<'a>, Self::Error>;
 
@@ -263,6 +269,10 @@ where
             .await?
             .execute(statement_id, params, exec_meta)
             .await
+    }
+
+    async fn remove_statement(&mut self, statement_id: u32) -> Result<(), Self::Error> {
+        self.upstream().await?.remove_statement(statement_id).await
     }
 
     async fn query<'a>(&'a mut self, query: &'a str) -> Result<Self::QueryResult<'a>, Self::Error> {

--- a/readyset-mir/src/rewrite/decorrelate.rs
+++ b/readyset-mir/src/rewrite/decorrelate.rs
@@ -19,8 +19,8 @@ use crate::{Column, NodeIndex};
 /// - [`Project`], [`Join`], [`LeftJoin`], and dependent left or inner joins *other* than the one
 ///   this filter depends on are all totally commutative with filters, so can be swapped in position
 ///   with those filters with impunity
-/// - Grouped nodes ([`Aggregation`] and [`Extremum`]) require adding any *non* dependent columns
-///   mentioned in the filter to the group-by of the node.
+/// - Grouped nodes ([`Aggregation`], [`Extremum`] and [`Distinct`]) require adding any *non*
+///   dependent columns mentioned in the filter to the group-by of the node.
 /// - All other nodes currently return an [unsupported error][] - it *is* theoretically possible to
 ///   push below any node, but currently we don't have that ability
 ///
@@ -103,7 +103,9 @@ fn push_dependent_filter(
         | MirNodeInner::LeftJoin { .. }
         | MirNodeInner::DependentJoin { .. }
         | MirNodeInner::AliasTable { .. } => true,
-        MirNodeInner::Aggregation { .. } | MirNodeInner::Extremum { .. } => {
+        MirNodeInner::Aggregation { .. }
+        | MirNodeInner::Extremum { .. }
+        | MirNodeInner::Distinct { .. } => {
             for col in dependency.non_dependent_columns() {
                 query.graph.add_column(child_idx, col.clone())?;
             }

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -143,10 +143,9 @@ impl ps::PsqlBackend for Backend {
         query: &str,
         parameter_data_types: &[Type],
     ) -> Result<ps::PrepareResponse, ps::Error> {
-        let statement_id = self.next_prepared_id(); // If prepare succeeds it will get this id
         self.prepare(query, parameter_data_types)
             .await?
-            .try_into_ps(statement_id)
+            .try_into_ps()
     }
 
     async fn on_execute(

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -21,12 +21,13 @@ use crate::{upstream, PostgreSqlUpstream};
 pub struct PrepareResponse<'a>(pub &'a cl::PrepareResult<LazyUpstream<PostgreSqlUpstream>>);
 
 impl<'a> PrepareResponse<'a> {
-    pub fn try_into_ps(self, prepared_statement_id: u32) -> Result<ps::PrepareResponse, ps::Error> {
+    pub fn try_into_ps(self) -> Result<ps::PrepareResponse, ps::Error> {
         use readyset_adapter::backend::noria_connector::PrepareResult::*;
         use readyset_adapter::backend::noria_connector::{
             PreparedSelectTypes, SelectPrepareResultInner,
         };
 
+        let prepared_statement_id = self.0.statement_id;
         match self.0.upstream_biased() {
             SinglePrepareResult::Noria(Select {
                 types: PreparedSelectTypes::Schema(SelectPrepareResultInner { params, schema, .. }),

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -24,20 +24,22 @@ impl<'a> PrepareResponse<'a> {
     pub fn try_into_ps(self, prepared_statement_id: u32) -> Result<ps::PrepareResponse, ps::Error> {
         use readyset_adapter::backend::noria_connector::PrepareResult::*;
         use readyset_adapter::backend::noria_connector::{
-            SelectPrepareResult, SelectPrepareResultInner,
+            PreparedSelectTypes, SelectPrepareResultInner,
         };
 
         match self.0.upstream_biased() {
-            SinglePrepareResult::Noria(Select(SelectPrepareResult::Schema(
-                SelectPrepareResultInner { params, schema, .. },
-            ))) => Ok(ps::PrepareResponse {
+            SinglePrepareResult::Noria(Select {
+                types: PreparedSelectTypes::Schema(SelectPrepareResultInner { params, schema, .. }),
+                ..
+            }) => Ok(ps::PrepareResponse {
                 prepared_statement_id,
                 param_schema: NoriaSchema(params).try_into()?,
                 row_schema: NoriaSchema(schema).try_into()?,
             }),
-            SinglePrepareResult::Noria(Select(SelectPrepareResult::NoSchema(_))) => {
-                Err(ps::Error::InternalError("Unreachable".into()))
-            }
+            SinglePrepareResult::Noria(Select {
+                types: PreparedSelectTypes::NoSchema,
+                ..
+            }) => Err(ps::Error::InternalError("Unreachable".into())),
             SinglePrepareResult::Noria(Insert { params, schema, .. }) => Ok(ps::PrepareResponse {
                 prepared_statement_id,
                 param_schema: NoriaSchema(params).try_into()?,

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -308,6 +308,16 @@ impl UpstreamDatabase for PostgreSqlUpstream {
         }
     }
 
+    async fn remove_statement(&mut self, statement_id: u32) -> Result<(), Self::Error> {
+        self.prepared_statements
+            .remove(&statement_id)
+            .ok_or(Error::ReadySet(ReadySetError::PreparedStatementMissing {
+                statement_id,
+            }))?;
+
+        Ok(())
+    }
+
     /// Handle starting a transaction with the upstream database.
     async fn start_tx<'a>(
         &'a mut self,

--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -899,13 +899,13 @@ mod types {
             .unwrap();
         eventually!(
             run_test: {
-                let res = client.query_one(&stmt, &[&"A"]).await.unwrap();
+                let res = client.query_one(&stmt, &[&"A"]).await;
                 let dest = last_query_info(&client).await.destination;
                 AssertUnwindSafe(move || (res, dest))
             },
             then_assert: |res| {
                 let (res, dest) = res();
-                assert_eq!(res.get::<_, String>(0), "a");
+                assert_eq!(res.unwrap().get::<_, String>(0), "a");
                 assert_eq!(dest, QueryDestination::Readyset);
             }
         );

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -1138,6 +1138,7 @@ impl SqlToMirConverter {
             }
         };
 
+        let is_correlated = is_correlated(&subquery);
         let query_graph = to_query_graph(subquery)?;
         let subquery_leaf = self.named_query_to_mir(
             query_name,
@@ -1185,7 +1186,11 @@ impl SqlToMirConverter {
             }],
             parent,
             right_mark,
-            JoinKind::Left,
+            if is_correlated {
+                JoinKind::DependentLeft
+            } else {
+                JoinKind::Left
+            },
         )?;
 
         Ok(self.make_project_node(

--- a/readyset-sql-passes/src/anonymize.rs
+++ b/readyset-sql-passes/src/anonymize.rs
@@ -202,7 +202,8 @@ impl<'ast> VisitorMut<'ast> for AnonymizeVisitor<'_> {
             | nom_sql::ShowStatement::ReadySetStatusAdapter
             | nom_sql::ShowStatement::ReadySetMigrationStatus(..)
             | nom_sql::ShowStatement::ReadySetVersion
-            | nom_sql::ShowStatement::ReadySetTables => {}
+            | nom_sql::ShowStatement::ReadySetTables
+            | nom_sql::ShowStatement::Connections => {}
         }
         Ok(())
     }

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -23,6 +23,7 @@ tracing-subscriber = "0.3.9"
 tracing-futures = "0.2.5"
 reqwest = { version = "0.11", features = ["json"] }
 chrono = "0.4"
+crossbeam-skiplist = "0.1.1"
 
 # Local dependencies
 health-reporter = { path = "../health-reporter" }


### PR DESCRIPTION
Add a method to the UpstreamDatabase trait, implemented for both psql
and mysql, that removes a statement from the upstream database. On
postgres, this is done via the Drop impl for StatementInner, but on
MySQL this needs to be done explicitly by calling conn.close(stmt).

This is unused as of this commit, but next up will be used by the client
library shim to fully implement closing of prepared statements

