### PR TITLE
demo: Remove grafana+prometheus from quickstart demo

### DIFF
--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -31,29 +31,6 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-  prometheus:
-    image: public.ecr.aws/readyset/readyset-prometheus:latest
-    healthcheck:
-      test: ["CMD", "nc", "-vz", "localhost", "9090"]
-      interval: 5s
-      timeout: 5s
-      retries: 12
-    expose:
-      - 9090
-    volumes:
-      - "prometheus:/prometheus"
-  pushgateway:
-    image: prom/pushgateway
-    expose:
-      - 9091
-  grafana:
-    image: public.ecr.aws/readyset/readyset-grafana:latest
-    ports:
-      - "4000:4000"
-    environment:
-      UPSTREAM_DB_URL: mysql://root:readyset@mysql/testdb
-      RS_PORT: 3307
-      RS_GRAFANA_PORT: 4000
   mysql:
     image: mysql:8
     environment:
@@ -71,5 +48,4 @@ services:
       - mysql:/var/lib/mysql
 volumes:
   mysql: ~
-  prometheus: ~
   readyset: ~

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -31,29 +31,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-  prometheus:
-    image: public.ecr.aws/readyset/readyset-prometheus:latest
-    healthcheck:
-      test: ["CMD", "nc", "-vz", "localhost", "9090"]
-      interval: 5s
-      timeout: 5s
-      retries: 12
-    expose:
-      - 9090
-    volumes:
-      - "prometheus:/prometheus"
-  pushgateway:
-    image: prom/pushgateway
-    expose:
-      - 9091
-  grafana:
-    image: public.ecr.aws/readyset/readyset-grafana:latest
-    ports:
-      - "4000:4000"
-    environment:
-      UPSTREAM_DB_URL: postgresql://postgres:readyset@postgres/testdb
-      RS_PORT: 5433
-      RS_GRAFANA_PORT: 4000
   postgres:
     image: postgres:14
     environment:
@@ -74,5 +51,4 @@ services:
       - postgres:/var/lib/postgresql/data
 volumes:
   postgres: ~
-  prometheus: ~
   readyset: ~

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -30,29 +30,5 @@ services:
       timeout: 1s
       retries: 5
       start_period: 5s
-  prometheus:
-    image: "public.ecr.aws/readyset/readyset-prometheus:latest"
-    healthcheck:
-      test: ["CMD", "nc", "-vz", "localhost", "9090"]
-      interval: 5s
-      timeout: 5s
-      retries: 12
-    expose:
-      - 9090
-    volumes:
-      - "prometheus:/prometheus"
-  pushgateway:
-    image: prom/pushgateway
-    expose:
-      - 9091
-  grafana:
-    image: "public.ecr.aws/readyset/readyset-grafana:latest"
-    ports:
-      - 4000:4000
-    environment:
-      # UPSTREAM_DB_URL:
-      RS_PORT: 5433
-      RS_GRAFANA_PORT: 4000
 volumes:
-  prometheus: ~
   readyset: ~


### PR DESCRIPTION
The current quickstart demo isn't showing stats in grafana properly
again.  We need to remove the custom-built grafana and prometheus
containers from the demo so that we don't have to continue to test and
maintain them.

