### PR TITLE
server: log reader when read stuck waiting for keys

### DIFF
--- a/readyset-server/src/worker/readers.rs
+++ b/readyset-server/src/worker/readers.rs
@@ -528,7 +528,7 @@ impl BlockingRead {
 
         // Check if we reached a warning timeout
         if self.first.elapsed() > WAIT_BEFORE_WARNING && !self.warned {
-            warn!(keys = ?still_waiting, "Read stuck waiting for keys");
+            warn!(reader=%target.name.display_unquoted(), keys = ?still_waiting, "Read stuck waiting for keys");
             self.warned = true;
         }
 


### PR DESCRIPTION
This adds the name of the reader when we see this warning log to help
with debugging.

