### PR TITLE
adapter: Extract match from query_noria_extensions

### DIFF
--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -137,6 +137,44 @@ impl SqlQuery {
     pub fn is_select(&self) -> bool {
         matches!(self, Self::Select(_))
     }
+
+    /// Returns true if this is a query for a ReadySet extension and not regular SQL.
+    pub fn is_readyset_extension(&self) -> bool {
+        match self {
+            SqlQuery::Explain(_)
+            | SqlQuery::CreateCache(_)
+            | SqlQuery::DropCache(_)
+            | SqlQuery::DropAllCaches(_) => true,
+            SqlQuery::Show(show_stmt) => match show_stmt {
+                ShowStatement::Events | ShowStatement::Tables(_) => false,
+                ShowStatement::CachedQueries(_)
+                | ShowStatement::ProxiedQueries(_)
+                | ShowStatement::ReadySetStatus
+                | ShowStatement::ReadySetStatusAdapter
+                | ShowStatement::ReadySetMigrationStatus(_)
+                | ShowStatement::ReadySetVersion
+                | ShowStatement::ReadySetTables
+                | ShowStatement::Connections => true,
+            },
+            SqlQuery::CreateTable(_)
+            | SqlQuery::CreateView(_)
+            | SqlQuery::AlterTable(_)
+            | SqlQuery::Insert(_)
+            | SqlQuery::CompoundSelect(_)
+            | SqlQuery::Select(_)
+            | SqlQuery::Delete(_)
+            | SqlQuery::DropTable(_)
+            | SqlQuery::DropView(_)
+            | SqlQuery::Update(_)
+            | SqlQuery::Set(_)
+            | SqlQuery::StartTransaction(_)
+            | SqlQuery::Commit(_)
+            | SqlQuery::Rollback(_)
+            | SqlQuery::RenameTable(_)
+            | SqlQuery::Use(_)
+            | SqlQuery::Comment(_) => false,
+        }
+    }
 }
 
 pub fn sql_query(dialect: Dialect) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], SqlQuery> {

--- a/readyset-mysql/tests/fallback.rs
+++ b/readyset-mysql/tests/fallback.rs
@@ -829,7 +829,7 @@ async fn replication_failure_ignores_table() {
     sleep().await;
     sleep().await;
 
-    assert!(last_statement_matches("readyset", "ok", &mut client).await);
+    assert!(last_statement_matches("upstream", "ok", &mut client).await);
     client
         .query_drop("CREATE CACHE FROM SELECT * FROM cats")
         .await

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -965,7 +965,7 @@ async fn setup_for_replication_failure(client: &Client) {
     sleep().await;
     sleep().await;
 
-    assert!(last_statement_matches("readyset", "ok", &client).await);
+    assert!(last_statement_matches("upstream", "ok", &client).await);
     client
         .simple_query("CREATE CACHE FROM SELECT * FROM cats")
         .await


### PR DESCRIPTION
`query_noria_extensions` had a bit of an awkward return time with an
Option<Result<Result>>, which can be cleaned up by checking that the
SqlQuery being passed into it is indeed a noria(readyset) extension
before calling the function. This also allows more ergonomic use of '?'
inside of `query_noria_extensions`.

