### PR TITLE
readyset-client: Add failpoint for loading controller state

### DIFF
--- a/readyset-client/src/consensus/consul.rs
+++ b/readyset-client/src/consensus/consul.rs
@@ -134,7 +134,7 @@ use futures::future::join_all;
 use futures::stream::FuturesOrdered;
 use futures::TryStreamExt;
 use metrics::gauge;
-use readyset_errors::{internal, internal_err};
+use readyset_errors::{internal, internal_err, set_failpoint_return_err};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
@@ -810,6 +810,7 @@ impl AuthorityControl for ConsulAuthority {
         P: Send + Serialize + DeserializeOwned,
         E: Send,
     {
+        set_failpoint_return_err!(failpoints::LOAD_CONTROLLER_STATE);
         self.ensure_leader().await?;
 
         loop {

--- a/readyset-client/src/failpoints/mod.rs
+++ b/readyset-client/src/failpoints/mod.rs
@@ -25,3 +25,5 @@ pub const POSTGRES_NEXT_WAL_EVENT: &str = "postgres-next-wal-event";
 /// Imitates a failure in the `NoriaAdapter::start_inner_postgres()` function that happens before we
 /// interact with the upstream database
 pub const START_INNER_POSTGRES: &str = "start-inner-postgres";
+/// Imitate a backwards incompatible deserialization from controller state
+pub const LOAD_CONTROLLER_STATE: &str = "load-controller-state";


### PR DESCRIPTION
This adds a failpoint that allows us to inject an arbitrary error when
loading controller state, making it easier to test such failure modes.

