### PR TITLE
adapter: Clear stored caches upon drop all

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1778,6 +1778,7 @@ where
     /// Forwards a `DROP ALL CACHES` request to noria
     #[instrument(skip(self))]
     async fn drop_all_caches(&mut self) -> ReadySetResult<noria_connector::QueryResult<'static>> {
+        self.authority.remove_all_cache_ddl_requests().await?;
         self.noria.drop_all_caches().await?;
         self.state.query_status_cache.clear();
         self.state.prepared_statements.iter_mut().for_each(

--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -258,6 +258,14 @@ pub trait AuthorityControl: Send + Sync {
         .await
     }
 
+    /// Removes all stored cache ddl requests
+    async fn remove_all_cache_ddl_requests(&self) -> ReadySetResult<()> {
+        modify_cache_ddl_requests(self, move |stmts| {
+            stmts.clear();
+        })
+        .await
+    }
+
     /// Returns stats persisted in the authority. Wrapper around `Self::try_read`.
     async fn persistent_stats(&self) -> ReadySetResult<Option<PersistentStats>> {
         self.try_read(PERSISTENT_STATS_PATH).await


### PR DESCRIPTION
If we see a 'drop all caches' query, remove all the caches we are
storing off to the side in case we need to re-run them.

