### PR TITLE
readyset-psql: allow set client_encoding('utf8')

### DIFF
--- a/readyset-psql/src/query_handler.rs
+++ b/readyset-psql/src/query_handler.rs
@@ -313,6 +313,7 @@ lazy_static! {
     static ref ALLOWED_PARAMETERS_WITH_VALUE: HashMap<&'static str, AllowedParameterValue> =
         HashMap::from([
             ("client_encoding", AllowedParameterValue::one_of([
+                PostgresParameterValue::literal("utf8"),
                 PostgresParameterValue::literal("utf-8"),
                 PostgresParameterValue::literal("UTF8"),
                 PostgresParameterValue::literal("unicode"),


### PR DESCRIPTION
We had an allow list of encodings that we support which were variations
of UTF8, but they didn't include utf8, which a RoR app I was working
with used.

