### PR TITLE
readyset-data: Fix citext coercion

### DIFF
--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -582,7 +582,9 @@ impl DfValue {
                 // it does then a value of 0 is generally a safe bet for enum values that don't
                 // trigger the happy path:
                 .unwrap_or(DfValue::Int(0));
-        } else if col_ty.is_array() && col_ty.innermost_array_type().is_enum() {
+        } else if (col_ty.is_array() && col_ty.innermost_array_type().is_enum())
+            || col_ty.is_citext()
+        {
             *self = self.coerce_to(col_ty, &DfType::Unknown)?;
         }
 

--- a/readyset-data/src/type.rs
+++ b/readyset-data/src/type.rs
@@ -417,6 +417,12 @@ impl DfType {
         matches!(self, DfType::Enum { .. })
     }
 
+    /// Returns `true` if this is a text type with a citext collation.
+    #[inline]
+    pub fn is_citext(&self) -> bool {
+        matches!(self, DfType::Text(Collation::Citext))
+    }
+
     /// Returns `true` if this is the JSON type in MySQL or PostgreSQL.
     #[inline]
     pub fn is_json(&self) -> bool {


### PR DESCRIPTION
We were encountering flakiness in our `readyset_psql::types::citext`
test where, seemingly, an insert was never making it to the reader node.
This ended up being caused by a race between the first read in the
reader node and the aforementioned insert (though the underlying problem
was caused by a mishandling of citext types). The test consists of a write
to a particular key and then a read of that same key, where the column
type of the key is citext. If the write happens first:

- The base table processes the insert
- The write is propagated to the reader with a key of type text with a
  utf8 collation (which is incorrect since we are using citext!)
- The reader throws away the write because there is a hole at that key
- The subequent read uses a key of type text with a *citext* collation,
  misses, triggers an upquery, and returns the correct results

Note that the type of the key read by the query is *different* than the
key in the `Record` propagated to the reader -- though the above test
passes, this difference in types is what causes this test to fail if we
reorder the read and write like so:

- We issue a read using a key of type text with a citext collation,
  which misses, triggers an upquery, and causes the hole to be filled
  with an empty result
- The base table processes the insert
- The write is propagated to the reader with a key of type text with a
  utf8 collation *which is a distinct value from the key we filled the
  hole with since the collation doesn't match*. This mismatch causes the
  reader to throw the write away since it finds a hole
- We attempt to read from the correct key (the one with citext collation),
  but we don't trigger an upquery because we filled the hole with an
  empty result above. The key point here is that the keys of the write
  and read are distinct values that are actually different slots in the
  index

Because citext is a custom type (just one that happens to be installed
by a Postgres extension), we need to coerce it the same way we coerce
other custom types when the base table receives a citext row in a table
operation; if we don't, we will just treat the value as text with a utf8
collation. This commit fixes the issue by properly coercing writes with
citext values.

Fixes: REA-3062
