### PR TITLE
server: Store original 'create cache' strings in authority

### DIFF
--- a/benchmarks/src/spec.rs
+++ b/benchmarks/src/spec.rs
@@ -269,6 +269,7 @@ impl WorkloadSpec {
                 let create_cache_query = nom_sql::CreateCacheStatement {
                     name: None,
                     inner: Ok(nom_sql::CacheInner::Statement(Box::new(stmt))),
+                    unparsed_create_cache_statement: spec.clone(),
                     always: false,
                     concurrently: false,
                 };

--- a/benchmarks/src/utils/query.rs
+++ b/benchmarks/src/utils/query.rs
@@ -214,6 +214,7 @@ impl ArbitraryQueryParameters {
             inner: Ok(nom_sql::CacheInner::Statement(Box::new(stmt))),
             always: false,
             concurrently: false,
+            unparsed_create_cache_statement: "unused for benchmark".to_string(),
         };
 
         conn.query_drop(create_cache_query.display(conn.dialect()).to_string())

--- a/benchmarks/src/write_benchmark.rs
+++ b/benchmarks/src/write_benchmark.rs
@@ -156,6 +156,7 @@ async fn create_indices(
                 inner: Ok(CacheInner::Statement(Box::new(query))),
                 always: false,
                 concurrently: false,
+                unparsed_create_cache_statement: "unused for benchmark".to_string(),
             };
             conn.query_drop(create_cache.display(conn.dialect()).to_string())
                 .await?;

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -225,6 +225,9 @@ pub struct CreateCacheStatement {
     /// statement. If it failed to parse, this will be an `Err` with the remainder [`String`]
     /// that could not be parsed.
     pub inner: Result<CacheInner, String>,
+    /// A full copy of the original 'create cache' statement that can be used to re-create the
+    /// cache after an upgrade
+    pub unparsed_create_cache_statement: String,
     /// If `always` is true, a cached query executed inside a transaction can be served from
     /// a readyset cache.
     /// if false, cached queries within a transaction are proxied to upstream
@@ -834,6 +837,7 @@ pub fn create_cached_query(
     dialect: Dialect,
 ) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], CreateCacheStatement> {
     move |i| {
+        let unparsed_create_cache_statement: String = String::from_utf8_lossy(*i).into();
         let (i, _) = tag_no_case("create")(i)?;
         let (i, _) = whitespace1(i)?;
         let (i, _) = tag_no_case("cache")(i)?;
@@ -849,6 +853,7 @@ pub fn create_cached_query(
             CreateCacheStatement {
                 name,
                 inner,
+                unparsed_create_cache_statement,
                 always: opts.always,
                 concurrently: opts.concurrently,
             },

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -996,6 +996,7 @@ impl NoriaConnector {
         &mut self,
         name: Option<&Relation>,
         statement: &nom_sql::SelectStatement,
+        unparsed_create_cache_statment: String,
         override_schema_search_path: Option<Vec<SqlIdentifier>>,
         always: bool,
         concurrently: bool,
@@ -1006,7 +1007,12 @@ impl NoriaConnector {
         let schema_search_path =
             override_schema_search_path.unwrap_or_else(|| self.schema_search_path.clone());
         let changelist = ChangeList::from_change(
-            Change::create_cache(name.clone(), statement.clone(), always),
+            Change::create_cache(
+                name.clone(),
+                statement.clone(),
+                unparsed_create_cache_statment,
+                always,
+            ),
             self.dialect,
         )
         .with_schema_search_path(schema_search_path.clone());
@@ -1067,8 +1073,17 @@ impl NoriaConnector {
                         );
                     }
 
+                    // We currently don't fully support async migrations, and piping through the
+                    // full 'create cache' string for _every_ query we see would be overly
+                    // expensive, so we fall back to constructing a 'create cache' statement from a
+                    // displayed version of the the SelectStatement we already parsed in this case
                     let changelist = ChangeList::from_change(
-                        Change::create_cache(qname.clone(), q.clone(), false),
+                        Change::create_cache(
+                            qname.clone(),
+                            q.clone(),
+                            format!("create cache from {}", q.display(self.parse_dialect)),
+                            false,
+                        ),
                         self.dialect,
                     )
                     .with_schema_search_path(search_path);

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -15,6 +15,7 @@ use readyset_client::query::{MigrationState, Query};
 use readyset_client::recipe::changelist::{Change, ChangeList};
 use readyset_client::{PlaceholderIdx, ReadySetHandle, ViewCreateRequest};
 use readyset_client_metrics::recorded;
+use readyset_data::dialect::SqlEngine;
 use readyset_data::DfValue;
 use readyset_errors::{internal_err, ReadySetResult};
 use readyset_sql_passes::InlineLiterals;
@@ -166,15 +167,24 @@ impl MigrationHandler {
 
             // Perform a migration on the original query to update the cache
             // TODO(ENG-2820): Implement retry
+            //
+            // We currently don't fully support inlined migrations, and piping through the
+            // full 'create cache' string for _every_ query we see would be overly
+            // expensive, so we fall back to constructing a 'create cache' statement from a
+            // displayed version of the the SelectStatement we already parsed in this case
             if !successful_migrations.is_empty() {
                 let _ = self
                     .noria
                     .handle_create_cached_query(
                         None,
                         &query.query().statement,
+                        format!(
+                            "create cache from {}",
+                            query.query().statement.display(self.parse_dialect())
+                        ),
                         Some(query.query().schema_search_path.clone()),
-                        false,
-                        false,
+                        /* always */ false,
+                        /* concurrently */ false,
                     )
                     .await;
                 // Inform the query status cache of completed migrations
@@ -294,6 +304,10 @@ impl MigrationHandler {
             .handle_create_cached_query(
                 None,
                 &inlined_query,
+                format!(
+                    "create cache from {}",
+                    inlined_query.display(self.parse_dialect())
+                ),
                 Some(view_request.schema_search_path.clone()),
                 false,
                 false,
@@ -327,8 +341,10 @@ impl MigrationHandler {
         }
         let qname =
             utils::generate_query_name(&view_request.statement, &view_request.schema_search_path);
+
+        // We do not need to provide a real "create cache" String for a dry run migration
         let changelist = ChangeList::from_change(
-            Change::create_cache(qname, view_request.statement.clone(), false),
+            Change::create_cache(qname, view_request.statement.clone(), "".to_string(), false),
             self.dialect,
         )
         .with_schema_search_path(view_request.schema_search_path.clone());
@@ -344,6 +360,13 @@ impl MigrationHandler {
                     .update_query_migration_state(view_request, MigrationState::Unsupported);
             }
             _ => {} // Leave it as pending.
+        }
+    }
+
+    fn parse_dialect(&self) -> nom_sql::Dialect {
+        match self.dialect.engine() {
+            SqlEngine::PostgreSQL => nom_sql::Dialect::PostgreSQL,
+            SqlEngine::MySQL => nom_sql::Dialect::MySQL,
         }
     }
 }

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -197,6 +197,7 @@ impl ChangeList {
                                 name,
                                 inner,
                                 always,
+                                unparsed_create_cache_statement,
                                 ..
                             }) => {
                                 let statement = match inner {
@@ -219,6 +220,7 @@ impl ChangeList {
                                     name,
                                     statement,
                                     always,
+                                    unparsed_create_cache_statement,
                                 }))
                             }
                             SqlQuery::AlterTable(ats) => changes.push(Change::AlterTable(ats)),
@@ -320,6 +322,9 @@ pub struct CreateCache {
     pub name: Option<Relation>,
     /// The `SELECT` statement for the body of the cache
     pub statement: Box<SelectStatement>,
+    /// A full copy of the original 'create cache' statement that can be used to re-create the
+    /// cache after an upgrade
+    pub unparsed_create_cache_statement: String,
     /// If set to `true`, execution of this cache will bypass transaction handling in the
     /// adapter
     pub always: bool,
@@ -408,9 +413,14 @@ pub enum Change {
 }
 
 impl Change {
-    /// Creates a new [`Change::CreateCache`] from the given `name` and
-    /// [`SelectStatement`].
-    pub fn create_cache<N>(name: N, statement: SelectStatement, always: bool) -> Self
+    /// Creates a new [`Change::CreateCache`] from the given `name`,
+    /// [`SelectStatement`], and unparsed String.
+    pub fn create_cache<N>(
+        name: N,
+        statement: SelectStatement,
+        unparsed_create_cache_statement: String,
+        always: bool,
+    ) -> Self
     where
         N: Into<Relation>,
     {
@@ -418,6 +428,7 @@ impl Change {
             name: Some(name.into()),
             statement: Box::new(statement),
             always,
+            unparsed_create_cache_statement,
         })
     }
 

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -369,7 +369,15 @@ impl SqlIncorporator {
                 }
                 Change::CreateCache(cc) => {
                     res.add_cache_statement(cc.clone());
-                    self.add_query(cc.name, *cc.statement, cc.always, &schema_search_path, mig)?;
+
+                    self.add_query(
+                        cc.name,
+                        *cc.statement,
+                        cc.unparsed_create_cache_statement,
+                        cc.always,
+                        &schema_search_path,
+                        mig,
+                    )?;
                 }
                 Change::AlterTable(_) => {
                     // The only ALTER TABLE changes that can end up here (currently) are ones that
@@ -611,6 +619,7 @@ impl SqlIncorporator {
         &mut self,
         name: Option<Relation>,
         mut stmt: SelectStatement,
+        unparsed_statement: String,
         always: bool,
         schema_search_path: &[SqlIdentifier],
         mig: &mut Migration<'_>,
@@ -675,6 +684,7 @@ impl SqlIncorporator {
             name: name.clone(),
             statement: stmt,
             always,
+            unparsed_statement,
         })?;
         self.registry
             .insert_invalidating_tables(name.clone(), invalidating_tables)?;

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -62,9 +62,11 @@ impl Recipe {
                 name,
                 statement,
                 always,
+                unparsed_statement,
             } => SqlQuery::CreateCache(CreateCacheStatement {
                 name: Some(name.clone()),
                 inner: Ok(CacheInner::Statement(Box::new(statement.clone()))),
+                unparsed_create_cache_statement: unparsed_statement.clone(),
                 always: *always,
                 concurrently: false, // concurrently not relevant after migrating
             }),

--- a/readyset-server/src/controller/sql/registry.rs
+++ b/readyset-server/src/controller/sql/registry.rs
@@ -37,6 +37,7 @@ pub(crate) enum RecipeExpr {
     Cache {
         name: Relation,
         statement: SelectStatement,
+        unparsed_statement: String,
         always: bool,
     },
 }
@@ -740,6 +741,7 @@ mod tests {
                 statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                     .unwrap(),
                 always: false,
+                unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table".into(),
             };
 
             assert_eq!(cached_query.name(), &query_name);
@@ -770,6 +772,7 @@ mod tests {
                 statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                     .unwrap(),
                 always: false,
+                unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table".into(),
             };
 
             let cached_query_table_refs = cached_query.table_references();
@@ -814,6 +817,8 @@ mod tests {
                     name: "test_query".into(),
                     statement: statement.clone(),
                     always: false,
+                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
+                        .into(),
                 })
                 .unwrap();
             registry
@@ -821,6 +826,8 @@ mod tests {
                     name: "test_query_alias".into(),
                     statement,
                     always: false,
+                    unparsed_statement:
+                        "CREATE CACHE test_query_alias FROM SELECT * FROM test_table".into(),
                 })
                 .unwrap();
 
@@ -831,6 +838,8 @@ mod tests {
                     name: "test_query".into(),
                     statement: statement.clone(),
                     always: false,
+                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
+                        .into(),
                 })
                 .unwrap();
             registry
@@ -838,6 +847,8 @@ mod tests {
                     name: "test_query_alias".into(),
                     statement,
                     always: false,
+                    unparsed_statement:
+                        "CREATE CACHE test_query_alias FROM SELECT * FROM test_table".into(),
                 })
                 .unwrap();
 
@@ -874,6 +885,8 @@ mod tests {
                 )
                 .unwrap(),
                 always: false,
+                unparsed_statement:
+                    "CREATE CACHE test_query2 FROM SELECT DISTINCT * FROM test_table".into(),
             };
 
             assert!(registry.add_query(expr.clone()).unwrap());
@@ -891,6 +904,7 @@ mod tests {
                 statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                     .unwrap(),
                 always: false,
+                unparsed_statement: "CREATE CACHE test_query2 FROM SELECT * FROM test_table".into(),
             };
             assert!(!registry.add_query(expr).unwrap());
 
@@ -901,7 +915,9 @@ mod tests {
                     name: "test_query".into(),
                     statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                         .unwrap(),
-                    always: false
+                    always: false,
+                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
+                        .into(),
                 }
             );
         }
