### PR TITLE
adapter: Make query status capacity configurable

### DIFF
--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -394,6 +394,16 @@ pub struct Options {
     /// will listen.
     #[clap(long, env = "CONTROLLER_ADDRESS")]
     controller_address: Option<IpAddr>,
+
+    /// The number of queries that will be retained and eligible to be returned by `show caches`
+    /// and `show proxied queries`.
+    #[clap(
+        long,
+        env = "QUERY_STATUS_CAPACITY",
+        default_value = "100000",
+        hide = true
+    )]
+    query_status_capacity: usize,
 }
 
 impl Options {
@@ -783,7 +793,7 @@ where
         rs_connect.in_scope(|| info!(?migration_style));
 
         let query_status_cache: &'static _ = Box::leak(Box::new(
-            QueryStatusCache::new()
+            QueryStatusCache::with_capacity(options.query_status_capacity)
                 .style(migration_style)
                 .enable_experimental_placeholder_inlining(
                     options.experimental_placeholder_inlining,


### PR DESCRIPTION
We store full query text in an lru cache that is used to serve 'show
proxied quries' requests. It has a default maximum capacity of 100,000.
This commit makes that value configurable at startup with a hidden
value.

