### PR TITLE
adapter: Use LruCache for parsed query cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,6 +4441,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "proptest",
  "quanta",
+ "rand 0.8.5",
  "readyset-alloc",
  "readyset-client",
  "readyset-client-metrics",

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -71,12 +71,17 @@ database-utils = { path = "../database-utils" }
 proptest = "1.0.0"
 test-strategy = "0.2.0"
 criterion = "0.3"
+rand = "0.8.5"
 
 [lib]
 path = "src/lib.rs"
 
 [[bench]]
 name = "rewrite"
+harness = false
+
+[[bench]]
+name = "parse"
 harness = false
 
 [features]

--- a/readyset-adapter/benches/parse.rs
+++ b/readyset-adapter/benches/parse.rs
@@ -1,0 +1,56 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use lru::LruCache;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+use readyset_client::query::QueryId;
+use readyset_util::hash::hash;
+
+fn random_string(len: usize) -> String {
+    rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect()
+}
+
+// Benchmarks to see if having an LruCache<String, SqlQuery> or an LruCache<QueryId, SqlQuery> is
+// faster for `parsed_query_cache`
+fn lru_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("LruCache Benchmarks");
+
+    for len in [100, 1000, 10000].iter() {
+        let mut lru_cache_str = LruCache::<String, String>::new(10000.try_into().expect("nonzero"));
+        let queries: Vec<String> = (0..100).map(|_| random_string(*len)).collect();
+        group.bench_with_input(
+            BenchmarkId::new("LruCache<String, String>", len),
+            len,
+            |b, &_| {
+                b.iter(|| {
+                    for q in queries.iter() {
+                        lru_cache_str.put(black_box(q.clone()), black_box(q.clone()));
+                    }
+                });
+            },
+        );
+
+        let mut lru_cache_hash =
+            LruCache::<QueryId, String>::new(10000.try_into().expect("nonzero"));
+        group.bench_with_input(
+            BenchmarkId::new("LruCache<QueryId, String>", len),
+            len,
+            |b, &_| {
+                b.iter(|| {
+                    for q in queries.iter() {
+                        let id = QueryId::new(hash(&q));
+                        lru_cache_hash.put(black_box(id), black_box(q.clone()));
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, lru_benchmarks);
+criterion_main!(benches);

--- a/readyset-util/src/hash.rs
+++ b/readyset-util/src/hash.rs
@@ -9,6 +9,8 @@ use std::hash::{Hash, Hasher};
 /// let x: i32 = 123;
 /// assert_eq!(readyset_util::hash::hash(&x), 14370432302296844161);
 /// ```
+// TODO: We probably want to use u128 here--u64 has 3% chance of collision once we get to 1 Billion
+// entries.
 pub fn hash<T: Hash>(x: &T) -> u64 {
     let mut hasher = DefaultHasher::new();
     x.hash(&mut hasher);


### PR DESCRIPTION
We were storing the full query string as well as the full parsed query
string for every unique parsed query we were seeing. This is quite
expensive if we are constantly seeing new queries.

This commit makes this cache an LRU cache with a capacity (for now) of
10k entries.

Also included in this commit is a benchmark used to decide if we should
use an LruCache<QueryId, SqlQuery> instead of the current version, which
the benchmarks says we should not as it is slower. The extra memory
usage is worth it since this is in the hot path.

