### PR TITLE
dataflow: Simplify domain channel code

### DIFF
--- a/readyset-dataflow/src/node/special/egress.rs
+++ b/readyset-dataflow/src/node/special/egress.rs
@@ -119,7 +119,7 @@ impl Egress {
 
     pub fn process(
         &mut self,
-        message: &mut Option<Box<Packet>>,
+        message: &mut Option<Packet>,
         keyed_by: Option<&[usize]>,
         shard: usize,
         replica: usize,
@@ -165,7 +165,7 @@ impl Egress {
             } else {
                 // we know this is a data (not a replay)
                 // because, a replay will force a take
-                message.as_ref().map(|m| Box::new(m.clone_data())).unwrap()
+                message.as_ref().map(|m| m.clone_data()).unwrap()
             };
 
             // src is usually ignored and overwritten by ingress
@@ -176,7 +176,7 @@ impl Egress {
 
             // Take the packet through the filter. The filter will make any necessary modifications
             // to the packet to be sent, and tell us if we should send the packet or drop it.
-            if !packet_filter.process(m.as_mut(), keyed_by, tx.node)? {
+            if !packet_filter.process(&mut m, keyed_by, tx.node)? {
                 tx.inc_dropped();
                 continue;
             }

--- a/readyset-dataflow/src/node/special/reader.rs
+++ b/readyset-dataflow/src/node/special/reader.rs
@@ -119,7 +119,7 @@ impl Reader {
     #[failpoint("reader-handle-packet")]
     pub(in crate::node) fn process(
         &mut self,
-        m: &mut Option<Box<Packet>>,
+        m: &mut Option<Packet>,
         swap: bool,
         state: &mut backlog::WriteHandle,
     ) {

--- a/readyset-dataflow/src/prelude.rs
+++ b/readyset-dataflow/src/prelude.rs
@@ -40,11 +40,8 @@ pub use readyset_errors::*;
 pub use vec1::vec1;
 
 pub use crate::processing::{ColumnRef, ColumnSource};
-pub use crate::EvictionKind;
+pub use crate::{ChannelCoordinator, EvictionKind};
 
-/// Channel coordinator type specialized for domains
-pub type ChannelCoordinator =
-    crate::domain::channel::ChannelCoordinator<ReplicaAddress, Box<Packet>>;
 pub trait Executor {
-    fn send(&mut self, dest: ReplicaAddress, m: Box<Packet>);
+    fn send(&mut self, dest: ReplicaAddress, m: Packet);
 }

--- a/readyset-server/src/lib.rs
+++ b/readyset-server/src/lib.rs
@@ -661,32 +661,6 @@ pub struct WorkerOptions {
     pub background_recovery_interval_seconds: u64,
 }
 
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
-use futures_util::sink::Sink;
-struct ImplSinkForSender<T>(tokio::sync::mpsc::UnboundedSender<T>);
-
-impl<T> Sink<T> for ImplSinkForSender<T> {
-    type Error = tokio::sync::mpsc::error::SendError<T>;
-
-    fn poll_ready(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-        self.0.send(item)
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn poll_close(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-}
-
 // TODO(justin): Change VolumeId type when we know this fixed size.
 /// Id associated with the worker server's volume.
 pub type VolumeId = String;

--- a/readyset-server/src/worker/mod.rs
+++ b/readyset-server/src/worker/mod.rs
@@ -10,7 +10,7 @@ use std::task::{ready, Context, Poll};
 use std::time::Duration;
 
 use dataflow::payload::EvictRequest;
-use dataflow::{DomainBuilder, DomainRequest, Packet, Readers};
+use dataflow::{ChannelCoordinator, DomainBuilder, DomainRequest, Packet, Readers};
 use enum_kinds::EnumKind;
 use futures::stream::FuturesUnordered;
 use futures_util::future::TryFutureExt;
@@ -44,8 +44,6 @@ use crate::worker::replica::WrappedDomainRequest;
 /// left-right map associated with a reader node.
 pub mod readers;
 mod replica;
-
-type ChannelCoordinator = dataflow::ChannelCoordinator<ReplicaAddress, Box<Packet>>;
 
 /// Timeout for requests made from the controller to the server
 const CONTROLLER_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
@@ -647,10 +645,10 @@ async fn do_eviction(
                         })?),
                     };
                     let r = tx
-                        .send(Box::new(Packet::Evict(EvictRequest::Bytes {
+                        .send(Packet::Evict(EvictRequest::Bytes {
                             node: None,
                             num_bytes: evict,
-                        })))
+                        }))
                         .await;
 
                     if let Err(e) = r {


### PR DESCRIPTION
This commit makes concrete all of the abstract domain channel code. It
seems like that code was written with the assumption that it would be
used broadly for many different purposes. In practice, we only use it
for domain communication, so we are able to remove most of the type
parameters to greatly simplify the types.

This change has the added benefit that we no longer need to `Box` domain
packets when sending them.

