### PR TITLE
server: Log if a parse round trip on a new cache fails

### DIFF
--- a/benchmarks/src/spec.rs
+++ b/benchmarks/src/spec.rs
@@ -93,7 +93,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use database_utils::{DatabaseConnection, QueryableConnection};
-use nom_sql::SqlQuery;
+use nom_sql::{DialectDisplay, SqlQuery};
 use rand::Rng;
 use rand_distr::{Uniform, WeightedAliasIndex};
 use readyset_data::DfValue;

--- a/benchmarks/src/utils/generate.rs
+++ b/benchmarks/src/utils/generate.rs
@@ -17,7 +17,7 @@ use nom::sequence::delimited;
 use nom_locate::LocatedSpan;
 use nom_sql::parser::{sql_query, SqlQuery};
 use nom_sql::whitespace::whitespace0;
-use nom_sql::{Column, Dialect, Expr, NomSqlResult, Relation};
+use nom_sql::{Column, Dialect, DialectDisplay, Expr, NomSqlResult, Relation};
 use query_generator::{ColumnName, TableName, TableSpec};
 use readyset_data::DfValue;
 use serde::{Deserialize, Serialize};

--- a/benchmarks/src/utils/mod.rs
+++ b/benchmarks/src/utils/mod.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use database_utils::{DatabaseURL, QueryableConnection};
+use nom_sql::DialectDisplay;
 use readyset_data::DfValue;
 use tracing::info;
 

--- a/benchmarks/src/utils/query.rs
+++ b/benchmarks/src/utils/query.rs
@@ -18,7 +18,7 @@ use anyhow::{anyhow, Result};
 use clap::Parser;
 use data_generator::{ColumnGenerator, DistributionAnnotation};
 use database_utils::{DatabaseConnection, DatabaseStatement, QueryableConnection};
-use nom_sql::{Dialect, Literal, SqlType};
+use nom_sql::{Dialect, DialectDisplay, Literal, SqlType};
 use readyset_data::DfValue;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/benchmarks/src/utils/spec.rs
+++ b/benchmarks/src/utils/spec.rs
@@ -15,7 +15,8 @@ use nom::sequence::{preceded, terminated};
 use nom_locate::LocatedSpan;
 use nom_sql::whitespace::whitespace0;
 use nom_sql::{
-    sql_query, CommentStatement, CreateTableOption, Dialect, Expr, SqlQuery, VariableScope,
+    sql_query, CommentStatement, CreateTableOption, Dialect, DialectDisplay, Expr, SqlQuery,
+    VariableScope,
 };
 use query_generator::{TableName, TableSpec};
 

