### PR TITLE
server: Store schema search path for stored caches

### DIFF
--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -11,6 +11,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use clap::ValueEnum;
 use enum_dispatch::enum_dispatch;
+use nom_sql::SqlIdentifier;
 use readyset_errors::{ReadySetError, ReadySetResult};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -37,6 +38,12 @@ pub type WorkerId = String;
 
 const CREATE_CACHE_STATEMENTS_PATH: &str = "create_cache_statements";
 const PERSISTENT_STATS_PATH: &str = "persistent_stats";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CreateCacheRequest {
+    pub unparsed_stmt: String,
+    pub schema_search_path: Vec<SqlIdentifier>,
+}
 
 /// A response to a `worker_heartbeat`, to inform the worker of its
 /// status within the system.

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -368,7 +368,10 @@ impl SqlIncorporator {
                     self.add_view(stmt.name, definition, schema_search_path.clone())?;
                 }
                 Change::CreateCache(cc) => {
-                    res.add_cache_statement(cc.clone());
+                    res.add_cache_statement(
+                        cc.unparsed_create_cache_statement.clone(),
+                        schema_search_path.clone(),
+                    )?;
 
                     self.add_query(
                         cc.name,


### PR DESCRIPTION
For each `create cache` statement we store in the authority, also store
the `schema search path` needed to fully resolve the relations in that
create cache statement.

