### PR TITLE
server: Restore caches after incompat. upgrade

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -85,7 +85,7 @@ use nom_sql::{
     InsertStatement, Relation, SelectStatement, SetStatement, ShowStatement, SqlIdentifier,
     SqlQuery, UpdateStatement, UseStatement,
 };
-use readyset_client::consensus::{Authority, AuthorityControl};
+use readyset_client::consensus::{Authority, AuthorityControl, CacheDDLRequest};
 use readyset_client::consistency::Timestamp;
 use readyset_client::query::*;
 use readyset_client::results::Results;
@@ -2045,18 +2045,27 @@ where
                 }
 
                 if let Some(unparsed_create_cache_statement) = unparsed_create_cache_statement {
-                    self.authority
-                        .add_cache_ddl_request(unparsed_create_cache_statement)
-                        .await?;
+                    let ddl_req = CacheDDLRequest {
+                        unparsed_stmt: unparsed_create_cache_statement.clone(),
+                        schema_search_path: self.noria.schema_search_path().to_owned(),
+                        dialect: self.settings.dialect.into(),
+                    };
+
+                    self.authority.add_cache_ddl_request(ddl_req).await?;
                 }
 
                 self.create_cached_query(name.as_ref(), stmt, search_path, *always, *concurrently)
                     .await
             }
             SqlQuery::DropCache(drop_cache) => {
-                self.authority
-                    .add_cache_ddl_request(&drop_cache.display_unquoted().to_string())
-                    .await?;
+                let ddl_req = CacheDDLRequest {
+                    unparsed_stmt: drop_cache.display_unquoted().to_string(),
+                    // drop cache statements explicitly don't use a search path, as the only schema
+                    // we need to resolve is the cache name.
+                    schema_search_path: vec![],
+                    dialect: self.settings.dialect.into(),
+                };
+                self.authority.add_cache_ddl_request(ddl_req).await?;
                 let DropCacheStatement { name } = drop_cache;
                 self.drop_cached_query(name).await
             }

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -18,6 +18,7 @@ pub async fn connect(config: Config) -> Client {
 pub async fn setup_standalone_with_authority(
     prefix: &str,
     authority: Option<Arc<Authority>>,
+    upstream: bool,
     recreate: bool,
 ) -> (Config, Handle, Arc<Authority>, ShutdownSender) {
     let dir = tempfile::tempdir().unwrap();
@@ -28,6 +29,7 @@ pub async fn setup_standalone_with_authority(
         ))
     });
     let (config, handle, shutdown_tx) = TestBuilder::default()
+        .fallback(upstream)
         .persistent(true)
         .recreate_database(recreate)
         .authority(authority.clone())


### PR DESCRIPTION
If we have detected a backwards incompatible upgrade, load the stored
cache ddl requests (create cache and drop cache statements) from the
authority, and then re-run them to restore the state of the dataflow
graph before the upgrade.

This commit handles and tests intermingled `create cache` and `drop
cache` statements, but does not yet fully handle error conditions that
may be encountered in `extend_recipe`, which will come in a separate
commit.

