### PR TITLE
server: Store dialect along with CreateCacheStatements

### DIFF
--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use enum_dispatch::enum_dispatch;
 use nom_sql::SqlIdentifier;
+use readyset_data::Dialect;
 use readyset_errors::{ReadySetError, ReadySetResult};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -39,10 +40,11 @@ pub type WorkerId = String;
 const CREATE_CACHE_STATEMENTS_PATH: &str = "create_cache_statements";
 const PERSISTENT_STATS_PATH: &str = "persistent_stats";
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateCacheRequest {
     pub unparsed_stmt: String,
     pub schema_search_path: Vec<SqlIdentifier>,
+    pub dialect: Dialect,
 }
 
 /// A response to a `worker_heartbeat`, to inform the worker of its

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -371,6 +371,7 @@ impl SqlIncorporator {
                     res.add_cache_statement(
                         cc.unparsed_create_cache_statement.clone(),
                         schema_search_path.clone(),
+                        mig.dialect,
                     )?;
 
                     self.add_query(

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -97,11 +97,13 @@ impl RecipeChanges {
         &mut self,
         unparsed_stmt: String,
         schema_search_path: Vec<SqlIdentifier>,
+        dialect: Dialect,
     ) -> ReadySetResult<()> {
         self.new_cache_statements
             .push(serde_json::ser::to_string(&CreateCacheRequest {
                 unparsed_stmt,
                 schema_search_path,
+                dialect,
             })?);
 
         Ok(())

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -945,7 +945,7 @@ async fn caches_go_in_authority_list() {
         ChangeList::from_str(
             "CREATE TABLE t (x int);
              CREATE CACHE q FROM SELECT x FROM t;",
-            Dialect::DEFAULT_MYSQL,
+            Dialect::DEFAULT_POSTGRESQL,
         )
         .unwrap(),
     )
@@ -955,6 +955,7 @@ async fn caches_go_in_authority_list() {
     let CreateCacheRequest {
         unparsed_stmt,
         schema_search_path,
+        dialect,
     } = serde_json::from_slice(
         authority
             .create_cache_statements()
@@ -966,6 +967,7 @@ async fn caches_go_in_authority_list() {
     )
     .unwrap();
     assert_eq!(unparsed_stmt, "CREATE CACHE q FROM SELECT x FROM t;");
+    assert_eq!(dialect, Dialect::DEFAULT_POSTGRESQL);
     assert!(schema_search_path.is_empty());
 
     shutdown_tx.shutdown().await;


### PR DESCRIPTION
To reload the create cache statements from the authority, we re-parse
them, which means we need to know which dialect to use to do so.

