### PR TITLE
treewide: Store 'create cache' statements in adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,8 @@ For questions or support, join us on the [ReadySet Community Slack](https://join
 
 ---
 
-## Project Status & Roadmap
-ReadySet is currently in beta. Our team is hard at work stabilizing the system with a focus on PostgreSQL. Our MySQL support is considered alpha. You can learn more about how we're approaching this and follow along on our progress below.
-
-| Project | Progress | Notes |
-| ----------- | ----------- | ----------- |
-| General System Testing | [Track](https://github.com/readysettech/readyset/issues/434) | Run ReadySet in a production-like environment and validate its robustness in the presence of faults.|
-| Dataflow Testing | [Track](https://github.com/readysettech/readyset/issues/431) | Expand testing of the ReadySet caching engine. |
-| Benchmarking & Analysis  | [Track](https://github.com/readysettech/readyset/issues/432) | Expand ReadySet's performance benchmarks to a wider array of workloads. |
-| Usability Improvements | [Track](https://github.com/readysettech/readyset/issues/443) | Make it easier to configure, interact with, and debug ReadySet. |
-| High Availability | [Track](https://github.com/readysettech/readyset/issues/433) | Ensure that ReadySet can accept connections, proxy queries, serve warm reads from the cache, and replicate writes from the primary database in the presence of certain failures. |
+## ReadySet Roadmap
+ReadySet is currently in beta. Our team is hard at work stabilizing the system with a focus on PostgreSQL. Our MySQL support is considered alpha. You can learn more about how we're approaching this and follow along on [our roadmap](https://github.com/readysettech/readyset/issues/856).
 
 ### Contribute
 If you're interested in contributing, we gratefully welcome helping hands! We welcome contributions as [GitHub pull requests](https://github.com/readysettech/readyset/pulls), creating [issues](https://github.com/readysettech/readyset/issues), advocacy, and participating in our [community](#join-the-community)!

--- a/benchmarks/src/spec.rs
+++ b/benchmarks/src/spec.rs
@@ -269,7 +269,7 @@ impl WorkloadSpec {
                 let create_cache_query = nom_sql::CreateCacheStatement {
                     name: None,
                     inner: Ok(nom_sql::CacheInner::Statement(Box::new(stmt))),
-                    unparsed_create_cache_statement: spec.clone(),
+                    unparsed_create_cache_statement: None,
                     always: false,
                     concurrently: false,
                 };

--- a/benchmarks/src/utils/query.rs
+++ b/benchmarks/src/utils/query.rs
@@ -214,7 +214,7 @@ impl ArbitraryQueryParameters {
             inner: Ok(nom_sql::CacheInner::Statement(Box::new(stmt))),
             always: false,
             concurrently: false,
-            unparsed_create_cache_statement: "unused for benchmark".to_string(),
+            unparsed_create_cache_statement: None,
         };
 
         conn.query_drop(create_cache_query.display(conn.dialect()).to_string())

--- a/benchmarks/src/write_benchmark.rs
+++ b/benchmarks/src/write_benchmark.rs
@@ -156,7 +156,7 @@ async fn create_indices(
                 inner: Ok(CacheInner::Statement(Box::new(query))),
                 always: false,
                 concurrently: false,
-                unparsed_create_cache_statement: "unused for benchmark".to_string(),
+                unparsed_create_cache_statement: None,
             };
             conn.query_drop(create_cache.display(conn.dialect()).to_string())
                 .await?;

--- a/nom-sql/src/create.rs
+++ b/nom-sql/src/create.rs
@@ -227,7 +227,7 @@ pub struct CreateCacheStatement {
     pub inner: Result<CacheInner, String>,
     /// A full copy of the original 'create cache' statement that can be used to re-create the
     /// cache after an upgrade
-    pub unparsed_create_cache_statement: String,
+    pub unparsed_create_cache_statement: Option<String>,
     /// If `always` is true, a cached query executed inside a transaction can be served from
     /// a readyset cache.
     /// if false, cached queries within a transaction are proxied to upstream
@@ -837,7 +837,7 @@ pub fn create_cached_query(
     dialect: Dialect,
 ) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], CreateCacheStatement> {
     move |i| {
-        let unparsed_create_cache_statement: String = String::from_utf8_lossy(*i).into();
+        let unparsed_create_cache_statement = Some(String::from_utf8_lossy(*i).into());
         let (i, _) = tag_no_case("create")(i)?;
         let (i, _) = whitespace1(i)?;
         let (i, _) = tag_no_case("cache")(i)?;

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -999,7 +999,6 @@ impl NoriaConnector {
         &mut self,
         name: Option<&Relation>,
         statement: &nom_sql::SelectStatement,
-        unparsed_create_cache_statment: String,
         override_schema_search_path: Option<Vec<SqlIdentifier>>,
         always: bool,
         concurrently: bool,
@@ -1010,12 +1009,7 @@ impl NoriaConnector {
         let schema_search_path =
             override_schema_search_path.unwrap_or_else(|| self.schema_search_path.clone());
         let changelist = ChangeList::from_change(
-            Change::create_cache(
-                name.clone(),
-                statement.clone(),
-                unparsed_create_cache_statment,
-                always,
-            ),
+            Change::create_cache(name.clone(), statement.clone(), always),
             self.dialect,
         )
         .with_schema_search_path(schema_search_path.clone());
@@ -1081,12 +1075,7 @@ impl NoriaConnector {
                     // expensive, so we fall back to constructing a 'create cache' statement from a
                     // displayed version of the the SelectStatement we already parsed in this case
                     let changelist = ChangeList::from_change(
-                        Change::create_cache(
-                            qname.clone(),
-                            q.clone(),
-                            format!("create cache from {}", q.display(self.parse_dialect)),
-                            false,
-                        ),
+                        Change::create_cache(qname.clone(), q.clone(), false),
                         self.dialect,
                     )
                     .with_schema_search_path(search_path);

--- a/readyset-client/src/consensus/consul.rs
+++ b/readyset-client/src/consensus/consul.rs
@@ -1575,12 +1575,9 @@ mod tests {
             .iter()
             .map(|stmt| {
                 let authority = authority.clone();
-                tokio::spawn(async move {
-                    authority
-                        .add_create_cache_statements([(*stmt).to_owned()])
-                        .await
-                        .unwrap()
-                })
+                tokio::spawn(
+                    async move { authority.add_create_cache_statement(stmt).await.unwrap() },
+                )
             })
             .collect::<FuturesUnordered<_>>();
 

--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -251,12 +251,9 @@ pub trait AuthorityControl: Send + Sync {
     ///
     /// These are stored separately from the controller state so that it's always available, using
     /// backwards-compatible serialization, for if the controller state can't be deserialized
-    async fn add_create_cache_statements<I>(&self, new_stmts: I) -> ReadySetResult<()>
-    where
-        I: IntoIterator<Item = String> + Clone + Send,
-    {
+    async fn add_create_cache_statement(&self, new_stmt: &str) -> ReadySetResult<()> {
         modify_create_cache_statements(self, move |stmts| {
-            stmts.extend(new_stmts.clone());
+            stmts.push(new_stmt.to_owned());
         })
         .await
     }

--- a/readyset-client/src/consensus/standalone.rs
+++ b/readyset-client/src/consensus/standalone.rs
@@ -463,12 +463,9 @@ mod tests {
             .iter()
             .map(|stmt| {
                 let authority = authority.clone();
-                tokio::spawn(async move {
-                    authority
-                        .add_create_cache_statements([(*stmt).to_owned()])
-                        .await
-                        .unwrap()
-                })
+                tokio::spawn(
+                    async move { authority.add_create_cache_statement(stmt).await.unwrap() },
+                )
             })
             .collect::<FuturesUnordered<_>>();
 

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -197,7 +197,6 @@ impl ChangeList {
                                 name,
                                 inner,
                                 always,
-                                unparsed_create_cache_statement,
                                 ..
                             }) => {
                                 let statement = match inner {
@@ -220,7 +219,6 @@ impl ChangeList {
                                     name,
                                     statement,
                                     always,
-                                    unparsed_create_cache_statement,
                                 }))
                             }
                             SqlQuery::AlterTable(ats) => changes.push(Change::AlterTable(ats)),
@@ -322,9 +320,6 @@ pub struct CreateCache {
     pub name: Option<Relation>,
     /// The `SELECT` statement for the body of the cache
     pub statement: Box<SelectStatement>,
-    /// A full copy of the original 'create cache' statement that can be used to re-create the
-    /// cache after an upgrade
-    pub unparsed_create_cache_statement: String,
     /// If set to `true`, execution of this cache will bypass transaction handling in the
     /// adapter
     pub always: bool,
@@ -415,12 +410,7 @@ pub enum Change {
 impl Change {
     /// Creates a new [`Change::CreateCache`] from the given `name`,
     /// [`SelectStatement`], and unparsed String.
-    pub fn create_cache<N>(
-        name: N,
-        statement: SelectStatement,
-        unparsed_create_cache_statement: String,
-        always: bool,
-    ) -> Self
+    pub fn create_cache<N>(name: N, statement: SelectStatement, always: bool) -> Self
     where
         N: Into<Relation>,
     {
@@ -428,7 +418,6 @@ impl Change {
             name: Some(name.into()),
             statement: Box::new(statement),
             always,
-            unparsed_create_cache_statement,
         })
     }
 
@@ -522,7 +511,6 @@ impl Change {
                         name,
                         inner,
                         always,
-                        unparsed_create_cache_statement,
                         ..
                     }) => {
                         let statement = match inner {
@@ -543,7 +531,6 @@ impl Change {
                             name,
                             statement,
                             always,
-                            unparsed_create_cache_statement,
                         })
                     }
                     SqlQuery::AlterTable(ats) => Change::AlterTable(ats),

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -1,7 +1,39 @@
+use std::sync::Arc;
+
+use readyset_client::consensus::{Authority, StandaloneAuthority};
+use readyset_client_test_helpers::psql_helpers::PostgreSQLAdapter;
+use readyset_client_test_helpers::TestBuilder;
+use readyset_server::Handle;
+use readyset_util::shutdown::ShutdownSender;
 use tokio_postgres::{Client, Config, NoTls};
 
 pub async fn connect(config: Config) -> Client {
     let (client, connection) = config.connect(NoTls).await.unwrap();
     tokio::spawn(connection);
     client
+}
+
+// This is used in integration.rs, but for some reason clippy isn't detecting that.
+#[allow(dead_code)]
+pub async fn setup_standalone_with_authority(
+    prefix: &str,
+    authority: Option<Arc<Authority>>,
+    recreate: bool,
+) -> (Config, Handle, Arc<Authority>, ShutdownSender) {
+    let dir = tempfile::tempdir().unwrap();
+    let dir_path = dir.path().to_str().unwrap();
+    let authority = authority.unwrap_or_else(|| {
+        Arc::new(Authority::from(
+            StandaloneAuthority::new(dir_path, prefix).unwrap(),
+        ))
+    });
+    let (config, handle, shutdown_tx) = TestBuilder::default()
+        .fallback(true)
+        .persistent(true)
+        .recreate_database(recreate)
+        .authority(authority.clone())
+        .build::<PostgreSQLAdapter>()
+        .await;
+
+    (config, handle, authority, shutdown_tx)
 }

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -43,7 +43,7 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
-use crate::controller::state::{DfState, DfStateHandle, RecipeChanges};
+use crate::controller::state::{DfState, DfStateHandle};
 use crate::controller::{ControllerState, Worker, WorkerIdentifier};
 use crate::worker::WorkerRequestKind;
 
@@ -559,12 +559,7 @@ impl Leader {
                     let authority = Arc::clone(authority);
                     let mut migration = tokio::spawn(async move {
                         let mut writer = dataflow_state_handle.write().await;
-                        let RecipeChanges {
-                            new_cache_statements,
-                        } = writer.as_mut().extend_recipe(body, false).await?;
-                        authority
-                            .add_create_cache_statements(new_cache_statements)
-                            .await?;
+                        writer.as_mut().extend_recipe(body, false).await?;
                         dataflow_state_handle.commit(writer, &authority).await?;
                         Ok(())
                     })

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -16,7 +16,6 @@ use vec1::Vec1;
 use super::registry::{MatchedCache, RecipeExpr};
 use super::BaseSchema;
 use crate::controller::sql::SqlIncorporator;
-use crate::controller::state::RecipeChanges;
 use crate::controller::Migration;
 
 pub(crate) type QueryID = u128;
@@ -62,11 +61,10 @@ impl Recipe {
                 name,
                 statement,
                 always,
-                unparsed_statement,
             } => SqlQuery::CreateCache(CreateCacheStatement {
                 name: Some(name.clone()),
                 inner: Ok(CacheInner::Statement(Box::new(statement.clone()))),
-                unparsed_create_cache_statement: unparsed_statement.clone(),
+                unparsed_create_cache_statement: None, // not relevant after migrating
                 always: *always,
                 concurrently: false, // concurrently not relevant after migrating
             }),
@@ -168,7 +166,7 @@ impl Recipe {
         &mut self,
         mig: &mut Migration<'_>,
         changelist: ChangeList,
-    ) -> ReadySetResult<RecipeChanges> {
+    ) -> ReadySetResult<()> {
         self.inc.apply_changelist(changelist, mig)
     }
 

--- a/readyset-server/src/controller/sql/registry.rs
+++ b/readyset-server/src/controller/sql/registry.rs
@@ -37,7 +37,6 @@ pub(crate) enum RecipeExpr {
     Cache {
         name: Relation,
         statement: SelectStatement,
-        unparsed_statement: String,
         always: bool,
     },
 }
@@ -741,7 +740,6 @@ mod tests {
                 statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                     .unwrap(),
                 always: false,
-                unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table".into(),
             };
 
             assert_eq!(cached_query.name(), &query_name);
@@ -772,7 +770,6 @@ mod tests {
                 statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                     .unwrap(),
                 always: false,
-                unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table".into(),
             };
 
             let cached_query_table_refs = cached_query.table_references();
@@ -817,8 +814,6 @@ mod tests {
                     name: "test_query".into(),
                     statement: statement.clone(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
-                        .into(),
                 })
                 .unwrap();
             registry
@@ -826,8 +821,6 @@ mod tests {
                     name: "test_query_alias".into(),
                     statement,
                     always: false,
-                    unparsed_statement:
-                        "CREATE CACHE test_query_alias FROM SELECT * FROM test_table".into(),
                 })
                 .unwrap();
 
@@ -838,8 +831,6 @@ mod tests {
                     name: "test_query".into(),
                     statement: statement.clone(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
-                        .into(),
                 })
                 .unwrap();
             registry
@@ -847,8 +838,6 @@ mod tests {
                     name: "test_query_alias".into(),
                     statement,
                     always: false,
-                    unparsed_statement:
-                        "CREATE CACHE test_query_alias FROM SELECT * FROM test_table".into(),
                 })
                 .unwrap();
 
@@ -885,8 +874,6 @@ mod tests {
                 )
                 .unwrap(),
                 always: false,
-                unparsed_statement:
-                    "CREATE CACHE test_query2 FROM SELECT DISTINCT * FROM test_table".into(),
             };
 
             assert!(registry.add_query(expr.clone()).unwrap());
@@ -904,7 +891,6 @@ mod tests {
                 statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                     .unwrap(),
                 always: false,
-                unparsed_statement: "CREATE CACHE test_query2 FROM SELECT * FROM test_table".into(),
             };
             assert!(!registry.add_query(expr).unwrap());
 
@@ -916,8 +902,6 @@ mod tests {
                     statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table;")
                         .unwrap(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
-                        .into(),
                 }
             );
         }
@@ -1057,8 +1041,6 @@ mod tests {
                     statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table")
                         .unwrap(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE test_query FROM SELECT * FROM test_table"
-                        .into(),
                 }
             );
             assert!(registry.get(&"test_query_alias".into()).is_none())
@@ -1104,7 +1086,6 @@ mod tests {
                     name: "test".into(),
                     statement: stmt.clone(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE test FROM SELECT * FROM test_table".into(),
                 })
                 .unwrap();
             assert!(registry.contains(&stmt))
@@ -1135,8 +1116,6 @@ mod tests {
                     statement: parse_select_statement(Dialect::MySQL, "SELECT * FROM test_table")
                         .unwrap(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE test_query2 FROM SELECT * FROM test_table"
-                        .into(),
                 })
                 .unwrap();
 
@@ -1224,8 +1203,6 @@ mod tests {
                     name: "foo".into(),
                     statement: query.clone(),
                     always: false,
-                    unparsed_statement: "CREATE CACHE foo FROM SELECT CAST(x AS public.abc) FROM t"
-                        .into(),
                 })
                 .unwrap());
 
@@ -1381,8 +1358,6 @@ mod tests {
                     name: "test_query".into(),
                     statement: statement.clone(),
                     always: false,
-                    unparsed_statement:
-                        "CREATE CACHE test_query FROM SELECT a FROM t WHERE a = 1 LIMIT ?".into(),
                 })
                 .unwrap();
 
@@ -1405,8 +1380,6 @@ mod tests {
                     name: "alias".into(),
                     statement,
                     always: false,
-                    unparsed_statement:
-                        "CREATE CACHE alias FROM SELECT a FROM t WHERE a = 1 LIMIT ?".into(),
                 })
                 .unwrap();
 
@@ -1440,8 +1413,6 @@ mod tests {
                     name: "query1".into(),
                     statement: statement1.clone(),
                     always: false,
-                    unparsed_statement:
-                        "CREATE CACHE query1 FROM SELECT a FROM t WHERE a = 1 LIMIT ?;".into(),
                 })
                 .unwrap();
 
@@ -1450,7 +1421,6 @@ mod tests {
                     name: "query1_alias".into(),
                     statement: statement1,
                     always: false,
-                    unparsed_statement: "CREATE CACHE query1_alias FROM SELECT a FROM t WHERE a = 1 LIMIT ?;".into(),
                 })
                 .unwrap();
 
@@ -1459,8 +1429,6 @@ mod tests {
                     name: "query2".into(),
                     statement: statement2,
                     always: false,
-                    unparsed_statement:
-                        "CREATE CACHE query2 FROM SELECT a FROM t WHERE a = 2 LIMIT ?;".into(),
                 })
                 .unwrap();
 

--- a/replicators/tests/tests.rs
+++ b/replicators/tests/tests.rs
@@ -447,9 +447,6 @@ impl TestHandle {
                             parse_select_statement(nom_sql::Dialect::MySQL, select_stmt.clone())
                                 .unwrap(),
                         ),
-                        unparsed_create_cache_statement: format!(
-                            "create cache {query_name} from {select_stmt}"
-                        ),
                         always: false,
                     }),
                 ],
@@ -1702,7 +1699,6 @@ async fn postgresql_ddl_replicate_drop_view_internal(url: &str) {
             .unwrap(),
         ),
         always: false,
-        unparsed_create_cache_statement: "unused for test".to_string(),
     });
     ctx.noria
         .extend_recipe(ChangeList::from_change(
@@ -1784,7 +1780,6 @@ async fn postgresql_ddl_replicate_create_view_internal(url: &str) {
                     .unwrap()
                 ),
                 always: true,
-                unparsed_create_cache_statement: "unused for test".to_string(),
             }),
             Dialect::DEFAULT_POSTGRESQL
         ))


### PR DESCRIPTION
Now that we are string the original, unparsed 'create cache' statement,
we don't need to store it from the controller, but can do it earlier on,
in the adapter.

This change refactors things for this earlier storage, removing
RecipeSpec and the related plumbing needed to do it after an
`extend_recipe` finishes.

We will need some extra logic to handle the case where an `extend
recipe` fails after we store a `create cache` statement, which will come
in a separate commit.

