### PR TITLE
Fix memory tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4663,13 +4663,16 @@ name = "readyset-common"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "bit-vec",
  "chrono",
+ "ndarray",
  "petgraph",
  "proptest",
  "readyset-client",
  "readyset-data",
  "readyset-util",
  "rlimit",
+ "rust_decimal",
  "serde",
  "test-strategy",
  "tracing",

--- a/dataflow-state/src/lib.rs
+++ b/dataflow-state/src/lib.rs
@@ -10,6 +10,7 @@ mod single_state;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
 use std::iter::FromIterator;
+use std::mem::size_of;
 use std::ops::{Bound, Deref};
 use std::rc::Rc;
 use std::vec;
@@ -586,11 +587,13 @@ impl Deref for Row {
 
 impl SizeOf for Row {
     fn size_of(&self) -> u64 {
-        use std::mem::size_of;
         size_of::<Self>() as u64
     }
     fn deep_size_of(&self) -> u64 {
-        (*self.0).deep_size_of()
+        // We need to account for the size of Rc (plus RcBox which is 2 * usize)
+        size_of::<Rc<Vec<DfValue>>>() as u64
+            + 2 * size_of::<usize>() as u64
+            + (*self.0).deep_size_of()
     }
     fn is_empty(&self) -> bool {
         false

--- a/readyset-common/Cargo.toml
+++ b/readyset-common/Cargo.toml
@@ -11,6 +11,9 @@ description = "Artifacts commonly shared among other ReadySet crates"
 chrono = { version = "0.4.0", features = ["serde"] }
 serde = { version = "1.0.8", features = ["rc", "derive"] }
 petgraph = { version = "0.5", features = ["serde-1"] }
+bit-vec = { version = "0.6", features = ["serde"] }
+rust_decimal = { version = "1.26", features = ["db-tokio-postgres", "serde-str"] }
+ndarray = { version = "0.15.4", features = ["serde"] }
 vec1 = "1.6.0"
 tuple = "0.5"
 triomphe = "0.1"

--- a/readyset-common/src/lib.rs
+++ b/readyset-common/src/lib.rs
@@ -5,13 +5,22 @@ mod local;
 mod records;
 pub mod ulimit;
 
+use std::mem::{size_of, size_of_val};
+
+use bit_vec::BitVec;
 use petgraph::prelude::*;
 pub use readyset_client::internal::{Index, IndexType};
-pub use readyset_data::DfValue;
+pub use readyset_data::{Array, DfValue, PassThrough, Text, TinyText};
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use vec1::Vec1;
 
 pub use self::local::*;
 pub use self::records::*;
+
+/// Overhead of ArcInner<T> structure
+/// for strong and weak counters
+const ARC_INNER_SIZE: u64 = 2 * size_of::<usize>() as u64;
 
 pub trait SizeOf {
     fn deep_size_of(&self) -> u64;
@@ -21,12 +30,27 @@ pub trait SizeOf {
 
 impl SizeOf for DfValue {
     fn deep_size_of(&self) -> u64 {
-        use std::mem::size_of_val;
-
         let inner = match *self {
-            DfValue::Text(ref t) => size_of_val(t) as u64 + t.as_bytes().len() as u64,
-            DfValue::BitVector(ref t) => size_of_val(t) as u64 + (t.len() as u64 + 7) / 8,
-            DfValue::ByteArray(ref t) => size_of_val(t) as u64 + t.len() as u64,
+            DfValue::Text(ref t) => t.deep_size_of(),
+            DfValue::BitVector(ref t) => ARC_INNER_SIZE + t.deep_size_of(),
+            DfValue::ByteArray(ref t) => {
+                ARC_INNER_SIZE
+                // to account for Vec<u8>
+                + size_of::<Vec<u8>>() as u64
+                // use capacity instead of length
+                + t.capacity() as u64
+            }
+            DfValue::Numeric(_) => {
+                ARC_INNER_SIZE
+                // `Decimal` size - 16 bytes
+                + size_of::<Decimal>() as u64
+            }
+            DfValue::Array(ref t) => {
+                ARC_INNER_SIZE
+                // SmallVec size
+                + t.deep_size_of()
+            }
+            DfValue::PassThrough(ref t) => ARC_INNER_SIZE + t.deep_size_of(),
             _ => 0u64,
         };
 
@@ -34,8 +58,6 @@ impl SizeOf for DfValue {
     }
 
     fn size_of(&self) -> u64 {
-        use std::mem::size_of;
-
         // doesn't include data if stored externally
         size_of::<DfValue>() as u64
     }
@@ -47,14 +69,14 @@ impl SizeOf for DfValue {
 
 impl SizeOf for Vec<DfValue> {
     fn deep_size_of(&self) -> u64 {
-        use std::mem::size_of_val;
-
-        size_of_val(self) as u64 + self.iter().fold(0u64, |acc, d| acc + d.deep_size_of())
+        let mut size =
+            size_of_val(self) as u64 + self.iter().fold(0u64, |acc, d| acc + d.deep_size_of());
+        // To account for vector overallocation
+        size += (self.capacity() - self.len()) as u64 * size_of::<DfValue>() as u64;
+        size
     }
 
     fn size_of(&self) -> u64 {
-        use std::mem::{size_of, size_of_val};
-
         size_of_val(self) as u64 + size_of::<DfValue>() as u64 * self.len() as u64
     }
 
@@ -65,14 +87,10 @@ impl SizeOf for Vec<DfValue> {
 
 impl SizeOf for Box<[DfValue]> {
     fn deep_size_of(&self) -> u64 {
-        use std::mem::size_of_val;
-
         size_of_val(self) as u64 + self.iter().fold(0u64, |acc, d| acc + d.deep_size_of()) + 8
     }
 
     fn size_of(&self) -> u64 {
-        use std::mem::{size_of, size_of_val};
-
         size_of_val(self) as u64 + size_of::<DfValue>() as u64 * self.len() as u64
     }
 
@@ -81,6 +99,93 @@ impl SizeOf for Box<[DfValue]> {
     }
 }
 
+impl SizeOf for PassThrough {
+    fn deep_size_of(&self) -> u64 {
+        size_of::<PassThrough>() as u64 + size_of_val::<[u8]>(&self.data) as u64
+    }
+
+    fn size_of(&self) -> u64 {
+        size_of::<PassThrough>() as u64
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl SizeOf for Array {
+    fn deep_size_of(&self) -> u64 {
+        size_of::<Array>() as u64
+        // SmallVec size
+        + 2 * size_of::<usize>() as u64
+        + self.num_dimensions() as u64 * size_of::<i32>() as u64
+        // estimate for ndarray data size
+        + self.values().map(|d| d.deep_size_of()).sum::<u64>()
+    }
+
+    fn size_of(&self) -> u64 {
+        size_of::<Array>() as u64
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl SizeOf for Text {
+    fn deep_size_of(&self) -> u64 {
+        // Size of triomphe::thin_arc::ThinArc
+        size_of::<usize>() as u64
+        // Size of triomphe::thin_arc::ArcInner - not public outside of the crate
+        + 2 * size_of::<usize>() as u64
+        // Size of triomphe::header::HeaderSliceWithLength - not public outside of a crate
+        + (2 * size_of::<usize>() + 1) as u64
+        // Text size
+        + self.as_bytes().len() as u64
+    }
+
+    fn size_of(&self) -> u64 {
+        size_of::<Text>() as u64
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl SizeOf for BitVec {
+    fn deep_size_of(&self) -> u64 {
+        // to account for BitVec size
+        size_of::<BitVec>() as u64
+        // get raw storage
+        + size_of_val(self.storage()) as u64
+    }
+
+    fn size_of(&self) -> u64 {
+        size_of::<BitVec>() as u64
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<T: SizeOf> SizeOf for Vec1<T> {
+    fn deep_size_of(&self) -> u64 {
+        let mut size = size_of::<Vec1<T>>() as u64;
+        size += self.iter().map(SizeOf::deep_size_of).sum::<u64>()
+            + ((self.capacity() - self.len()) as u64) * (size_of::<T>() as u64);
+        size
+    }
+
+    fn size_of(&self) -> u64 {
+        size_of::<Vec1<T>>() as u64
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
 /// A reference to a node, and potentially a partial index on that node
 ///
 /// The index is only included if partial materialization is possible; if it's present, it
@@ -117,8 +222,6 @@ mod tests {
 
     #[test]
     fn data_type_mem_size() {
-        use std::mem::{size_of, size_of_val};
-
         use chrono::NaiveDateTime;
 
         let s = "this needs to be longer than 14 chars to make it be a Text";
@@ -138,8 +241,8 @@ mod tests {
         assert_eq!(size_of_val(&txt) as u64, txt.size_of());
         assert_eq!(
             txt.deep_size_of(),
-            // DfValue + Arc's ptr + string
-            txt.size_of() + 8 + (s.len() as u64)
+            // DfValue + overhead + string
+            txt.size_of() + 41 + (s.len() as u64)
         );
         assert_eq!(size_of_val(&shrt), 16);
         assert_eq!(size_of_val(&time), 16);
@@ -148,6 +251,6 @@ mod tests {
 
         assert_eq!(size_of_val(&rec), 24);
         assert_eq!(rec.size_of(), 24 + 3 * 16);
-        assert_eq!(rec.deep_size_of(), 24 + 3 * 16 + (8 + 16));
+        assert_eq!(rec.deep_size_of(), 24 + 3 * 16 + (41 + 16));
     }
 }


### PR DESCRIPTION
Added several fixes into memory tracking of materialized data flow state
(DfValue::deep_size_of, Row::deep_size_of, Vec::deep_size_of,
base_row_bytes_from_comparison, and base_row_bytes)

