### PR TITLE
nom-sql: Refactor OrderBy into a struct

### DIFF
--- a/nom-sql/src/analysis.rs
+++ b/nom-sql/src/analysis.rs
@@ -6,7 +6,7 @@ use std::iter;
 
 use crate::{
     Column, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr, InValue, JoinConstraint,
-    Relation, SelectStatement,
+    OrderBy, Relation, SelectStatement,
 };
 
 /// Extension trait providing the `referred_tables` method to various parts of the AST
@@ -319,10 +319,12 @@ impl SelectStatement {
                 })
             }))
             .chain(self.order.iter().flat_map(|oc| {
-                oc.order_by.iter().filter_map(|(f, _)| match f {
-                    FieldReference::Expr(expr) => Some(expr),
-                    _ => None,
-                })
+                oc.order_by
+                    .iter()
+                    .filter_map(|OrderBy { field, .. }| match field {
+                        FieldReference::Expr(expr) => Some(expr),
+                        _ => None,
+                    })
             }))
             .collect();
 

--- a/nom-sql/src/analysis/visit_mut.rs
+++ b/nom-sql/src/analysis/visit_mut.rs
@@ -22,9 +22,9 @@ use crate::{
     DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropTableStatement,
     DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr,
     GroupByClause, InValue, InsertStatement, JoinClause, JoinConstraint, JoinRightSide, Literal,
-    OrderClause, Relation, SelectSpecification, SelectStatement, SetNames, SetPostgresParameter,
-    SetStatement, SetVariables, ShowStatement, SqlIdentifier, SqlQuery, SqlType, TableExpr,
-    TableExprInner, TableKey, UpdateStatement, UseStatement,
+    OrderBy, OrderClause, Relation, SelectSpecification, SelectStatement, SetNames,
+    SetPostgresParameter, SetStatement, SetVariables, ShowStatement, SqlIdentifier, SqlQuery,
+    SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement, UseStatement,
 };
 
 /// Each method of the `VisitorMut` trait is a hook to be potentially overridden when recursively
