### PR TITLE
Rename 'CreateCacheRequest' to 'CacheDDLRequest'

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2045,7 +2045,7 @@ where
 
                 if let Some(unparsed_create_cache_statement) = unparsed_create_cache_statement {
                     self.authority
-                        .add_create_cache_statement(unparsed_create_cache_statement)
+                        .add_cache_ddl_request(unparsed_create_cache_statement)
                         .await?;
                 }
 

--- a/readyset-client/src/consensus/consul.rs
+++ b/readyset-client/src/consensus/consul.rs
@@ -1566,7 +1566,7 @@ mod tests {
         authority.delete_all_keys().await;
 
         assert_eq!(
-            authority.create_cache_statements().await.unwrap(),
+            authority.cache_ddl_requests().await.unwrap(),
             Vec::<String>::new()
         );
 
@@ -1575,9 +1575,7 @@ mod tests {
             .iter()
             .map(|stmt| {
                 let authority = authority.clone();
-                tokio::spawn(
-                    async move { authority.add_create_cache_statement(stmt).await.unwrap() },
-                )
+                tokio::spawn(async move { authority.add_cache_ddl_request(stmt).await.unwrap() })
             })
             .collect::<FuturesUnordered<_>>();
 
@@ -1585,7 +1583,7 @@ mod tests {
             res.unwrap();
         }
 
-        let mut stmts = authority.create_cache_statements().await.unwrap();
+        let mut stmts = authority.cache_ddl_requests().await.unwrap();
         stmts.sort();
         assert_eq!(stmts, STMTS);
     }

--- a/readyset-client/src/consensus/standalone.rs
+++ b/readyset-client/src/consensus/standalone.rs
@@ -454,7 +454,7 @@ mod tests {
         );
 
         assert_eq!(
-            authority.create_cache_statements().await.unwrap(),
+            authority.cache_ddl_requests().await.unwrap(),
             Vec::<String>::new()
         );
 
@@ -463,9 +463,7 @@ mod tests {
             .iter()
             .map(|stmt| {
                 let authority = authority.clone();
-                tokio::spawn(
-                    async move { authority.add_create_cache_statement(stmt).await.unwrap() },
-                )
+                tokio::spawn(async move { authority.add_cache_ddl_request(stmt).await.unwrap() })
             })
             .collect::<FuturesUnordered<_>>();
 
@@ -473,7 +471,7 @@ mod tests {
             res.unwrap();
         }
 
-        let mut stmts = authority.create_cache_statements().await.unwrap();
+        let mut stmts = authority.cache_ddl_requests().await.unwrap();
         stmts.sort();
         assert_eq!(stmts, STMTS);
     }

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -1834,7 +1834,7 @@ async fn caches_go_in_authority_list() {
         sleep().await;
     }
 
-    let res = authority.create_cache_statements().await.unwrap();
+    let res = authority.cache_ddl_requests().await.unwrap();
     let unparsed_stmt = res.get(0).unwrap();
     assert_eq!(unparsed_stmt, "CREATE CACHE q FROM SELECT x FROM t;");
 


### PR DESCRIPTION
We will be storing `drop cache` statements along with `create cache`
ones, so rename the struct storing them to be more generic.

We can't (at least trivially) remove a `create cache request` when
processing a `create cache request` because we don't know what the id
will be after rewriting etc.

