### PR TITLE
metrics: Add domain packet queueing metrics

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -355,6 +355,14 @@ pub mod recorded {
     /// | packet_type | The type of packet |
     pub const DOMAIN_PACKET_SENT: &str = "readyset_domain.packet_sent";
 
+    /// Gauge: The number of dataflow packets queued for each domain.
+    ///
+    /// | Tag | Description |
+    /// | domain | The index of the domain. |
+    /// | shard | The shard of the base table the lookup is requested in. |
+    /// | packet_type | The type of packet |
+    pub const DOMAIN_PACKETS_QUEUED: &str = "readyset_domain.packets_queued";
+
     /// Histogram: The time a snapshot takes to be performed.
     pub const REPLICATOR_SNAPSHOT_DURATION: &str = "readyset_replicator.snapshot_duration_us";
 

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -44,7 +44,7 @@ use vec1::Vec1;
 
 pub(crate) use self::replay_paths::ReplayPath;
 use self::replay_paths::{Destination, ReplayPathSpec, ReplayPaths, Target};
-use crate::domain::channel::ChannelCoordinator;
+use crate::domain::channel::{ChannelCoordinator, DomainReceiver, DomainSender};
 use crate::node::special::EgressTx;
 use crate::node::{NodeProcessingResult, ProcessEnv};
 use crate::payload::{
@@ -4504,5 +4504,9 @@ impl Domain {
         }
 
         Ok(())
+    }
+
+    pub fn channel(&self) -> (DomainSender, DomainReceiver) {
+        channel::domain_channel(self.address())
     }
 }

--- a/readyset-dataflow/src/lib.rs
+++ b/readyset-dataflow/src/lib.rs
@@ -63,9 +63,7 @@ pub use dataflow_state::{
     BaseTableState, DurabilityMode, MaterializedNodeState, PersistenceParameters, PersistentState,
 };
 
-pub use crate::domain::channel::{
-    channel as domain_channel, ChannelCoordinator, DomainReceiver, DomainSender, DualTcpStream,
-};
+pub use crate::domain::channel::{ChannelCoordinator, DomainReceiver, DomainSender, DualTcpStream};
 pub use crate::domain::{Domain, DomainBuilder, DomainIndex};
 pub use crate::node_map::NodeMap;
 pub use crate::payload::{DomainRequest, Packet, PacketDiscriminants};

--- a/readyset-server/src/worker/mod.rs
+++ b/readyset-server/src/worker/mod.rs
@@ -336,7 +336,7 @@ impl Worker {
 
                 // this channel is used for in-process domain traffic, to avoid going through the
                 // network stack unnecessarily
-                let (local_tx, local_rx) = dataflow::domain_channel();
+                let (local_tx, local_rx) = domain.channel();
                 // this channel is used for domain requests; it has a buffer size of 1 to prevent
                 // flooding a domain with requests
                 let (req_tx, req_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
Adds a new `readyset_domain.packets_queued` gauge metric to keep track
of how many packets are queued for each domain at a given time.

