### PR TITLE
psql-srv: Deallocate unnamed prepared statement on Parse

### DIFF
--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -690,6 +690,18 @@ impl Protocol {
                     parameter_data_types,
                 } => {
                     self.state = State::Extended;
+
+                    if prepared_statement_name.is_empty() {
+                        if let Some(id) = self
+                            .prepared_statements
+                            .remove(prepared_statement_name.borrow() as &str)
+                            .map(|d| d.prepared_statement_id)
+                        {
+                            backend.on_close(id).await?;
+                            channel.clear_statement_param_types(&prepared_statement_name);
+                        }
+                    }
+
                     let PrepareResponse {
                         prepared_statement_id,
                         param_schema,


### PR DESCRIPTION
Per the postgres documentation[0] for the Extended Query protocol, if a
Parse request is received for an unnamed prepared statement, any
previously-prepared unnamed prepared statement should be deallocated. We
previously didn't do this - which we think was causing unbounded growth
in the number of prepared statements sent to the upstream DB. We *could*
go to a bunch of effort to pass the empty string through to the upstream
DB, but it's much simpler to just add an extra check to the handling of
the Parse message to call on_close for an existing unnamed prepared
statement if one exists

[0]: https://www.postgresql.org/docs/current/protocol-flow.html