@@ -1040,7 +1056,9 @@ mod tests {
                     name: "test_query".into(),
                     statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table")
                         .unwrap(),
-                    always: false
+                    always: false,
+                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
+                        .into(),
                 }
             );
             assert!(registry.get(&"test_query_alias".into()).is_none())
@@ -1086,6 +1104,7 @@ mod tests {
                     name: "test".into(),
                     statement: stmt.clone(),
                     always: false,
+                    unparsed_statement: "CREATE CACHE test FROM SELECT * FROM test_table".into(),
                 })
                 .unwrap();
             assert!(registry.contains(&stmt))
@@ -1116,6 +1135,8 @@ mod tests {
                     statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table")
                         .unwrap(),
                     always: false,
+                    unparsed_statement: "CREATE CACHE test_query2 FROM SELECT * FROM test_table"
+                        .into(),
                 })
                 .unwrap();
 
@@ -1202,7 +1223,9 @@ mod tests {
                 .add_query(RecipeExpr::Cache {
                     name: "foo".into(),
                     statement: query.clone(),
-                    always: false
+                    always: false,
+                    unparsed_statement: "CREATE CACHE foo FROM SELECT CAST(x AS public.abc) FROM t"
+                        .into(),
                 })
                 .unwrap());
 
@@ -1358,6 +1381,8 @@ mod tests {
                     name: "test_query".into(),
                     statement: statement.clone(),
                     always: false,
+                    unparsed_statement:
+                        "CREATE CACHE test_query FROM SELECT a FROM t WHERE a = 1 LIMIT ?".into(),
                 })
                 .unwrap();
 
