### PR TITLE
readyset-psql: Reduce citext test flakiness

### DIFF
--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -892,13 +892,13 @@ mod types {
             .unwrap();
         eventually!(
             run_test: {
-                let res = client.query_one(&stmt, &[&"A"]).await.unwrap();
+                let res = client.query_one(&stmt, &[&"A"]).await;
                 let dest = last_query_info(&client).await.destination;
                 AssertUnwindSafe(move || (res, dest))
             },
             then_assert: |res| {
                 let (res, dest) = res();
-                assert_eq!(res.get::<_, String>(0), "a");
+                assert_eq!(res.unwrap().get::<_, String>(0), "a");
                 assert_eq!(dest, QueryDestination::Readyset);
             }
         );


### PR DESCRIPTION
Moves an `unwrap()` from the `run_test` block to the `then_assert` block
of the `eventually!` macro. This doesn't resolve every way in which it
flakes, but it seems like a recent change has caused the test to flake
in this specific way more frequently.

Refs: REA-3062
