### PR TITLE
readyset-psql: Fix citext tests

### DIFF
--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -893,6 +893,16 @@ mod types {
             .await
             .unwrap();
 
+        // Wait until the `CREATE TABLE` has been replicated
+        eventually!(run_test: {
+            let result = client
+                .simple_query("CREATE CACHE FROM SELECT * FROM t WHERE x = $1")
+                .await;
+            AssertUnwindSafe(move || result)
+        }, then_assert: |result| {
+            result().unwrap()
+        });
+
         let stmt = client
             .prepare("SELECT * FROM t WHERE x = $1")
             .await
@@ -932,6 +942,16 @@ mod types {
             .simple_query("CREATE TABLE t (x citext);")
             .await
             .unwrap();
+
+        // Wait until the `CREATE TABLE` has been replicated
+        eventually!(run_test: {
+            let result = client
+                .simple_query("CREATE CACHE FROM SELECT * FROM t WHERE x = $1")
+                .await;
+            AssertUnwindSafe(move || result)
+        }, then_assert: |result| {
+            result().unwrap()
+        });
 
         let stmt = client
             .prepare("SELECT * FROM t WHERE x = $1")


### PR DESCRIPTION
Adds calls to `eventually!` in the two citext tests to ensure that the
prior `CREATE TABLE` statement is replicated before we attempt to
prepare a statement or perform a migration.

Fixes: REA-3062