@@ -1380,6 +1405,8 @@ mod tests {
                     name: "alias".into(),
                     statement,
                     always: false,
+                    unparsed_statement:
+                        "CREATE CACHE alias FROM SELECT a FROM t WHERE a = 1 LIMIT ?".into(),
                 })
                 .unwrap();
 
@@ -1413,6 +1440,8 @@ mod tests {
                     name: "query1".into(),
                     statement: statement1.clone(),
                     always: false,
+                    unparsed_statement:
+                        "CREATE CACHE query1 FROM SELECT a FROM t WHERE a = 1 LIMIT ?;".into(),
                 })
                 .unwrap();
 
@@ -1421,6 +1450,7 @@ mod tests {
                     name: "query1_alias".into(),
                     statement: statement1,
                     always: false,
+                    unparsed_statement: "CREATE CACHE query1_alias FROM SELECT a FROM t WHERE a = 1 LIMIT ?;".into(),
                 })
                 .unwrap();
 
@@ -1429,6 +1459,8 @@ mod tests {
                     name: "query2".into(),
                     statement: statement2,
                     always: false,
+                    unparsed_statement:
+                        "CREATE CACHE query2 FROM SELECT a FROM t WHERE a = 2 LIMIT ?;".into(),
                 })
                 .unwrap();
 


### PR DESCRIPTION
Rather than parsing and displaying `create cache` statements, for
explicit `create cache` statements, take some extra time to clone and
pass along the full, original query string and store that instead.

The rationale for doing this is: if we succeeded in parsing the query
originally, we are guaranteed to succeed in doing it again. But if we
parse and then display and re-parse, that opens us up to having a bug in
our display implementation.

