### PR TITLE
logictests: Add failing test for self-join

### DIFF
--- a/logictests/cte_problematic_self_join.fail.test
+++ b/logictests/cte_problematic_self_join.fail.test
@@ -1,0 +1,17 @@
+statement ok
+create table t (x int);
+
+query II nosort
+WITH l AS (SELECT t.x FROM t), r AS (SELECT t.x FROM t)
+SELECT * FROM l JOIN r ON l.x = r.x;
+----
+
+statement ok
+insert into t (x) values (1);
+
+query II nosort
+WITH l AS (SELECT t.x FROM t), r AS (SELECT t.x FROM t)
+SELECT * FROM l JOIN r ON l.x = r.x;
+----
+1
+1


### PR DESCRIPTION
Adds a failing logictest for a self-join in the context of a CTE that is
not being detected by our `DetectProblematicSelfJoins` rewrite pass.
Eventually, we should rewrite this rewrite pass to be a MIR-based
rewrite pass, which will be able to detect 100% of these kinds of
problematic self-joins.

Refs: REA-340, REA-3650
