### PR TITLE
adapter: Suppress clippy warning for aarch64 targets

### DIFF
--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -138,6 +138,9 @@ pub enum PreparedSelectTypes {
 }
 
 #[derive(Debug, Clone)]
+// Due to differences in data type sizes, the large_enum_variant Clippy warning was being emitted
+// for this type, but only when compiling for aarch64 targets.
+#[cfg_attr(target_arch = "aarch64", allow(clippy::large_enum_variant))]
 pub enum PrepareResult {
     Select {
         types: PreparedSelectTypes,


### PR DESCRIPTION
Due to platform-specific data type sizes, Clippy was emitting a warning
about large enum variants on the `PrepareResult` type only when
compiling for aarch64 targets. This commit conditionally allows this
Clippy lint for aarch64 targets to silence the warning.

