### PR TITLE
dataflow: Split Input/Message forward metrics

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -34,8 +34,8 @@ pub mod recorded {
     pub const DOMAIN_REPLAY_MISSES: &str = "readyset_domain.replay_misses";
 
     /// Histogram: The time in microseconds that a domain spends
-    /// handling and forwarding a Message or Input packet. Recorded at
-    /// the domain following handling each Message and Input packet.
+    /// handling and forwarding a Message packet. Recorded at the domain
+    /// following handling each Message packet.
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
@@ -43,11 +43,11 @@ pub mod recorded {
     /// | to_node |The dst node of the packet. |
     /// | domain | The index of the domain handling the packet. |
     /// | shard | The shard the domain handling the packet. |
-    pub const DOMAIN_FORWARD_TIME: &str = "readyset_forward_time_us";
+    pub const DOMAIN_MESSAGE_FORWARD_TIME: &str = "readyset_message_forward_time_us";
 
     /// Counter: The total time the domain spends handling and forwarding
-    /// a Message or Input packet. Recorded at the domain following handling
-    /// each Message and Input packet.
+    /// a Message packet. Recorded at the domain following handling each
+    /// Message packet.
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
@@ -55,7 +55,31 @@ pub mod recorded {
     /// | to_node |The dst node of the packet. |
     /// | domain | The index of the domain handling the packet. |
     /// | shard | The shard the domain handling the packet. |
-    pub const DOMAIN_TOTAL_FORWARD_TIME: &str = "readyset_total_forward_time_us";
+    pub const DOMAIN_TOTAL_MESSAGE_FORWARD_TIME: &str = "readyset_total_message_forward_time_us";
+
+    /// Histogram: The time in microseconds that a domain spends
+    /// handling and forwarding an Input packet. Recorded at the domain
+    /// following handling each Input packet.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | from_node | The src node of the packet. |
+    /// | to_node |The dst node of the packet. |
+    /// | domain | The index of the domain handling the packet. |
+    /// | shard | The shard the domain handling the packet. |
+    pub const DOMAIN_INPUT_FORWARD_TIME: &str = "readyset_input_forward_time_us";
+
+    /// Counter: The total time the domain spends handling and forwarding
+    /// an Input packet. Recorded at the domain following handling each
+    /// Input packet.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | from_node | The src node of the packet. |
+    /// | to_node |The dst node of the packet. |
+    /// | domain | The index of the domain handling the packet. |
+    /// | shard | The shard the domain handling the packet. |
+    pub const DOMAIN_TOTAL_INPUT_FORWARD_TIME: &str = "readyset_total_input_forward_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling a ReplayPiece packet. Recorded at the domain following

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -243,7 +243,7 @@ impl DomainMetrics {
         }
     }
 
-    pub(super) fn rec_forward_time(
+    pub(super) fn rec_message_forward_time(
         &mut self,
         src: LocalNodeIndex,
         dst: LocalNodeIndex,
@@ -254,7 +254,7 @@ impl DomainMetrics {
             histo.record(time.as_micros() as f64);
         } else {
             let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_FORWARD_TIME,
+                recorded::DOMAIN_TOTAL_MESSAGE_FORWARD_TIME,
                 "from_node" => src.to_string(),
                 "to_node" => dst.to_string(),
                 "domain" => self.index.clone(),
@@ -262,7 +262,40 @@ impl DomainMetrics {
             );
 
             let histo = register_histogram!(
-                recorded::DOMAIN_FORWARD_TIME,
+                recorded::DOMAIN_MESSAGE_FORWARD_TIME,
+                "from_node" => src.to_string(),
+                "to_node" => dst.to_string(),
+                "domain" => self.index.clone(),
+                "shard" => self.shard.clone(),
+            );
+
+            ctr.increment(time.as_micros() as u64);
+            histo.record(time.as_micros() as f64);
+
+            self.total_forward_time.insert((src, dst), (ctr, histo));
+        }
+    }
+
+    pub(super) fn rec_input_forward_time(
+        &mut self,
+        src: LocalNodeIndex,
+        dst: LocalNodeIndex,
+        time: Duration,
+    ) {
+        if let Some((ctr, histo)) = self.total_forward_time.get(&(src, dst)) {
+            ctr.increment(time.as_micros() as u64);
+            histo.record(time.as_micros() as f64);
+        } else {
+            let ctr = register_counter!(
+                recorded::DOMAIN_TOTAL_INPUT_FORWARD_TIME,
+                "from_node" => src.to_string(),
+                "to_node" => dst.to_string(),
+                "domain" => self.index.clone(),
+                "shard" => self.shard.clone(),
+            );
+
+            let histo = register_histogram!(
+                recorded::DOMAIN_INPUT_FORWARD_TIME,
                 "from_node" => src.to_string(),
                 "to_node" => dst.to_string(),
                 "domain" => self.index.clone(),

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -2366,7 +2366,7 @@ impl Domain {
         self.metrics.inc_packets_sent(&m);
 
         match *m {
-            Packet::Message { .. } | Packet::Input { .. } => {
+            Packet::Message { .. } => {
                 // WO for https://github.com/rust-lang/rfcs/issues/1403
                 let start = time::Instant::now();
                 let src = m.src();
@@ -2374,7 +2374,19 @@ impl Domain {
                 self.total_forward_time.start();
                 self.dispatch(m, executor)?;
                 self.total_forward_time.stop();
-                self.metrics.rec_forward_time(src, dst, start.elapsed());
+                self.metrics
+                    .rec_message_forward_time(src, dst, start.elapsed());
+            }
+            Packet::Input { .. } => {
+                // WO for https://github.com/rust-lang/rfcs/issues/1403
+                let start = time::Instant::now();
+                let src = m.src();
+                let dst = m.dst();
+                self.total_forward_time.start();
+                self.dispatch(m, executor)?;
+                self.total_forward_time.stop();
+                self.metrics
+                    .rec_input_forward_time(src, dst, start.elapsed());
             }
             Packet::ReplayPiece { tag, .. } => {
                 let start = time::Instant::now();


### PR DESCRIPTION
Splits the `readyset_forward_time` metric into separate
`readyset_message_forward_time` and `readyset_input_forward_time`
metrics to give us more granular information on how domains are spending
their time.