--- a/benchmarks/src/write_benchmark.rs
+++ b/benchmarks/src/write_benchmark.rs
@@ -12,8 +12,8 @@ use database_utils::{DatabaseConnection, DatabaseError, DatabaseURL, QueryableCo
 use itertools::Itertools;
 use metrics::Unit;
 use nom_sql::{
-    BinaryOperator, CacheInner, CreateCacheStatement, Dialect, Expr, FieldDefinitionExpr,
-    ItemPlaceholder, Literal, SelectStatement, TableExpr, TableExprInner,
+    BinaryOperator, CacheInner, CreateCacheStatement, Dialect, DialectDisplay, Expr,
+    FieldDefinitionExpr, ItemPlaceholder, Literal, SelectStatement, TableExpr, TableExprInner,
 };
 use parking_lot::Mutex;
 use query_generator::{ColumnName, TableSpec};

--- a/data-generator/tests/mysql.rs
+++ b/data-generator/tests/mysql.rs
@@ -3,7 +3,7 @@ use std::env;
 use data_generator::{random_value_of_type, unique_value_of_type, value_of_type};
 use mysql_async::prelude::Queryable;
 use mysql_async::Value;
-use nom_sql::{Dialect, SqlType};
+use nom_sql::{Dialect, DialectDisplay, SqlType};
 use proptest::prop_assume;
 use rand::rngs::mock::StepRng;
 use serial_test::serial;

--- a/dataflow-expression/src/lower.rs
+++ b/dataflow-expression/src/lower.rs
@@ -1,8 +1,8 @@
 use std::iter;
 
 use nom_sql::{
-    BinaryOperator as SqlBinaryOperator, Column, Expr as AstExpr, FunctionExpr, InValue, Relation,
-    UnaryOperator,
+    BinaryOperator as SqlBinaryOperator, Column, DialectDisplay, Expr as AstExpr, FunctionExpr,
+    InValue, Relation, UnaryOperator,
 };
 use readyset_data::dialect::SqlEngine;
 use readyset_data::{DfType, DfValue};

--- a/nom-sql/src/alter.rs
+++ b/nom-sql/src/alter.rs
@@ -25,7 +25,7 @@ use crate::create::key_specification;
 use crate::literal::literal;
 use crate::table::{relation, Relation};
 use crate::whitespace::whitespace1;
-use crate::{Dialect, Literal, NomSqlResult, SqlIdentifier};
+use crate::{Dialect, DialectDisplay, Literal, NomSqlResult, SqlIdentifier};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum AlterColumnOperation {
@@ -33,8 +33,8 @@ pub enum AlterColumnOperation {
     DropColumnDefault,
 }
 
-impl AlterColumnOperation {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for AlterColumnOperation {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             AlterColumnOperation::SetColumnDefault(val) => {
                 write!(f, "SET DEFAULT {}", val.display(dialect))
@@ -109,8 +109,8 @@ pub enum AlterTableDefinition {
      * DropTableConstraint(..), */
 }
 
-impl AlterTableDefinition {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for AlterTableDefinition {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::AddColumn(col) => {
                 write!(f, "ADD COLUMN {}", col.display(dialect))
@@ -175,8 +175,8 @@ pub struct AlterTableStatement {
     pub only: bool,
 }
 
-impl AlterTableStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for AlterTableStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "ALTER TABLE {} ", self.table.display(dialect))?;
 

--- a/nom-sql/src/column.rs
+++ b/nom-sql/src/column.rs
@@ -15,7 +15,9 @@ use crate::common::{column_identifier_no_alias, parse_comment};
 use crate::expression::expression;
 use crate::sql_type::type_identifier;
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{literal, Dialect, Expr, Literal, NomSqlResult, Relation, SqlIdentifier, SqlType};
+use crate::{
+    literal, Dialect, DialectDisplay, Expr, Literal, NomSqlResult, Relation, SqlIdentifier, SqlType,
+};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct Column {
@@ -59,8 +61,8 @@ impl PartialOrd for Column {
     }
 }
 
-impl Column {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for Column {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             if let Some(ref table) = self.table {
                 write!(f, "{}.", table.display(dialect))?;
@@ -68,7 +70,9 @@ impl Column {
             write!(f, "{}", dialect.quote_identifier(&self.name))
         })
     }
+}
 
+impl Column {
     /// Like [`display()`](Self::display) except the schema, table, and column name will not be
     /// quoted.
     ///
@@ -98,8 +102,8 @@ pub enum ColumnConstraint {
     OnUpdateCurrentTimestamp(Option<Literal>),
 }
 
-impl ColumnConstraint {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for ColumnConstraint {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Null => write!(f, "NULL"),
             Self::NotNull => write!(f, "NOT NULL"),
@@ -157,8 +161,10 @@ impl ColumnSpecification {
             _ => None,
         })
     }
+}
 
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for ColumnSpecification {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(
                 f,

--- a/nom-sql/src/comment.rs
+++ b/nom-sql/src/comment.rs
@@ -11,7 +11,7 @@ use test_strategy::Arbitrary;
 
 use crate::common::statement_terminator;
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{literal, Dialect, NomSqlResult, SqlIdentifier};
+use crate::{literal, Dialect, DialectDisplay, NomSqlResult, SqlIdentifier};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum CommentStatement {
@@ -26,8 +26,8 @@ pub enum CommentStatement {
     },
 }
 
-impl CommentStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CommentStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Column {
                 column_name,

--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -278,6 +278,8 @@ pub enum FieldDefinitionExpr {
     #[default]
     All,
     AllInTable(Relation),
+    // TODO: re-enable once Expr round trip is stable
+    #[weight(0)]
     Expr {
         expr: Expr,
         alias: Option<SqlIdentifier>,
@@ -1179,6 +1181,10 @@ mod tests {
 
     mod postgres {
         use super::*;
+
+        test_format_parse_round_trip!(
+            rt_field_def_expr(field_definition_expr, Vec<FieldDefinitionExpr>, Dialect::PostgreSQL);
+        );
 
         #[test]
         fn cast() {

--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 
 use crate::column::Column;
-use crate::dialect::Dialect;
+use crate::dialect::{Dialect, DialectDisplay};
 use crate::expression::expression;
 use crate::table::Relation;
 use crate::whitespace::{whitespace0, whitespace1};
@@ -134,8 +134,10 @@ impl TableKey {
             TableKey::FulltextKey { .. } => &None,
         }
     }
+}
 
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for TableKey {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             if let Some(constraint_name) = self.constraint_name() {
                 write!(
@@ -306,8 +308,8 @@ impl From<Literal> for FieldDefinitionExpr {
     }
 }
 
-impl FieldDefinitionExpr {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for FieldDefinitionExpr {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::All => write!(f, "*"),
             Self::AllInTable(table) => {
@@ -339,8 +341,8 @@ pub enum FieldReference {
     Expr(Expr),
 }
 
-impl FieldReference {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for FieldReference {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Numeric(n) => write!(f, "{}", n),
             Self::Expr(expr) => write!(f, "{}", expr.display(dialect)),

--- a/nom-sql/src/compound_select.rs
+++ b/nom-sql/src/compound_select.rs
@@ -14,7 +14,7 @@ use crate::common::{opt_delimited, terminated_with_statement_terminator};
 use crate::order::{order_clause, OrderClause};
 use crate::select::{limit_offset_clause, nested_selection, LimitClause, SelectStatement};
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, NomSqlResult};
+use crate::{Dialect, DialectDisplay, NomSqlResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, Arbitrary)]
 pub enum CompoundSelectOperator {
@@ -42,8 +42,8 @@ pub struct CompoundSelectStatement {
     pub limit_clause: LimitClause,
 }
 
-impl CompoundSelectStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CompoundSelectStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             for (op, sel) in &self.selects {
                 if let Some(o) = op {

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -27,7 +27,7 @@ use crate::order::{order_type, OrderType};
 use crate::select::{nested_selection, selection, SelectStatement};
 use crate::table::{relation, Relation};
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, NomSqlError, NomSqlResult, SqlIdentifier};
+use crate::{Dialect, DialectDisplay, NomSqlError, NomSqlResult, SqlIdentifier};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct CreateTableBody {
@@ -35,8 +35,8 @@ pub struct CreateTableBody {
     pub keys: Option<Vec<TableKey>>,
 }
 
-impl CreateTableBody {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CreateTableBody {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             for (i, field) in self.fields.iter().enumerate() {
                 if i != 0 {
@@ -74,8 +74,8 @@ pub struct CreateTableStatement {
     pub options: Result<Vec<CreateTableOption>, String>,
 }
 
-impl CreateTableStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CreateTableStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "CREATE TABLE ")?;
             if self.if_not_exists {
@@ -143,8 +143,8 @@ pub enum SelectSpecification {
     Simple(SelectStatement),
 }
 
-impl SelectSpecification {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SelectSpecification {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Compound(csq) => write!(f, "{}", csq.display(dialect)),
             Self::Simple(sq) => write!(f, "{}", sq.display(dialect)),
@@ -165,8 +165,8 @@ pub struct CreateViewStatement {
     pub definition: Result<Box<SelectSpecification>, String>,
 }
 
-impl CreateViewStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CreateViewStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "CREATE VIEW {} ", self.name.display(dialect))?;
 
@@ -196,8 +196,8 @@ pub enum CacheInner {
     Id(SqlIdentifier),
 }
 
-impl CacheInner {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CacheInner {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Statement(stmt) => write!(f, "{}", stmt.display(dialect)),
             Self::Id(id) => write!(f, "{id}"),
@@ -233,8 +233,8 @@ pub struct CreateCacheStatement {
     pub concurrently: bool,
 }
 
-impl CreateCacheStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CreateCacheStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "CREATE CACHE ")?;
             if self.concurrently {

--- a/nom-sql/src/delete.rs
+++ b/nom-sql/src/delete.rs
@@ -12,7 +12,7 @@ use crate::common::statement_terminator;
 use crate::select::where_clause;
 use crate::table::{relation, Relation};
 use crate::whitespace::whitespace1;
-use crate::{Dialect, Expr, NomSqlResult};
+use crate::{Dialect, DialectDisplay, Expr, NomSqlResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DeleteStatement {
@@ -20,8 +20,8 @@ pub struct DeleteStatement {
     pub where_clause: Option<Expr>,
 }
 
-impl DeleteStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for DeleteStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "DELETE FROM {}", self.table.display(dialect))?;
 

--- a/nom-sql/src/dialect.rs
+++ b/nom-sql/src/dialect.rs
@@ -27,9 +27,15 @@ pub trait DialectDisplay {
 }
 
 #[derive(Debug)]
-pub struct CommaSeparatedList<T>(pub Vec<T>);
+pub struct CommaSeparatedList<'a, T>(&'a Vec<T>);
 
-impl<T> DialectDisplay for CommaSeparatedList<T>
+impl<'a, T> From<&'a Vec<T>> for CommaSeparatedList<'a, T> {
+    fn from(value: &'a Vec<T>) -> Self {
+        CommaSeparatedList(value)
+    }
+}
+
+impl<'a, T> DialectDisplay for CommaSeparatedList<'a, T>
 where
     T: DialectDisplay,
 {

--- a/nom-sql/src/dialect.rs
+++ b/nom-sql/src/dialect.rs
@@ -50,6 +50,16 @@ where
     }
 }
 
+#[cfg(test)]
+impl<T> DialectDisplay for Vec<T>
+where
+    T: DialectDisplay,
+{
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + '_ {
+        self.iter().map(|i| i.display(dialect)).join(", ")
+    }
+}
+
 #[inline]
 pub(crate) fn is_sql_identifier(chr: u8) -> bool {
     is_alphanumeric(chr) || chr == b'_'

--- a/nom-sql/src/drop.rs
+++ b/nom-sql/src/drop.rs
@@ -14,7 +14,7 @@ use test_strategy::Arbitrary;
 use crate::common::{statement_terminator, ws_sep_comma};
 use crate::table::{relation, table_list, Relation};
 use crate::whitespace::whitespace1;
-use crate::{Dialect, NomSqlResult};
+use crate::{Dialect, DialectDisplay, NomSqlResult};
 
 fn if_exists(i: LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], bool> {
     map(
@@ -40,8 +40,8 @@ pub struct DropTableStatement {
     pub if_exists: bool,
 }
 
-impl DropTableStatement {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for DropTableStatement {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "DROP TABLE ")?;
 
@@ -83,8 +83,8 @@ pub struct DropCacheStatement {
     pub name: Relation,
 }
 
-impl DropCacheStatement {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for DropCacheStatement {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| write!(f, "DROP CACHE {}", self.name.display(dialect)))
     }
 }
@@ -109,8 +109,8 @@ pub struct DropViewStatement {
     pub if_exists: bool,
 }
 
-impl DropViewStatement {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for DropViewStatement {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "DROP VIEW ")?;
             if self.if_exists {

--- a/nom-sql/src/explain.rs
+++ b/nom-sql/src/explain.rs
@@ -12,7 +12,7 @@ use test_strategy::Arbitrary;
 use crate::common::statement_terminator;
 use crate::table::relation;
 use crate::whitespace::whitespace1;
-use crate::{Dialect, NomSqlResult, Relation};
+use crate::{Dialect, DialectDisplay, NomSqlResult, Relation};
 
 /// EXPLAIN statements
 ///

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -629,7 +629,7 @@ impl Expr {
                 }
                 write!(f, ")")
             }
-            Expr::Variable(var) => write!(f, "{}", var),
+            Expr::Variable(var) => write!(f, "{}", var.display(dialect)),
         })
     }
 }

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -25,7 +25,9 @@ use crate::select::nested_selection;
 use crate::set::{variable_scope_prefix, Variable};
 use crate::sql_type::{mysql_int_cast_targets, type_identifier};
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Column, Dialect, Literal, NomSqlResult, SelectStatement, SqlIdentifier, SqlType};
+use crate::{
+    Column, Dialect, DialectDisplay, Literal, NomSqlResult, SelectStatement, SqlIdentifier, SqlType,
+};
 
 /// Function call expressions
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize, Arbitrary)]
@@ -101,8 +103,8 @@ impl FunctionExpr {
     }
 }
 
-impl FunctionExpr {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for FunctionExpr {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             FunctionExpr::Avg {
                 expr,
@@ -359,8 +361,8 @@ pub enum InValue {
     List(Vec<Expr>),
 }
 
-impl InValue {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for InValue {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             InValue::Subquery(stmt) => write!(f, "{}", stmt.display(dialect)),
             InValue::List(exprs) => write!(
@@ -381,8 +383,8 @@ pub struct CaseWhenBranch {
     pub body: Expr,
 }
 
-impl CaseWhenBranch {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for CaseWhenBranch {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(
                 f,
@@ -500,8 +502,8 @@ pub enum Expr {
     Variable(Variable),
 }
 
-impl Expr {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for Expr {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Expr::Call(fe) => write!(f, "{}", fe.display(dialect)),
             Expr::Literal(l) => write!(f, "{}", l.display(dialect)),

--- a/nom-sql/src/insert.rs
+++ b/nom-sql/src/insert.rs
@@ -16,7 +16,7 @@ use crate::common::{
 };
 use crate::table::{relation, Relation};
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, Expr, NomSqlResult};
+use crate::{Dialect, DialectDisplay, Expr, NomSqlResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct InsertStatement {
@@ -27,8 +27,8 @@ pub struct InsertStatement {
     pub on_duplicate: Option<Vec<(Column, Expr)>>,
 }
 
-impl InsertStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for InsertStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "INSERT INTO {}", self.table.display(dialect))?;
 

--- a/nom-sql/src/join.rs
+++ b/nom-sql/src/join.rs
@@ -17,6 +17,7 @@ pub enum JoinRightSide {
     /// A single table expression.
     Table(TableExpr),
     /// A comma-separated (and implicitly joined) sequence of tables.
+    #[strategy(size_range(1..12))]
     Tables(Vec<TableExpr>),
 }
 

--- a/nom-sql/src/join.rs
+++ b/nom-sql/src/join.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 
 use crate::column::Column;
-use crate::{Dialect, Expr, NomSqlResult, TableExpr};
+use crate::{Dialect, DialectDisplay, Expr, NomSqlResult, TableExpr};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary)]
 pub enum JoinRightSide {
@@ -30,8 +30,8 @@ impl JoinRightSide {
     }
 }
 
-impl JoinRightSide {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for JoinRightSide {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Table(t) => write!(f, "{}", t.display(dialect)),
             Self::Tables(ts) => write!(f, "({})", ts.iter().map(|t| t.display(dialect)).join(", ")),
@@ -84,8 +84,8 @@ pub enum JoinConstraint {
     Empty,
 }
 
-impl JoinConstraint {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for JoinConstraint {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::On(ce) => write!(f, "ON {}", ce.display(dialect)),
             Self::Using(columns) => write!(

--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::create::{
 };
 pub use self::create_table_options::CreateTableOption;
 pub use self::delete::DeleteStatement;
-pub use self::dialect::Dialect;
+pub use self::dialect::{Dialect, DialectDisplay};
 pub use self::drop::{
     DropAllCachesStatement, DropCacheStatement, DropTableStatement, DropViewStatement,
 };

--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(macro_use_extern_crate)]
-#![feature(box_patterns)]
+#![allow(incomplete_features)]
+#![feature(box_patterns, return_position_impl_trait_in_trait)]
 #![allow(macro_use_extern_crate)]
 
 #[cfg(test)]

--- a/nom-sql/src/literal.rs
+++ b/nom-sql/src/literal.rs
@@ -31,6 +31,7 @@ use crate::{Dialect, DialectDisplay, NomSqlResult, SqlType};
 #[derive(Clone, Debug, Serialize, Deserialize, Arbitrary)]
 pub struct Float {
     pub value: f32,
+    #[strategy(1u8..=30u8)]
     pub precision: u8,
 }
 
@@ -71,6 +72,7 @@ impl Hash for Float {
 #[derive(Clone, Debug, Serialize, Deserialize, Arbitrary)]
 pub struct Double {
     pub value: f64,
+    #[strategy(1u8..=30u8)]
     pub precision: u8,
 }
 
@@ -146,6 +148,7 @@ pub enum Literal {
     /// didn't exist.
     Float(Float),
     Double(Double),
+    #[weight(0)]
     Numeric(i128, u32),
     String(String),
     #[weight(0)]
@@ -769,6 +772,13 @@ mod tests {
                 Literal::Boolean(false)
             );
         }
+    }
+    mod postgres {
+        use super::*;
+
+        test_format_parse_round_trip!(
+            rt_literal(literal, Literal, Dialect::PostgreSQL);
+        );
     }
 
     mod mysql {

--- a/nom-sql/src/literal.rs
+++ b/nom-sql/src/literal.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 
 use crate::dialect::is_sql_identifier;
-use crate::{Dialect, NomSqlResult, SqlType};
+use crate::{Dialect, DialectDisplay, NomSqlResult, SqlType};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Arbitrary)]
 pub struct Float {
@@ -209,8 +209,8 @@ impl From<ItemPlaceholder> for Literal {
     }
 }
 
-impl Literal {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for Literal {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             macro_rules! write_real {
                 ($real:expr, $prec:expr) => {{

--- a/nom-sql/src/order.rs
+++ b/nom-sql/src/order.rs
@@ -15,7 +15,7 @@ use test_strategy::Arbitrary;
 
 use crate::common::{field_reference, ws_sep_comma};
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, FieldReference, NomSqlResult};
+use crate::{Dialect, DialectDisplay, FieldReference, NomSqlResult};
 
 #[derive(
     Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Arbitrary,
@@ -105,8 +105,8 @@ pub struct OrderClause {
     pub order_by: Vec<OrderBy>,
 }
 
-impl OrderClause {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for OrderClause {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(
                 f,

--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -36,7 +36,9 @@ use crate::transaction::{
 use crate::update::{updating, UpdateStatement};
 use crate::use_statement::{use_statement, UseStatement};
 use crate::whitespace::whitespace0;
-use crate::{Dialect, DropAllCachesStatement, Expr, NomSqlResult, SqlType, TableKey};
+use crate::{
+    Dialect, DialectDisplay, DropAllCachesStatement, Expr, NomSqlResult, SqlType, TableKey,
+};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 #[allow(clippy::large_enum_variant)]
@@ -65,8 +67,8 @@ pub enum SqlQuery {
     Comment(CommentStatement),
 }
 
-impl SqlQuery {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SqlQuery {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Select(select) => write!(f, "{}", select.display(dialect)),
             Self::Insert(insert) => write!(f, "{}", insert.display(dialect)),

--- a/nom-sql/src/rename.rs
+++ b/nom-sql/src/rename.rs
@@ -12,15 +12,15 @@ use test_strategy::Arbitrary;
 use crate::common::ws_sep_comma;
 use crate::table::{relation, Relation};
 use crate::whitespace::whitespace1;
-use crate::{Dialect, NomSqlResult};
+use crate::{Dialect, DialectDisplay, NomSqlResult};
 
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct RenameTableStatement {
     pub ops: Vec<RenameTableOperation>,
 }
 
-impl RenameTableStatement {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for RenameTableStatement {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| {
             write!(
                 f,
@@ -50,8 +50,8 @@ pub struct RenameTableOperation {
     pub to: Relation,
 }
 
-impl RenameTableOperation {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for RenameTableOperation {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| {
             write!(
                 f,

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -464,6 +464,7 @@ fn join_rhs(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u
                 delimited(tag("("), table_expr_list(dialect), tag(")")),
                 JoinRightSide::Tables,
             ),
+            map(tag("()"), |_| JoinRightSide::Tables(vec![])),
         ))(i)
     }
 }
@@ -2071,6 +2072,7 @@ mod tests {
 
         test_format_parse_round_trip!(
             rt_limit_clause(limit_offset, LimitClause, Dialect::PostgreSQL);
+            rt_join_rhs(join_rhs, JoinRightSide, Dialect::PostgreSQL);
         );
 
         #[test]

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -2073,6 +2073,8 @@ mod tests {
         test_format_parse_round_trip!(
             rt_limit_clause(limit_offset, LimitClause, Dialect::PostgreSQL);
             rt_join_rhs(join_rhs, JoinRightSide, Dialect::PostgreSQL);
+            rt_join_constraint(join_constraint, JoinConstraint, Dialect::PostgreSQL);
+            rt_join_clause(join_clause, JoinClause, Dialect::PostgreSQL);
         );
 
         #[test]

--- a/nom-sql/src/select.rs
+++ b/nom-sql/src/select.rs
@@ -2075,6 +2075,7 @@ mod tests {
             rt_join_rhs(join_rhs, JoinRightSide, Dialect::PostgreSQL);
             rt_join_constraint(join_constraint, JoinConstraint, Dialect::PostgreSQL);
             rt_join_clause(join_clause, JoinClause, Dialect::PostgreSQL);
+            rt_group_by_clause(group_by_clause, GroupByClause, Dialect::PostgreSQL);
         );
 
         #[test]

--- a/nom-sql/src/set.rs
+++ b/nom-sql/src/set.rs
@@ -17,7 +17,7 @@ use crate::common::statement_terminator;
 use crate::expression::expression;
 use crate::literal::literal;
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, Expr, Literal, NomSqlError, NomSqlResult, SqlIdentifier};
+use crate::{Dialect, DialectDisplay, Expr, Literal, NomSqlError, NomSqlResult, SqlIdentifier};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum SetStatement {
@@ -26,8 +26,8 @@ pub enum SetStatement {
     PostgresParameter(SetPostgresParameter),
 }
 
-impl SetStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SetStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "SET ")?;
             match self {
@@ -76,8 +76,8 @@ pub enum SetPostgresParameterValue {
     Value(PostgresParameterValue),
 }
 
-impl SetPostgresParameterValue {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SetPostgresParameterValue {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             SetPostgresParameterValue::Default => write!(f, "DEFAULT"),
             SetPostgresParameterValue::Value(val) => write!(f, "{}", val.display(dialect)),
@@ -103,8 +103,8 @@ pub enum PostgresParameterValueInner {
     Literal(Literal),
 }
 
-impl PostgresParameterValueInner {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for PostgresParameterValueInner {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             PostgresParameterValueInner::Identifier(ident) => write!(f, "{}", ident),
             PostgresParameterValueInner::Literal(lit) => write!(f, "{}", lit.display(dialect)),
@@ -151,8 +151,8 @@ impl PostgresParameterValue {
     }
 }
 
-impl PostgresParameterValue {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for PostgresParameterValue {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             PostgresParameterValue::Single(v) => write!(f, "{}", v.display(dialect)),
             PostgresParameterValue::List(l) => {
@@ -255,8 +255,10 @@ impl Variable {
             Some(&self.name)
         }
     }
+}
 
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for Variable {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             match dialect {
                 Dialect::PostgreSQL => {
@@ -275,8 +277,8 @@ impl Variable {
     }
 }
 
-impl SetVariables {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SetVariables {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(
                 f,
@@ -317,8 +319,8 @@ pub struct SetPostgresParameter {
     pub value: SetPostgresParameterValue,
 }
 
-impl SetPostgresParameter {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SetPostgresParameter {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             if let Some(scope) = self.scope {
                 write!(f, "{} ", scope)?;

--- a/nom-sql/src/set.rs
+++ b/nom-sql/src/set.rs
@@ -255,16 +255,23 @@ impl Variable {
             Some(&self.name)
         }
     }
-}
 
-impl Display for Variable {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.scope == VariableScope::User {
-            write!(f, "@")?;
-        } else {
-            write!(f, "@@{}.", self.scope)?;
-        }
-        write!(f, "{}", self.name)
+    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+        fmt_with(move |f| {
+            match dialect {
+                Dialect::PostgreSQL => {
+                    // Postgres doesn't have variable scope
+                }
+                Dialect::MySQL => {
+                    if self.scope == VariableScope::User {
+                        write!(f, "@")?;
+                    } else {
+                        write!(f, "@@{}.", self.scope)?;
+                    }
+                }
+            }
+            write!(f, "{}", self.name)
+        })
     }
 }
 
@@ -276,7 +283,11 @@ impl SetVariables {
                 "{}",
                 self.variables
                     .iter()
-                    .map(|(var, value)| format!("{} = {}", var, value.display(dialect)))
+                    .map(|(var, value)| format!(
+                        "{} = {}",
+                        var.display(dialect),
+                        value.display(dialect)
+                    ))
                     .join(", ")
             )
         })
@@ -620,6 +631,19 @@ mod tests {
     /// https://www.postgresql.org/docs/current/sql-set.html
     mod postgres {
         use super::*;
+
+        test_format_parse_round_trip!(
+            rt_variable(variable, Variable, Dialect::PostgreSQL, {
+                // Only allow Variables with names that aren't keywords
+                |s: &Variable| {
+                    let name = s.name.to_string();
+                    Dialect::PostgreSQL
+                        .identifier()
+                        .map(|ident| ident.to_ascii_lowercase())
+                        .parse(LocatedSpan::new(name.as_bytes())).is_ok()
+                }
+            });
+        );
 
         #[test]
         fn set_client_min_messages() {

--- a/nom-sql/src/show.rs
+++ b/nom-sql/src/show.rs
@@ -15,7 +15,7 @@ use test_strategy::Arbitrary;
 
 use crate::expression::expression;
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{literal, Dialect, Expr, Literal, NomSqlResult};
+use crate::{literal, Dialect, DialectDisplay, Expr, Literal, NomSqlResult};
 
 pub type QueryID = String;
 
@@ -33,8 +33,8 @@ pub enum ShowStatement {
     Connections,
 }
 
-impl ShowStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for ShowStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "SHOW ")?;
             match self {
@@ -205,8 +205,8 @@ pub struct Tables {
     pub filter: Option<FilterPredicate>,
 }
 
-impl Tables {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for Tables {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             if self.full {
                 write!(f, "FULL ")?;
@@ -256,8 +256,8 @@ pub enum FilterPredicate {
     Where(Expr),
 }
 
-impl FilterPredicate {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for FilterPredicate {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| match self {
             Self::Like(like) => write!(f, "LIKE '{}'", like),
             Self::Where(expr) => write!(f, "WHERE {}", expr.display(dialect)),

--- a/nom-sql/src/sql_type.rs
+++ b/nom-sql/src/sql_type.rs
@@ -24,7 +24,7 @@ use triomphe::ThinArc;
 use crate::common::{ws_sep_comma, Sign};
 use crate::table::relation;
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, NomSqlResult, Relation};
+use crate::{Dialect, DialectDisplay, NomSqlResult, Relation};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum IntervalFields {
@@ -297,8 +297,10 @@ impl SqlType {
         }
         self
     }
+}
 
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for SqlType {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             let write_with_len = |f: &mut fmt::Formatter, name, len| {
                 write!(f, "{}", name)?;

--- a/nom-sql/src/table.rs
+++ b/nom-sql/src/table.rs
@@ -101,6 +101,8 @@ impl Relation {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Arbitrary)]
 pub enum TableExprInner {
     Table(Relation),
+    // TODO: re-enable after SelectStatement round-trips
+    #[weight(0)]
     Subquery(Box<SelectStatement>),
 }
 

--- a/nom-sql/src/table.rs
+++ b/nom-sql/src/table.rs
@@ -15,7 +15,7 @@ use test_strategy::Arbitrary;
 use crate::common::{as_alias, ws_sep_comma};
 use crate::select::nested_selection;
 use crate::whitespace::whitespace0;
-use crate::{Dialect, NomSqlResult, SelectStatement, SqlIdentifier};
+use crate::{Dialect, DialectDisplay, NomSqlResult, SelectStatement, SqlIdentifier};
 
 /// A (potentially schema-qualified) name for a relation
 ///
@@ -72,8 +72,8 @@ impl<'a> From<&'a String> for Relation {
     }
 }
 
-impl Relation {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for Relation {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| {
             if let Some(schema) = &self.schema {
                 write!(f, "{}.", dialect.quote_identifier(schema))?;
@@ -81,7 +81,9 @@ impl Relation {
             write!(f, "{}", dialect.quote_identifier(&self.name))
         })
     }
+}
 
+impl Relation {
     /// Like [`display()`](Self::display) except the schema and table name will not be quoted.
     ///
     /// This should not be used to emit SQL code and instead should mostly be for error messages.
@@ -118,8 +120,10 @@ impl TableExprInner {
             Err(self)
         }
     }
+}
 
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for TableExprInner {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| match self {
             TableExprInner::Table(t) => write!(f, "{}", t.display(dialect)),
             TableExprInner::Subquery(sq) => write!(f, "({})", sq.display(dialect)),
@@ -144,8 +148,8 @@ impl From<Relation> for TableExpr {
     }
 }
 
-impl TableExpr {
-    pub fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
+impl DialectDisplay for TableExpr {
+    fn display(&self, dialect: Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "{}", self.inner.display(dialect))?;
 

--- a/nom-sql/src/update.rs
+++ b/nom-sql/src/update.rs
@@ -14,7 +14,7 @@ use crate::common::{assignment_expr_list, statement_terminator};
 use crate::select::where_clause;
 use crate::table::{relation, Relation};
 use crate::whitespace::{whitespace0, whitespace1};
-use crate::{Dialect, Expr, NomSqlResult};
+use crate::{Dialect, DialectDisplay, Expr, NomSqlResult};
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct UpdateStatement {
@@ -23,8 +23,8 @@ pub struct UpdateStatement {
     pub where_clause: Option<Expr>,
 }
 
-impl UpdateStatement {
-    pub fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
+impl DialectDisplay for UpdateStatement {
+    fn display(&self, dialect: Dialect) -> impl fmt::Display + Copy + '_ {
         fmt_with(move |f| {
             write!(f, "UPDATE {} ", self.table.display(dialect))?;
 

--- a/query-generator/src/lib.rs
+++ b/query-generator/src/lib.rs
@@ -19,7 +19,7 @@
 //! Generating a simple query, with a single query parameter and a single inner join:
 //!
 //! ```rust
-//! use nom_sql::{Dialect, JoinOperator};
+//! use nom_sql::{Dialect, DialectDisplay, JoinOperator};
 //! use query_generator::{GeneratorState, QueryOperation, QuerySeed};
 //!
 //! let mut gen = GeneratorState::default();
@@ -2782,7 +2782,7 @@ impl GenerateOpts {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::BinaryOperator;
+    use nom_sql::{BinaryOperator, DialectDisplay};
 
     use super::*;
 

--- a/query-generator/src/main.rs
+++ b/query-generator/src/main.rs
@@ -2,6 +2,7 @@
 
 use anyhow::bail;
 use clap::Parser;
+use nom_sql::DialectDisplay;
 use query_generator::GenerateOpts;
 
 #[derive(Parser)]

--- a/query-generator/tests/mysql.rs
+++ b/query-generator/tests/mysql.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use mysql_async::prelude::Queryable;
 use mysql_async::{OptsBuilder, Params};
-use nom_sql::{CreateTableStatement, Dialect};
+use nom_sql::{CreateTableStatement, Dialect, DialectDisplay};
 use query_generator::{GeneratorState, QuerySeed};
 use serial_test::serial;
 use test_strategy::proptest;

--- a/query-generator/tests/postgresql.rs
+++ b/query-generator/tests/postgresql.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use nom_sql::{CreateTableStatement, Dialect};
+use nom_sql::{CreateTableStatement, Dialect, DialectDisplay};
 use query_generator::{GeneratorState, QueryDialect, QuerySeed};
 use test_strategy::proptest;
 use tokio_postgres::NoTls;

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -81,7 +81,7 @@ use futures::future::{self, OptionFuture};
 use lru::LruCache;
 use mysql_common::row::convert::{FromRow, FromRowError};
 use nom_sql::{
-    CacheInner, CreateCacheStatement, DeleteStatement, Dialect, DropCacheStatement,
+    CacheInner, CreateCacheStatement, DeleteStatement, Dialect, DialectDisplay, DropCacheStatement,
     InsertStatement, Relation, SelectStatement, SetStatement, ShowStatement, SqlIdentifier,
     SqlQuery, UpdateStatement, UseStatement,
 };

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -6,8 +6,8 @@ use std::sync::{atomic, Arc};
 
 use itertools::Itertools;
 use nom_sql::{
-    self, ColumnConstraint, DeleteStatement, Expr, InsertStatement, Relation, SqlIdentifier,
-    SqlQuery, UnaryOperator, UpdateStatement,
+    self, ColumnConstraint, DeleteStatement, DialectDisplay, Expr, InsertStatement, Relation,
+    SqlIdentifier, SqlQuery, UnaryOperator, UpdateStatement,
 };
 use readyset_client::consensus::{Authority, AuthorityControl};
 use readyset_client::consistency::Timestamp;

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 
 use dataflow_expression::Dialect;
 use metrics::{counter, register_counter, Counter};
-use nom_sql::Literal;
+use nom_sql::{DialectDisplay, Literal};
 use readyset_client::query::{MigrationState, Query};
 use readyset_client::recipe::changelist::{Change, ChangeList};
 use readyset_client::{PlaceholderIdx, ReadySetHandle, ViewCreateRequest};

--- a/readyset-adapter/src/rewrite.rs
+++ b/readyset-adapter/src/rewrite.rs
@@ -7,7 +7,8 @@ use std::{iter, mem};
 use itertools::{Either, Itertools};
 use nom_sql::analysis::visit_mut::{self, VisitorMut};
 use nom_sql::{
-    BinaryOperator, Expr, InValue, ItemPlaceholder, LimitClause, Literal, SelectStatement,
+    BinaryOperator, DialectDisplay, Expr, InValue, ItemPlaceholder, LimitClause, Literal,
+    SelectStatement,
 };
 use readyset_data::{DfType, DfValue};
 use readyset_errors::{

--- a/readyset-adapter/src/views_synchronizer.rs
+++ b/readyset-adapter/src/views_synchronizer.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use dataflow_expression::Dialect;
+use nom_sql::DialectDisplay;
 use readyset_client::query::MigrationState;
 use readyset_client::ReadySetHandle;
 use readyset_util::shutdown::ShutdownReceiver;

--- a/readyset-client/src/lib.rs
+++ b/readyset-client/src/lib.rs
@@ -137,6 +137,7 @@
 //! binary MySQL and PostgreSQL protocols, which provides a compatibility layer for applications
 //! that wish to continue to issue ad-hoc MySQL or PostgreSQL queries through existing SQL client
 //! libraries.
+#![allow(incomplete_features)]
 #![feature(
     result_flattening,
     type_alias_impl_trait,
@@ -145,7 +146,8 @@
     bound_as_ref,
     box_into_inner,
     is_sorted,
-    once_cell
+    once_cell,
+    return_position_impl_trait_in_trait
 )]
 #![deny(macro_use_extern_crate)]
 #![deny(unused_extern_crates)]

--- a/readyset-client/src/query.rs
+++ b/readyset-client/src/query.rs
@@ -11,6 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use nom_sql::DialectDisplay;
 use readyset_data::DfValue;
 use readyset_sql_passes::anonymize::{Anonymize, Anonymizer};
 use readyset_util::fmt::fmt_with;
@@ -113,16 +114,17 @@ impl Hash for Query {
         }
     }
 }
-
-impl Query {
+impl DialectDisplay for Query {
     /// Displays the query using appropriate formatting for the given dialect.
-    pub fn display(&self, dialect: nom_sql::Dialect) -> impl Display + Copy + '_ {
+    fn display(&self, dialect: nom_sql::Dialect) -> impl Display + Copy + '_ {
         fmt_with(move |f| match self {
             Query::Parsed(q) => write!(f, "{}", q.statement.display(dialect)),
             Query::ParseFailed(s) => write!(f, "{s}"),
         })
     }
+}
 
+impl Query {
     /// Clones the inner query into a String and anonymizes the literals in it if it is a parsed
     /// SelectStatement. If the query failed to parse, the query is fully anonymized
     pub fn to_anonymized_string(&self, anonymizer: &mut Anonymizer) -> String {

--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -18,7 +18,7 @@ use enum_kinds::EnumKind;
 use eui48::{MacAddress, MacAddressFormat};
 use itertools::Itertools;
 use mysql_time::MySqlTime;
-use nom_sql::{Double, Float, Literal, SqlType};
+use nom_sql::{DialectDisplay, Double, Float, Literal, SqlType};
 use postgres_types::Format;
 use readyset_errors::{internal, invalid_query_err, unsupported, ReadySetError, ReadySetResult};
 use readyset_util::arbitrary::{arbitrary_decimal, arbitrary_duration};

--- a/readyset-logictest/src/from_query_log.rs
+++ b/readyset-logictest/src/from_query_log.rs
@@ -5,7 +5,9 @@ use anyhow::anyhow;
 use clap::Parser;
 use database_utils::{DatabaseConnection, DatabaseURL, QueryableConnection};
 use itertools::Itertools;
-use nom_sql::{parse_query, Dialect, Expr, FieldDefinitionExpr, FunctionExpr, SqlQuery};
+use nom_sql::{
+    parse_query, Dialect, DialectDisplay, Expr, FieldDefinitionExpr, FunctionExpr, SqlQuery,
+};
 use tokio::fs::{File, OpenOptions};
 use tokio::io::{AsyncWriteExt, BufReader};
 

--- a/readyset-logictest/src/generate.rs
+++ b/readyset-logictest/src/generate.rs
@@ -10,8 +10,8 @@ use console::style;
 use database_utils::{DatabaseConnection, DatabaseURL, QueryableConnection};
 use itertools::Itertools;
 use nom_sql::{
-    parse_query, BinaryOperator, CreateTableStatement, DeleteStatement, Dialect, Expr, SqlQuery,
-    SqlType,
+    parse_query, BinaryOperator, CreateTableStatement, DeleteStatement, Dialect, DialectDisplay,
+    Expr, SqlQuery, SqlType,
 };
 use query_generator::{GeneratorState, ParameterMode, QuerySeed};
 

--- a/readyset-mir/src/node/node_inner.rs
+++ b/readyset-mir/src/node/node_inner.rs
@@ -7,7 +7,9 @@ use dataflow::ops::union;
 use dataflow::PostLookupAggregates;
 use derive_more::From;
 use itertools::Itertools;
-use nom_sql::{BinaryOperator, ColumnSpecification, Expr, OrderType, Relation, SqlIdentifier};
+use nom_sql::{
+    BinaryOperator, ColumnSpecification, DialectDisplay, Expr, OrderType, Relation, SqlIdentifier,
+};
 use readyset_client::{PlaceholderIdx, ViewPlaceholder};
 use readyset_errors::{internal, ReadySetResult};
 use serde::{Deserialize, Serialize};

--- a/readyset-mir/src/rewrite/fuse.rs
+++ b/readyset-mir/src/rewrite/fuse.rs
@@ -1,7 +1,7 @@
 use std::mem::replace;
 
 use nom_sql::analysis::visit_mut::{self, VisitorMut};
-use nom_sql::{BinaryOperator, Expr, Literal};
+use nom_sql::{BinaryOperator, DialectDisplay, Expr, Literal};
 use readyset_errors::{internal, invariant_eq, ReadySetResult};
 use tracing::trace;
 

--- a/readyset-mir/src/rewrite/fuse_project.rs
+++ b/readyset-mir/src/rewrite/fuse_project.rs
@@ -1,0 +1,126 @@
+use nom_sql::analysis::visit_mut::{self, VisitorMut};
+use nom_sql::{DialectDisplay, Expr};
+use readyset_errors::{internal, invariant_eq, ReadySetResult};
+use tracing::trace;
+
+use crate::node::{MirNodeInner, ProjectExpr};
+use crate::query::MirQuery;
+use crate::Column;
+
+fn inline_parent_expr_references(expr: &mut Expr, parent_emit: &[ProjectExpr]) {
+    struct InlineParentExprReferencesVisitor<'a>(&'a [ProjectExpr]);
+    impl<'a, 'ast> VisitorMut<'ast> for InlineParentExprReferencesVisitor<'a> {
+        type Error = !;
+
+        fn visit_expr(&mut self, expr: &'ast mut Expr) -> Result<(), Self::Error> {
+            if let Expr::Column(nom_sql::Column { name, table: None }) = expr {
+                let name = name.clone();
+                if let Some(parent_expr) = self.0.iter().find_map(|expr| match expr {
+                    ProjectExpr::Expr { expr, alias } if *alias == name => Some(expr.clone()),
+                    _ => None,
+                }) {
+                    *expr = parent_expr;
+                }
+                Ok(())
+            } else {
+                visit_mut::walk_expr(self, expr)
+            }
+        }
+    }
+
+    let Ok(()) = InlineParentExprReferencesVisitor(parent_emit).visit_expr(expr);
+}
+
+/// Rewrite the given query to fuse subsequent [`Project`] nodes into one node, inlining
+/// expressions into column references
+///
+/// Given that we don't have any common subexpression analysis, this is essentially always an
+/// optimization, as it allows us to avoid extra project nodes (and extra intermediary result sets!)
+/// in the final query graph.
+///
+/// [`Project`]: MirNodeInner::Project
+pub(crate) fn fuse_project_nodes(query: &mut MirQuery<'_>) -> ReadySetResult<()> {
+    let mut projects_to_fuse = vec![];
+    for child_ni in query.topo_nodes() {
+        let node = query.get_node(child_ni).unwrap();
+        if !matches!(node.inner, MirNodeInner::Project { .. }) {
+            continue;
+        }
+
+        let ancestors = query.ancestors(child_ni)?;
+        if ancestors.is_empty() {
+            // This node's ancestor might not be in the same query! If so, there's no fusing we can
+            // do (since we can't remove existing nodes)
+            continue;
+        }
+        invariant_eq!(
+            ancestors.len(),
+            1,
+            "Project nodes can only have one parent (node: {})",
+            child_ni.index()
+        );
+        let parent_ni = ancestors[0];
+        let parent = query.get_node(parent_ni).unwrap();
+        // TODO(aspen): Fuse through AliasTable?
+        if !matches!(parent.inner, MirNodeInner::Project { .. }) {
+            continue;
+        }
+
+        projects_to_fuse.push((parent_ni, child_ni));
+    }
+
+    for (parent_ni, child_ni) in projects_to_fuse {
+        trace!(
+            parent_ni = %parent_ni.index(),
+            child_ni = %child_ni.index(),
+            "Fusing project nodes"
+        );
+        let parent_emit = match query.remove_node(parent_ni)?.unwrap().inner {
+            MirNodeInner::Project { emit } => emit,
+            _ => internal!(),
+        };
+        let Some(child_node) = query.get_node_mut(child_ni) else {
+            continue
+        };
+        let emit = match &mut child_node.inner {
+            MirNodeInner::Project { emit } => emit,
+            _ => internal!(),
+        };
+
+        for project_expr in emit {
+            let name = match project_expr {
+                ProjectExpr::Column(Column {
+                    name, table: None, ..
+                }) => name.clone(),
+                ProjectExpr::Expr { expr, .. } => {
+                    inline_parent_expr_references(expr, &parent_emit);
+                    continue;
+                }
+                ProjectExpr::Column(Column { table: Some(_), .. }) => continue,
+            };
+            trace!(
+                parent_ni = %parent_ni.index(),
+                child_ni = %child_ni.index(),
+                %name,
+                "Trying to find column in parent"
+            );
+
+            if let Some(parent_expr) = parent_emit.iter().find_map(|expr| match expr {
+                ProjectExpr::Expr { expr, alias } if *alias == name => Some(expr.clone()),
+                _ => None,
+            }) {
+                trace!(
+                    %name,
+                    parent_expr = %parent_expr.display(nom_sql::Dialect::MySQL),
+                    "Found column in parent"
+                );
+                *project_expr = ProjectExpr::Expr {
+                    expr: parent_expr,
+                    alias: name,
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/readyset-mir/src/visualize.rs
+++ b/readyset-mir/src/visualize.rs
@@ -6,6 +6,7 @@ use dataflow::ops::union;
 use dataflow::PostLookupAggregateFunction;
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use nom_sql::DialectDisplay;
 use petgraph::visit::EdgeRef;
 use petgraph::Direction;
 use readyset_client::ViewPlaceholder;

--- a/readyset-mysql/src/schema.rs
+++ b/readyset-mysql/src/schema.rs
@@ -1,6 +1,6 @@
 #![warn(clippy::panic)]
 
-use nom_sql::{self, ColumnConstraint, Relation};
+use nom_sql::{self, ColumnConstraint, DialectDisplay, Relation};
 use readyset_client::ColumnSchema;
 use readyset_data::DfType;
 use readyset_errors::{unsupported, ReadySetResult};

--- a/readyset-psql/src/query_handler.rs
+++ b/readyset-psql/src/query_handler.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 
 use lazy_static::lazy_static;
 use nom_sql::{
-    Literal, PostgresParameterValue, PostgresParameterValueInner, SetNames, SetPostgresParameter,
-    SetPostgresParameterValue, SetStatement, SqlQuery,
+    DialectDisplay, Literal, PostgresParameterValue, PostgresParameterValueInner, SetNames,
+    SetPostgresParameter, SetPostgresParameterValue, SetStatement, SqlQuery,
 };
 use readyset_adapter::backend::noria_connector::QueryResult;
 use readyset_adapter::backend::{noria_connector, SelectSchema};

--- a/readyset-server/src/controller/sql/mir/grouped.rs
+++ b/readyset-server/src/controller/sql/mir/grouped.rs
@@ -6,7 +6,7 @@ use mir::node::ProjectExpr;
 use mir::{Column, NodeIndex};
 use nom_sql::analysis::ReferredColumns;
 use nom_sql::FunctionExpr::*;
-use nom_sql::{self, Expr, FieldDefinitionExpr, Relation, SqlIdentifier};
+use nom_sql::{self, DialectDisplay, Expr, FieldDefinitionExpr, Relation, SqlIdentifier};
 use readyset_errors::{unsupported, ReadySetError, ReadySetResult};
 use readyset_sql_passes::is_aggregate;
 

--- a/readyset-server/src/controller/sql/mir/mod.rs
+++ b/readyset-server/src/controller/sql/mir/mod.rs
@@ -18,8 +18,8 @@ pub use mir::{Column, NodeIndex};
 use nom_sql::analysis::ReferredColumns;
 use nom_sql::{
     BinaryOperator, CaseWhenBranch, ColumnSpecification, CompoundSelectOperator, CreateTableBody,
-    Expr, FieldDefinitionExpr, FieldReference, FunctionExpr, InValue, LimitClause, Literal,
-    NonReplicatedRelation, OrderBy, OrderClause, OrderType, Relation, SelectStatement,
+    DialectDisplay, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr, InValue, LimitClause,
+    Literal, NonReplicatedRelation, OrderBy, OrderClause, OrderType, Relation, SelectStatement,
     SqlIdentifier, TableKey, UnaryOperator,
 };
 use petgraph::visit::Reversed;

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -6,9 +6,9 @@ use ::mir::visualize::GraphViz;
 use ::mir::DfNodeIndex;
 use ::serde::{Deserialize, Serialize};
 use nom_sql::{
-    CompoundSelectOperator, CompoundSelectStatement, CreateTableBody, FieldDefinitionExpr,
-    NonReplicatedRelation, NotReplicatedReason, Relation, SelectSpecification, SelectStatement,
-    SqlIdentifier, SqlType, TableExpr,
+    CompoundSelectOperator, CompoundSelectStatement, CreateTableBody, DialectDisplay,
+    FieldDefinitionExpr, NonReplicatedRelation, NotReplicatedReason, Relation, SelectSpecification,
+    SelectStatement, SqlIdentifier, SqlType, TableExpr,
 };
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::{AlterTypeChange, Change, PostgresTableMetadata};

--- a/readyset-server/src/controller/sql/query_graph.rs
+++ b/readyset-server/src/controller/sql/query_graph.rs
@@ -10,9 +10,10 @@ use common::{DfValue, IndexType};
 use nom_sql::analysis::visit_mut::{walk_expr, VisitorMut};
 use nom_sql::analysis::ReferredColumns;
 use nom_sql::{
-    BinaryOperator, Column, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr, InValue,
-    ItemPlaceholder, JoinConstraint, JoinOperator, JoinRightSide, LimitClause, Literal, OrderBy,
-    OrderType, Relation, SelectStatement, SqlIdentifier, TableExpr, TableExprInner,
+    BinaryOperator, Column, DialectDisplay, Expr, FieldDefinitionExpr, FieldReference,
+    FunctionExpr, InValue, ItemPlaceholder, JoinConstraint, JoinOperator, JoinRightSide,
+    LimitClause, Literal, OrderBy, OrderType, Relation, SelectStatement, SqlIdentifier, TableExpr,
+    TableExprInner,
 };
 use readyset_client::{PlaceholderIdx, ViewPlaceholder};
 use readyset_errors::{

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -31,7 +31,8 @@ use futures::stream::{self, FuturesUnordered, StreamExt, TryStreamExt};
 use futures::{FutureExt, TryFutureExt, TryStream};
 use metrics::{gauge, histogram};
 use nom_sql::{
-    CacheInner, CreateCacheStatement, NonReplicatedRelation, Relation, SqlIdentifier, SqlQuery,
+    CacheInner, CreateCacheStatement, DialectDisplay, NonReplicatedRelation, Relation,
+    SqlIdentifier, SqlQuery,
 };
 use petgraph::visit::{Bfs, IntoNodeReferences};
 use petgraph::Direction;

--- a/readyset-sql-passes/src/alias_removal.rs
+++ b/readyset-sql-passes/src/alias_removal.rs
@@ -221,9 +221,9 @@ mod tests {
     use std::convert::TryInto;
 
     use nom_sql::{
-        parse_query, parser, BinaryOperator, Column, Dialect, Expr, FieldDefinitionExpr,
-        ItemPlaceholder, JoinClause, JoinConstraint, JoinOperator, JoinRightSide, Literal,
-        Relation, SelectStatement, SqlQuery, TableExpr, TableExprInner,
+        parse_query, parser, BinaryOperator, Column, Dialect, DialectDisplay, Expr,
+        FieldDefinitionExpr, ItemPlaceholder, JoinClause, JoinConstraint, JoinOperator,
+        JoinRightSide, Literal, Relation, SelectStatement, SqlQuery, TableExpr, TableExprInner,
     };
 
     use super::{AliasRemoval, TableAliasRewrite};

--- a/readyset-sql-passes/src/expr/constant_fold.rs
+++ b/readyset-sql-passes/src/expr/constant_fold.rs
@@ -74,7 +74,7 @@ pub fn constant_fold_expr(expr: &mut Expr, dialect: Dialect) {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::parse_expr;
+    use nom_sql::{parse_expr, DialectDisplay};
 
     use super::*;
 

--- a/readyset-sql-passes/src/expr/normalize_negation.rs
+++ b/readyset-sql-passes/src/expr/normalize_negation.rs
@@ -100,7 +100,7 @@ pub fn normalize_negation(expr: &mut Expr) {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::{parse_expr, Dialect};
+    use nom_sql::{parse_expr, Dialect, DialectDisplay};
 
     use super::*;
 

--- a/readyset-sql-passes/src/implied_tables.rs
+++ b/readyset-sql-passes/src/implied_tables.rs
@@ -256,7 +256,10 @@ impl ImpliedTableExpansion for SqlQuery {
 mod tests {
     use std::collections::HashMap;
 
-    use nom_sql::{parse_query, Column, Dialect, Expr, FieldDefinitionExpr, SqlQuery, TableExpr};
+    use nom_sql::{
+        parse_query, Column, Dialect, DialectDisplay, Expr, FieldDefinitionExpr, SqlQuery,
+        TableExpr,
+    };
 
     use super::*;
 

--- a/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
+++ b/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
@@ -1,6 +1,7 @@
 use nom_sql::analysis::contains_aggregate;
 use nom_sql::{
-    Expr, FieldDefinitionExpr, FieldReference, LimitClause, OrderBy, SelectStatement, SqlQuery,
+    DialectDisplay, Expr, FieldDefinitionExpr, FieldReference, LimitClause, OrderBy,
+    SelectStatement, SqlQuery,
 };
 use readyset_errors::{ReadySetError, ReadySetResult};
 

--- a/readyset-sql-passes/src/resolve_schemas.rs
+++ b/readyset-sql-passes/src/resolve_schemas.rs
@@ -225,7 +225,7 @@ impl ResolveSchemas for CreateTableStatement {
 mod tests {
     use std::fmt::Debug;
 
-    use nom_sql::{parse_create_table, Dialect};
+    use nom_sql::{parse_create_table, Dialect, DialectDisplay};
 
     use super::*;
     use crate::util::parse_select_statement;

--- a/readyset-sql-passes/src/rewrite_between.rs
+++ b/readyset-sql-passes/src/rewrite_between.rs
@@ -111,7 +111,7 @@ impl RewriteBetween for SqlQuery {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::{parse_query, Dialect};
+    use nom_sql::{parse_query, Dialect, DialectDisplay};
 
     use super::*;
 

--- a/readyset-sql-passes/src/star_expansion.rs
+++ b/readyset-sql-passes/src/star_expansion.rs
@@ -169,7 +169,7 @@ impl StarExpansion for SqlQuery {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::{parse_query, Dialect};
+    use nom_sql::{parse_query, Dialect, DialectDisplay};
 
     use super::*;
 

--- a/readyset-sql-passes/src/strip_post_filters.rs
+++ b/readyset-sql-passes/src/strip_post_filters.rs
@@ -76,7 +76,7 @@ impl StripPostFilters for SqlQuery {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::{parse_query, Dialect};
+    use nom_sql::{parse_query, Dialect, DialectDisplay};
 
     use super::*;
 

--- a/readyset-sql-passes/src/util.rs
+++ b/readyset-sql-passes/src/util.rs
@@ -4,8 +4,9 @@ use std::iter;
 use itertools::Either;
 use nom_sql::analysis::is_aggregate;
 use nom_sql::{
-    BinaryOperator, Column, CommonTableExpr, Expr, FieldDefinitionExpr, FunctionExpr, InValue,
-    JoinClause, JoinRightSide, Relation, SelectStatement, SqlIdentifier, TableExpr, TableExprInner,
+    BinaryOperator, Column, CommonTableExpr, DialectDisplay, Expr, FieldDefinitionExpr,
+    FunctionExpr, InValue, JoinClause, JoinRightSide, Relation, SelectStatement, SqlIdentifier,
+    TableExpr, TableExprInner,
 };
 
 pub(crate) fn join_clause_tables(join: &JoinClause) -> impl Iterator<Item = &TableExpr> {

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use metrics::{register_counter, register_histogram, Counter, Histogram, SharedString};
-use nom_sql::SqlQuery;
+use nom_sql::{DialectDisplay, SqlQuery};
 use readyset_client::query::QueryId;
 use readyset_client_metrics::{
     recorded, DatabaseType, EventType, QueryExecutionEvent, QueryLogMode, SqlQueryType,

--- a/replicators/src/db_util.rs
+++ b/replicators/src/db_util.rs
@@ -2,7 +2,7 @@
 //! Contains helpers for determining the schemas and tables of a database for use in replication
 use std::collections::HashMap;
 
-use nom_sql::Dialect;
+use nom_sql::{Dialect, DialectDisplay};
 use readyset_errors::ReadySetError;
 use readyset_sql_passes::anonymize::{Anonymize, Anonymizer};
 use readyset_telemetry_reporter::{TelemetryBuilder, TelemetryEvent, TelemetrySender};

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -12,7 +12,7 @@ use metrics::register_gauge;
 use mysql::prelude::Queryable;
 use mysql::{Transaction, TxOpts};
 use mysql_async as mysql;
-use nom_sql::{NonReplicatedRelation, NotReplicatedReason, Relation};
+use nom_sql::{DialectDisplay, NonReplicatedRelation, NotReplicatedReason, Relation};
 use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::{Change, ChangeList};
 use readyset_data::Dialect;

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -10,7 +10,7 @@ use futures::FutureExt;
 use metrics::{counter, histogram};
 use mysql::prelude::Queryable;
 use mysql::{OptsBuilder, PoolConstraints, PoolOpts, SslOpts};
-use nom_sql::{NonReplicatedRelation, NotReplicatedReason, Relation};
+use nom_sql::{DialectDisplay, NonReplicatedRelation, NotReplicatedReason, Relation};
 use postgres_native_tls::MakeTlsConnector;
 use readyset_client::consistency::Timestamp;
 #[cfg(feature = "failure_injection")]

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -11,8 +11,8 @@ use itertools::Itertools;
 use metrics::register_gauge;
 use nom_sql::{
     parse_key_specification_string, parse_sql_type, Column, ColumnConstraint, ColumnSpecification,
-    CreateTableBody, CreateTableStatement, Dialect, NonReplicatedRelation, NotReplicatedReason,
-    Relation, SqlIdentifier, TableKey,
+    CreateTableBody, CreateTableStatement, Dialect, DialectDisplay, NonReplicatedRelation,
+    NotReplicatedReason, Relation, SqlIdentifier, TableKey,
 };
 use postgres_types::{accepts, FromSql, Kind, Type};
 use readyset_client::metrics::recorded;

--- a/replicators/tests/ddl_vertical.rs
+++ b/replicators/tests/ddl_vertical.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use itertools::Itertools;
-use nom_sql::SqlType;
+use nom_sql::{DialectDisplay, SqlType};
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Just, Strategy};
 use proptest::{collection, sample};


### PR DESCRIPTION
If we are able to parse a select statement but fail to perform a
display().parse() round trip, we will fail to load a stored 'create
cache' statement after a backwards incompatible upgrade.

This commit adds a check and logs an error if we detect we will fail
this, so that we can fix the issue before upgrading.

