### PR TITLE
server: Don't return unsupported for default NullOrder

### DIFF
--- a/nom-sql/src/order.rs
+++ b/nom-sql/src/order.rs
@@ -54,6 +54,23 @@ pub enum NullOrder {
     NullsLast,
 }
 
+impl NullOrder {
+    /// Returns `true` if this is the default null order for the given order type.
+    ///
+    /// From [the postgres docs][pg-docs]:
+    ///
+    /// > By default, null values sort as if larger than any non-null value; that is, `NULLS FIRST`
+    /// > is the default for `DESC` order, and `NULLS LAST` otherwise.
+    ///
+    /// [pg-docs]: https://www.postgresql.org/docs/current/queries-order.html
+    pub fn is_default_for(self, ot: OrderType) -> bool {
+        self == match ot {
+            OrderType::OrderDescending => Self::NullsFirst,
+            OrderType::OrderAscending => Self::NullsLast,
+        }
+    }
+}
+
 impl Display for NullOrder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -292,17 +292,23 @@ impl SqlToMirConverter {
                                          order_type,
                                          null_order,
                                      }| {
-                                        if null_order.is_some() {
-                                            unsupported!("NULLS FIRST/LAST is not yet supported");
+                                        let order_type =
+                                            order_type.unwrap_or(OrderType::OrderAscending);
+                                        if let Some(null_order) = null_order {
+                                            if !null_order.is_default_for(order_type) {
+                                                unsupported!(
+                                                 "Non-default NULLS FIRST/LAST is not yet supported"
+                                             );
+                                            }
                                         }
                                         Ok((
                                             match field {
                                                 FieldReference::Numeric(_) => internal!(
-                                                "Numeric field references should have been removed"
-                                            ),
+                                                 "Numeric field references should have been removed"
+                                             ),
                                                 FieldReference::Expr(e) => e.clone(),
                                             },
-                                            order_type.unwrap_or(OrderType::OrderAscending),
+                                            order_type,
                                         ))
                                     },
                                 )

--- a/readyset-server/src/controller/sql/query_graph.rs
+++ b/readyset-server/src/controller/sql/query_graph.rs
@@ -1298,8 +1298,11 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
                          order_type,
                          null_order,
                      }| {
-                        if null_order.is_some() {
-                            unsupported!("NULLS FIRST/LAST is not yet supported");
+                        let order_type = order_type.unwrap_or(OrderType::OrderAscending);
+                        if let Some(null_order) = null_order {
+                            if !null_order.is_default_for(order_type) {
+                                unsupported!("Non-default NULLS FIRST/LAST is not yet supported");
+                            }
                         }
 
                         Ok((
@@ -1314,7 +1317,7 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
                                     internal!("Numeric field references should have been removed")
                                 }
                             },
-                            order_type.unwrap_or(OrderType::OrderAscending),
+                            order_type,
                         ))
                     },
                 )
@@ -1339,8 +1342,14 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
                                      order_type,
                                      null_order,
                                  }| {
-                                    if null_order.is_some() {
-                                        unsupported!("NULLS FIRST/LAST is not yet supported");
+                                    let order_type =
+                                        order_type.unwrap_or(OrderType::OrderAscending);
+                                    if let Some(null_order) = null_order {
+                                        if !null_order.is_default_for(order_type) {
+                                            unsupported!(
+                                                "Non-default NULLS FIRST/LAST is not yet supported"
+                                            );
+                                        }
                                     }
                                     Ok((
                                         match field {
@@ -1351,7 +1360,7 @@ pub fn to_query_graph(stmt: SelectStatement) -> ReadySetResult<QueryGraph> {
                                             }
                                             FieldReference::Expr(expr) => expr,
                                         },
-                                        order_type.unwrap_or(OrderType::OrderAscending),
+                                        order_type,
                                     ))
                                 },
                             )


### PR DESCRIPTION
If a NullOrder is explicitly specified that happens to be the default
for the particular order direction (see the pg docs[0]), don't return an
unsupported error - just ignore it.

[0]: https://www.postgresql.org/docs/current/queries-order.html