@@ -179,6 +179,10 @@ pub trait VisitorMut<'ast>: Sized {
 
     fn visit_having_clause(&mut self, expr: &'ast mut Expr) -> Result<(), Self::Error> {
         self.visit_expr(expr)
+    }
+
+    fn visit_order_by(&mut self, order_by: &'ast mut OrderBy) -> Result<(), Self::Error> {
+        walk_order_by(self, order_by)
     }
 
     fn visit_order_clause(&mut self, order: &'ast mut OrderClause) -> Result<(), Self::Error> {
@@ -615,12 +619,20 @@ pub fn walk_group_by_clause<'ast, V: VisitorMut<'ast>>(
     Ok(())
 }
 
+pub fn walk_order_by<'ast, V: VisitorMut<'ast>>(
+    visitor: &mut V,
+    order_by: &'ast mut OrderBy,
+) -> Result<(), V::Error> {
+    visitor.visit_field_reference(&mut order_by.field)?;
+    Ok(())
+}
+
 pub fn walk_order_clause<'ast, V: VisitorMut<'ast>>(
     visitor: &mut V,
     order_clause: &'ast mut OrderClause,
 ) -> Result<(), V::Error> {
-    for (field, _) in &mut order_clause.order_by {
-        visitor.visit_field_reference(field)?;
+    for order_by in &mut order_clause.order_by {
+        visitor.visit_order_by(order_by)?;
     }
     Ok(())
 }

--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -39,7 +39,7 @@ pub use self::literal::{
     embedded_literal, literal, raw_string_literal, utf8_string_literal, Double, Float,
     ItemPlaceholder, Literal, QuotingStyle,
 };
-pub use self::order::{OrderClause, OrderType};
+pub use self::order::{OrderBy, OrderClause, OrderType};
 pub use self::parser::*;
 pub use self::select::{CommonTableExpr, GroupByClause, JoinClause, LimitClause, SelectStatement};
 pub use self::set::{

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -691,8 +691,8 @@ mod tests {
     use crate::expression::CaseWhenBranch;
     use crate::table::Relation;
     use crate::{
-        to_nom_result, BinaryOperator, Expr, FunctionExpr, InValue, ItemPlaceholder, SqlType,
-        TableExprInner,
+        to_nom_result, BinaryOperator, Expr, FunctionExpr, InValue, ItemPlaceholder, OrderBy,
+        SqlType, TableExprInner,
     };
 
     fn columns(cols: &[&str]) -> Vec<FieldDefinitionExpr> {
@@ -1411,10 +1411,10 @@ mod tests {
                 fields: vec![FieldDefinitionExpr::All],
                 where_clause: expected_where_cond,
                 order: Some(OrderClause {
-                    order_by: vec![(
-                        FieldReference::Expr(Expr::Column("item.i_title".into())),
-                        None
-                    )],
+                    order_by: vec![OrderBy {
+                        field: FieldReference::Expr(Expr::Column("item.i_title".into())),
+                        order_type: None
+                    }],
                 }),
                 limit_clause: LimitClause::LimitOffset {
                     limit: Some(50.into()),
@@ -1465,7 +1465,10 @@ mod tests {
                 }),
             }],
             order: Some(OrderClause {
-                order_by: vec![(FieldReference::Expr(Expr::Column("contactId".into())), None)],
+                order_by: vec![OrderBy {
+                    field: FieldReference::Expr(Expr::Column("contactId".into())),
+                    order_type: None,
+                }],
             }),
             ..Default::default()
         };
@@ -1956,7 +1959,10 @@ mod tests {
             assert_eq!(
                 res.order,
                 Some(OrderClause {
-                    order_by: vec![(FieldReference::Numeric(1), None)]
+                    order_by: vec![OrderBy {
+                        field: FieldReference::Numeric(1),
+                        order_type: None
+                    }]
                 })
             )
         }

--- a/query-generator/src/lib.rs
+++ b/query-generator/src/lib.rs
@@ -85,7 +85,7 @@ use nom_sql::{
     BinaryOperator, Column, ColumnConstraint, ColumnSpecification, CommonTableExpr,
     CreateTableBody, CreateTableStatement, Dialect as ParseDialect, Expr, FieldDefinitionExpr,
     FieldReference, FunctionExpr, InValue, ItemPlaceholder, JoinClause, JoinConstraint,
-    JoinOperator, JoinRightSide, LimitClause, Literal, OrderClause, OrderType, Relation,
+    JoinOperator, JoinRightSide, LimitClause, Literal, OrderBy, OrderClause, OrderType, Relation,
     SelectStatement, SqlIdentifier, SqlType, SqlTypeArbitraryOptions, TableExpr, TableExprInner,
     TableKey,
 };
@@ -1715,7 +1715,7 @@ impl QueryOperation {
             QueryOperation::Distinct => {
                 query.distinct = true;
                 if let Some(order) = &query.order {
-                    for (field, _) in &order.order_by {
+                    for OrderBy { field, .. } in &order.order_by {
                         let expr = match field {
                             FieldReference::Numeric(_) => {
                                 unreachable!(
@@ -1948,10 +1948,10 @@ impl QueryOperation {
                     ..column_name.into()
                 };
                 query.order = Some(OrderClause {
-                    order_by: vec![(
-                        FieldReference::Expr(Expr::Column(column.clone())),
-                        Some(*order_type),
-                    )],
+                    order_by: vec![OrderBy {
+                        field: FieldReference::Expr(Expr::Column(column.clone())),
+                        order_type: Some(*order_type),
+                    }],
                 });
 
                 query.limit_clause = LimitClause::LimitOffset {
@@ -1985,10 +1985,10 @@ impl QueryOperation {
                     ..column_name.into()
                 };
                 query.order = Some(OrderClause {
-                    order_by: vec![(
-                        FieldReference::Expr(Expr::Column(column.clone())),
-                        Some(*order_type),
-                    )],
+                    order_by: vec![OrderBy {
+                        field: FieldReference::Expr(Expr::Column(column.clone())),
+                        order_type: Some(*order_type),
+                    }],
                 });
 
                 // Since we are setting both fields, check first to see what kind of syntax
@@ -2601,7 +2601,7 @@ impl QuerySeed {
             }
 
             if let Some(order) = &query.order {
-                for (field, _) in &order.order_by {
+                for OrderBy { field, .. } in &order.order_by {
                     let expr = match field {
                         FieldReference::Expr(expr) => expr,
                         FieldReference::Numeric(_) => unreachable!(

--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -79,3 +79,6 @@ pub const QUERY_LOG_VIEW_NOT_FOUND: &str = "readyset_query_log_view_not_found";
 
 /// Counter: The number of errors due to RPC failures.
 pub const QUERY_LOG_RPC_ERRORS: &str = "readyset_query_log_rpc_errors";
+
+/// Gauge: The last seen size in bytes of a /metrics payload.
+pub const METRICS_PAYLOAD_SIZE_BYTES: &str = "readyset_metrics_payload_size_bytes";

--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -582,7 +582,9 @@ impl DfValue {
                 // it does then a value of 0 is generally a safe bet for enum values that don't
                 // trigger the happy path:
                 .unwrap_or(DfValue::Int(0));
-        } else if col_ty.is_array() && col_ty.innermost_array_type().is_enum() {
+        } else if (col_ty.is_array() && col_ty.innermost_array_type().is_enum())
+            || col_ty.is_citext()
+        {
             *self = self.coerce_to(col_ty, &DfType::Unknown)?;
         }
 

--- a/readyset-data/src/type.rs
+++ b/readyset-data/src/type.rs
@@ -417,6 +417,12 @@ impl DfType {
         matches!(self, DfType::Enum { .. })
     }
 
+    /// Returns `true` if this is a text type with a citext collation.
+    #[inline]
+    pub fn is_citext(&self) -> bool {
+        matches!(self, DfType::Text(Collation::Citext))
+    }
+
     /// Returns `true` if this is the JSON type in MySQL or PostgreSQL.
     #[inline]
     pub fn is_json(&self) -> bool {

--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -893,6 +893,16 @@ mod types {
             .await
             .unwrap();
 
+        // Wait until the `CREATE TABLE` has been replicated
+        eventually!(run_test: {
+            let result = client
+                .simple_query("CREATE CACHE FROM SELECT * FROM t WHERE x = $1")
+                .await;
+            AssertUnwindSafe(move || result)
+        }, then_assert: |result| {
+            result().unwrap()
+        });
+
         let stmt = client
             .prepare("SELECT * FROM t WHERE x = $1")
             .await
@@ -932,6 +942,16 @@ mod types {
             .simple_query("CREATE TABLE t (x citext);")
             .await
             .unwrap();
+
+        // Wait until the `CREATE TABLE` has been replicated
+        eventually!(run_test: {
+            let result = client
+                .simple_query("CREATE CACHE FROM SELECT * FROM t WHERE x = $1")
+                .await;
+            AssertUnwindSafe(move || result)
+        }, then_assert: |result| {
+            result().unwrap()
+        });
 
         let stmt = client
             .prepare("SELECT * FROM t WHERE x = $1")

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -19,8 +19,8 @@ use nom_sql::analysis::ReferredColumns;
 use nom_sql::{
     BinaryOperator, CaseWhenBranch, ColumnSpecification, CompoundSelectOperator, CreateTableBody,
     Expr, FieldDefinitionExpr, FieldReference, FunctionExpr, InValue, LimitClause, Literal,
-    NonReplicatedRelation, OrderClause, OrderType, Relation, SelectStatement, SqlIdentifier,
-    TableKey, UnaryOperator,
+    NonReplicatedRelation, OrderBy, OrderClause, OrderType, Relation, SelectStatement,
+    SqlIdentifier, TableKey, UnaryOperator,
 };
 use petgraph::visit::Reversed;
 use petgraph::Direction;
@@ -286,15 +286,15 @@ impl SqlToMirConverter {
                         .map(|o| {
                             o.order_by
                                 .iter()
-                                .map(|(e, ot)| {
+                                .map(|OrderBy { field, order_type }| {
                                     Ok((
-                                        match e {
+                                        match field {
                                             FieldReference::Numeric(_) => internal!(
                                                 "Numeric field references should have been removed"
                                             ),
                                             FieldReference::Expr(e) => e.clone(),
                                         },
-                                        ot.unwrap_or(OrderType::OrderAscending),
+                                        order_type.unwrap_or(OrderType::OrderAscending),
                                     ))
                                 })
                                 .collect::<ReadySetResult<_>>()

--- a/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
+++ b/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
@@ -1,5 +1,7 @@
 use nom_sql::analysis::contains_aggregate;
-use nom_sql::{Expr, FieldDefinitionExpr, FieldReference, LimitClause, SelectStatement, SqlQuery};
+use nom_sql::{
+    Expr, FieldDefinitionExpr, FieldReference, LimitClause, OrderBy, SelectStatement, SqlQuery,
+};
 use readyset_errors::{ReadySetError, ReadySetResult};
 
 pub trait NormalizeTopKWithAggregate: Sized {
@@ -32,7 +34,10 @@ impl NormalizeTopKWithAggregate for SelectStatement {
                 match &self.group_by {
                     Some(group_by) => {
                         // Each field in the order clause...
-                        for (order_field, _) in &order.order_by {
+                        for OrderBy {
+                            field: order_field, ..
+                        } in &order.order_by
+                        {
                             // ...must either appear in the group by clause...
                             let in_group_by_clause = group_by
                                 .fields
@@ -177,10 +182,10 @@ mod tests {
                 assert_eq!(
                     stmt.order,
                     Some(OrderClause {
-                        order_by: vec![(
-                            FieldReference::Expr(Expr::Column("column_3".into())),
-                            Some(OrderType::OrderAscending)
-                        )]
+                        order_by: vec![OrderBy {
+                            field: FieldReference::Expr(Expr::Column("column_3".into())),
+                            order_type: Some(OrderType::OrderAscending)
+                        }]
                     })
                 );
 

--- a/readyset-sql-passes/src/remove_numeric_field_references.rs
+++ b/readyset-sql-passes/src/remove_numeric_field_references.rs
@@ -1,4 +1,4 @@
-use nom_sql::{Expr, FieldDefinitionExpr, FieldReference, SelectStatement, SqlQuery};
+use nom_sql::{Expr, FieldDefinitionExpr, FieldReference, OrderBy, SelectStatement, SqlQuery};
 use readyset_errors::{internal, invalid_query_err, ReadySetResult};
 
 pub trait RemoveNumericFieldReferences: Sized {
@@ -40,7 +40,7 @@ impl RemoveNumericFieldReferences for SelectStatement {
         }
 
         if let Some(order) = &mut self.order {
-            for (field, _) in &mut order.order_by {
+            for OrderBy { field, .. } in &mut order.order_by {
                 if let FieldReference::Numeric(n) = field {
                     *field = FieldReference::Expr(lookup_field(*n as _)?);
                 }
@@ -92,10 +92,10 @@ mod tests {
         assert_eq!(
             result.order,
             Some(OrderClause {
-                order_by: vec![(
-                    FieldReference::Expr(Expr::Column("id".into())),
-                    Some(OrderType::OrderAscending)
-                )]
+                order_by: vec![OrderBy {
+                    field: FieldReference::Expr(Expr::Column("id".into())),
+                    order_type: Some(OrderType::OrderAscending)
+                }]
             })
         )
     }

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -830,6 +830,7 @@ where
             prometheus_handle: prometheus_handle.clone(),
             health_reporter: health_reporter.clone(),
             failpoint_channel: tx,
+            metrics: Default::default(),
         };
 
         let router_shutdown_rx = shutdown_rx.clone();


### PR DESCRIPTION
In preparation for adding an extra field (for NULLS FIRST/LAST) here,
refactor the tuple of FieldReference, Option<OrderType> into a struct
with named fields rather than a tuple.

