### PR TITLE
nom-sql: Parse ORDER BY ... NULLS FIRST/LAST

### DIFF
--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -1413,7 +1413,8 @@ mod tests {
                 order: Some(OrderClause {
                     order_by: vec![OrderBy {
                         field: FieldReference::Expr(Expr::Column("item.i_title".into())),
-                        order_type: None
+                        order_type: None,
+                        null_order: None
                     }],
                 }),
                 limit_clause: LimitClause::LimitOffset {
@@ -1468,6 +1469,7 @@ mod tests {
                 order_by: vec![OrderBy {
                     field: FieldReference::Expr(Expr::Column("contactId".into())),
                     order_type: None,
+                    null_order: None,
                 }],
             }),
             ..Default::default()
@@ -1961,7 +1963,8 @@ mod tests {
                 Some(OrderClause {
                     order_by: vec![OrderBy {
                         field: FieldReference::Numeric(1),
-                        order_type: None
+                        order_type: None,
+                        null_order: None
                     }]
                 })
             )

--- a/query-generator/src/lib.rs
+++ b/query-generator/src/lib.rs
@@ -1951,6 +1951,7 @@ impl QueryOperation {
                     order_by: vec![OrderBy {
                         field: FieldReference::Expr(Expr::Column(column.clone())),
                         order_type: Some(*order_type),
+                        null_order: None,
                     }],
                 });
 
@@ -1988,6 +1989,7 @@ impl QueryOperation {
                     order_by: vec![OrderBy {
                         field: FieldReference::Expr(Expr::Column(column.clone())),
                         order_type: Some(*order_type),
+                        null_order: None,
                     }],
                 });
 

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -286,17 +286,26 @@ impl SqlToMirConverter {
                         .map(|o| {
                             o.order_by
                                 .iter()
-                                .map(|OrderBy { field, order_type }| {
-                                    Ok((
-                                        match field {
-                                            FieldReference::Numeric(_) => internal!(
+                                .map(
+                                    |OrderBy {
+                                         field,
+                                         order_type,
+                                         null_order,
+                                     }| {
+                                        if null_order.is_some() {
+                                            unsupported!("NULLS FIRST/LAST is not yet supported");
+                                        }
+                                        Ok((
+                                            match field {
+                                                FieldReference::Numeric(_) => internal!(
                                                 "Numeric field references should have been removed"
                                             ),
-                                            FieldReference::Expr(e) => e.clone(),
-                                        },
-                                        order_type.unwrap_or(OrderType::OrderAscending),
-                                    ))
-                                })
+                                                FieldReference::Expr(e) => e.clone(),
+                                            },
+                                            order_type.unwrap_or(OrderType::OrderAscending),
+                                        ))
+                                    },
+                                )
                                 .collect::<ReadySetResult<_>>()
                         })
                         .transpose()?,

--- a/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
+++ b/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
@@ -184,7 +184,8 @@ mod tests {
                     Some(OrderClause {
                         order_by: vec![OrderBy {
                             field: FieldReference::Expr(Expr::Column("column_3".into())),
-                            order_type: Some(OrderType::OrderAscending)
+                            order_type: Some(OrderType::OrderAscending),
+                            null_order: None
                         }]
                     })
                 );

--- a/readyset-sql-passes/src/remove_numeric_field_references.rs
+++ b/readyset-sql-passes/src/remove_numeric_field_references.rs
@@ -94,7 +94,8 @@ mod tests {
             Some(OrderClause {
                 order_by: vec![OrderBy {
                     field: FieldReference::Expr(Expr::Column("id".into())),
-                    order_type: Some(OrderType::OrderAscending)
+                    order_type: Some(OrderType::OrderAscending),
+                    null_order: None
                 }]
             })
         )


### PR DESCRIPTION
Parse NULLS FIRST / NULLS LAST on the individual order by elements of
the ORDER BY clause, putting them in a new `null_order` field on
OrderBy. Later on, if this is ever anything other than None, we return
an unsupported error.

