### PR TITLE
build: Increase ulimit on readyset-build container

### DIFF
--- a/build/docker-compose.ci-test.yml
+++ b/build/docker-compose.ci-test.yml
@@ -26,6 +26,10 @@ services:
       - '6379'
   app:
     image: "305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}"
+    ulimits:
+      nofile:
+        soft: "65536"
+        hard: "65536"
     working_dir: /workdir
     volumes:
     - 'target:/workdir/target'


### PR DESCRIPTION
On buildkite elastic-ci 6.9 images, the default ulimit in docker
containers was too low for logictests to run successfully.  This change
increases the limit from 32k to 65536.

That is rather a lot of files to have open...  perhaps we're leaking
open files...?

