### PR TITLE
dataflow: Add domain channel types

### DIFF
--- a/readyset-dataflow/src/lib.rs
+++ b/readyset-dataflow/src/lib.rs
@@ -63,7 +63,9 @@ pub use dataflow_state::{
     BaseTableState, DurabilityMode, MaterializedNodeState, PersistenceParameters, PersistentState,
 };
 
-pub use crate::domain::channel::{ChannelCoordinator, DualTcpStream};
+pub use crate::domain::channel::{
+    channel as domain_channel, ChannelCoordinator, DomainReceiver, DomainSender, DualTcpStream,
+};
 pub use crate::domain::{Domain, DomainBuilder, DomainIndex};
 pub use crate::node_map::NodeMap;
 pub use crate::payload::{DomainRequest, Packet, PacketDiscriminants};

--- a/readyset-server/src/worker/mod.rs
+++ b/readyset-server/src/worker/mod.rs
@@ -336,7 +336,7 @@ impl Worker {
 
                 // this channel is used for in-process domain traffic, to avoid going through the
                 // network stack unnecessarily
-                let (local_tx, local_rx) = tokio::sync::mpsc::unbounded_channel();
+                let (local_tx, local_rx) = dataflow::domain_channel();
                 // this channel is used for domain requests; it has a buffer size of 1 to prevent
                 // flooding a domain with requests
                 let (req_tx, req_rx) = tokio::sync::mpsc::channel(1);


### PR DESCRIPTION
This commit adds `DomainSender` and `DomainReceiver` types that wrap the
tokio mpsc sender and receiver types. This will allow us to add, in a
future commit, metrics that track the number of `Packet`s queued for
each domain: these wrapper types will wrap a domain metrics handle and
will allow us to emit a metric in centralized locations
(`DomainSender::send` and `DomainReceiver::recv`), as opposed to having
to emit a metric everywhere we invoke `UnboundedSender::send`.

