### PR TITLE
build: Remove auto retry on 255 exit code (some more)

### DIFF
--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -4,8 +4,6 @@ common_values:
     automatic: &agent_kill_conditions
       - exit_status: -1  # Agent was lost
         limit: 2
-      - exit_status: 255 # Forced agent shutdown
-        limit: 2
 
 steps:
   - label: ':clojure: Run jepsen test with --help'

--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -6,8 +6,6 @@ common_values:
     automatic: &agent_kill_conditions
       - exit_status: -1  # Agent was lost
         limit: 2
-      - exit_status: 255 # Forced agent shutdown
-        limit: 2
 
 steps:
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,8 +8,6 @@ common_values:
     automatic: &agent_kill_conditions
       - exit_status: -1  # Agent was lost
         limit: 2
-      - exit_status: 255 # Forced agent shutdown
-        limit: 2
 
 steps:
   # TODO: ronh: decide what kind of linting we want in the OSS pipeline


### PR DESCRIPTION
This is an application of cd3ad2c to additional pipeline files.  Not
sure why I missed them on the first pass.

Removing retry on 255 error code prevents retrying jobs that time out.

