### PR TITLE
alloc-metrics: Remove log in Ok() case

### DIFF
--- a/readyset-alloc-metrics/src/lib.rs
+++ b/readyset-alloc-metrics/src/lib.rs
@@ -56,7 +56,6 @@ impl AllocatorMetricsReporter {
 
         match fetch_stats() {
             Ok(stats) => {
-                info!("NEXT alloc stats: {:?}", stats);
                 self.allocated.set(stats.allocated as f64);
                 self.active.set(stats.active as f64);
                 self.retained.set(stats.retained as f64);


### PR DESCRIPTION
This log is a bit too noisy--leaving the log for the Err() case and can
use the metrics to observe the Ok() case.

