### PR TITLE
Add "Drop cache" statements to the authority

### DIFF
--- a/nom-sql/src/drop.rs
+++ b/nom-sql/src/drop.rs
@@ -89,6 +89,12 @@ impl DialectDisplay for DropCacheStatement {
     }
 }
 
+impl DropCacheStatement {
+    pub fn display_unquoted(&self) -> impl Display + Copy + '_ {
+        fmt_with(move |f| write!(f, "DROP CACHE {}", self.name.display_unquoted()))
+    }
+}
+
 pub fn drop_cached_query(
     dialect: Dialect,
 ) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], DropCacheStatement> {

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2052,7 +2052,13 @@ where
                 self.create_cached_query(name.as_ref(), stmt, search_path, *always, *concurrently)
                     .await
             }
-            SqlQuery::DropCache(DropCacheStatement { name }) => self.drop_cached_query(name).await,
+            SqlQuery::DropCache(drop_cache) => {
+                self.authority
+                    .add_cache_ddl_request(&drop_cache.display_unquoted().to_string())
+                    .await?;
+                let DropCacheStatement { name } = drop_cache;
+                self.drop_cached_query(name).await
+            }
             SqlQuery::DropAllCaches(_) => self.drop_all_caches().await,
             SqlQuery::Show(ShowStatement::CachedQueries(query_id)) => {
                 // Log a telemetry event

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -28,7 +28,6 @@ pub async fn setup_standalone_with_authority(
         ))
     });
     let (config, handle, shutdown_tx) = TestBuilder::default()
-        .fallback(true)
         .persistent(true)
         .recreate_database(recreate)
         .authority(authority.clone())


### PR DESCRIPTION
In order to restore the correct set of caches after a backwards
incompatible upgrade, we need to re-process or coalesce "create cache"
and "drop cache" statements. Coalescing them is not trivial because
`drop cache` uses the query id OR an alias of the cache. So store drop
cache requests alongside the create cache requests so that we can replay
them on the upgrades.

