### PR TITLE
query_graph: Classify join preds for LEFT JOINs

### DIFF
--- a/readyset-server/src/controller/sql/mir/join.rs
+++ b/readyset-server/src/controller/sql/mir/join.rs
@@ -47,9 +47,19 @@ pub(super) fn make_joins(
     for jref in qg.join_order.iter() {
         let (mut join_kind, jps) = match &qg.edges[&(jref.src.clone(), jref.dst.clone())] {
             QueryGraphEdge::Join { on } => (JoinKind::Inner, on),
-            QueryGraphEdge::LeftJoin { on, extra_preds } => {
-                if !extra_preds.is_empty() {
-                    unsupported!("Non-equal predicates not (yet) supported in left joins");
+            QueryGraphEdge::LeftJoin {
+                on,
+                left_local_preds,
+                right_local_preds,
+                global_preds,
+                params,
+            } => {
+                if !(left_local_preds.is_empty()
+                    && right_local_preds.is_empty()
+                    && global_preds.is_empty()
+                    && params.is_empty())
+                {
+                    unsupported!("Non equal-join predicates not (yet) supported in left joins");
                 }
                 (JoinKind::Left, on)
             }

--- a/readyset-server/src/controller/sql/query_signature.rs
+++ b/readyset-server/src/controller/sql/query_signature.rs
@@ -80,13 +80,21 @@ impl Signature for QueryGraph {
                         .flat_map(|p| vec![&p.left, &p.right])
                         .for_each(&mut record_column);
                 }
-                QueryGraphEdge::LeftJoin { on, extra_preds } => {
+                QueryGraphEdge::LeftJoin {
+                    on,
+                    left_local_preds,
+                    right_local_preds,
+                    global_preds,
+                    ..
+                } => {
                     on.iter()
                         .flat_map(|p| vec![&p.left, &p.right])
                         .for_each(&mut record_column);
 
-                    extra_preds
+                    left_local_preds
                         .iter()
+                        .chain(right_local_preds)
+                        .chain(global_preds)
                         .flat_map(|expr| expr.referred_columns())
                         .for_each(&mut record_column);
                 }


### PR DESCRIPTION
Unlike inner joins, non-join-key predicates in left joins can't just be
considered as part of other query predicates in the WHERE clause -
semantically, those predicates need to be executed either above the
join, or as part of the join itself - specifically so that rows
which *don't* satisfy those predicates get NULLs for all columns from
the right-hand side of the join.

In the real world, many queries have "local" predicates in the ON clause
of the join - predicates which mention only columns on one side of the
join. These predicates can be compiled as regular filter nodes just
above the join on either side, without having to modify the left join
operator in dataflow to execute arbitrary filter expressions during join
clause evaluation.

To pave the way to compiling these queries, this commit classifies
the (non join-predicate) conditions in the ON clause of LEFT JOINs as
either local to the left, local to the right, global, or parameters.
This still returns an error whenever these lists are non-empty, but
coming up we can compile left-local and right-local preds as filter
nodes during MIR lowering.

