### PR TITLE
readyset-data: Impl into/from between our dialects

### DIFF
--- a/readyset-data/src/dialect.rs
+++ b/readyset-data/src/dialect.rs
@@ -109,3 +109,25 @@ impl Dialect {
         }
     }
 }
+
+impl From<Dialect> for nom_sql::Dialect {
+    fn from(d: Dialect) -> Self {
+        match d.engine {
+            SqlEngine::PostgreSQL => nom_sql::Dialect::PostgreSQL,
+            SqlEngine::MySQL => nom_sql::Dialect::MySQL,
+        }
+    }
+}
+
+impl From<nom_sql::Dialect> for Dialect {
+    fn from(d: nom_sql::Dialect) -> Self {
+        match d {
+            nom_sql::Dialect::PostgreSQL => Self {
+                engine: SqlEngine::PostgreSQL,
+            },
+            nom_sql::Dialect::MySQL => Self {
+                engine: SqlEngine::MySQL,
+            },
+        }
+    }
+}

--- a/replicators/src/table_filter.rs
+++ b/replicators/src/table_filter.rs
@@ -31,7 +31,7 @@ use readyset_util::redacted::RedactedString;
 pub(crate) struct TableFilter {
     /// A mapping between schema to the list of tables to replicate from that schema.
     /// Only the tables included in the map will be replicated.
-    /// This is only populated by the --rplication-tables option
+    /// This is only populated by the --replication-tables option
     explicitly_replicated: BTreeMap<SqlIdentifier, ReplicateTableSpec>,
     /// A mapping between schema to the list of tables to *NOT* replicate from that schema.
     /// Any other valid tables will be replicated, where a valid table is either one of the tables


### PR DESCRIPTION
We have 2 representations of a SQL `Dialect` that may diverge but for
now map roughly 1:1. Add a From impl so that we can convert from one to
the other.

