### PR TITLE
readyset-{psql,mysql}: Implement closing of prepared statements

### DIFF
--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -699,7 +699,9 @@ where
         }
     }
 
-    async fn on_close(&mut self, _: u32) {}
+    async fn on_close(&mut self, statement_id: u32) {
+        let _ = self.noria.remove_statement(statement_id).await;
+    }
 
     async fn on_query(&mut self, query: &str, results: QueryResultWriter<'_, W>) -> io::Result<()> {
         if self.enable_statement_logging {

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -163,7 +163,8 @@ impl ps::PsqlBackend for Backend {
             .try_into()
     }
 
-    async fn on_close(&mut self, _statement_id: u32) -> Result<(), ps::Error> {
+    async fn on_close(&mut self, statement_id: u32) -> Result<(), ps::Error> {
+        self.inner.remove_statement(statement_id).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Implement the rest of closing prepared statements for both readyset-psql
and -mysql, by delegating to the `remove_statement` method on the
Backend.

Release-Note-Core: ReadySet now correctly closes upstream prepared
  statements when the client requests prepared statements to be closed
  over either the MySQL or PostgreSQL protocols.
