### PR TITLE
mir: Don't try to fuse nodes with multiple descendants

### DIFF
--- a/readyset-mir/src/rewrite/fuse.rs
+++ b/readyset-mir/src/rewrite/fuse.rs
@@ -49,6 +49,13 @@ fn fuse_nodes(
             child_ni = %child_ni.index(),
             "Fusing nodes"
         );
+
+        let descendants = query.descendants(parent_ni)?;
+        // Calling remove_node has an invariant that there be only one descendant, so filter out
+        // any that don't satisfy this
+        if descendants.len() > 1 {
+            continue;
+        }
         let parent_node = query.remove_node(parent_ni)?.unwrap();
         let Some(child_node) = query.get_node_mut(child_ni) else {
             continue


### PR DESCRIPTION
When we try to fuse nodes, we have an invariant that they must have a
single descendant. The previous logic was checking for this single child
only after calling `remove_node`, but `remove_node` itself was erroring
out in this case. This commit adds a check before that to prevent these
errors.

