### PR TITLE
nom-sql: Disallow trailing comma in col list

### DIFF
--- a/readyset-adapter/src/rewrite.rs
+++ b/readyset-adapter/src/rewrite.rs
@@ -1124,8 +1124,8 @@ mod tests {
         #[test]
         fn literal_in_in_rhs() {
             test_auto_parametrize(
-                "select hashtags.*, from hashtags inner join invites_hashtags on hashtags.id = invites_hashtags.hashtag_id where invites_hashtags.invite_id in (10,20,31)",
-                "select hashtags.*, from hashtags inner join invites_hashtags on hashtags.id = invites_hashtags.hashtag_id where invites_hashtags.invite_id in (?,?,?)",
+                "select hashtags.* from hashtags inner join invites_hashtags on hashtags.id = invites_hashtags.hashtag_id where invites_hashtags.invite_id in (10,20,31)",
+                "select hashtags.* from hashtags inner join invites_hashtags on hashtags.id = invites_hashtags.hashtag_id where invites_hashtags.invite_id in (?,?,?)",
                     vec![(0, 10.into()), (1, 20.into()), (2, 31.into())],
             );
         }

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -1902,7 +1902,7 @@ async fn it_works_with_multiple_arithmetic_expressions() {
     let (mut g, shutdown_tx) =
         start_simple_unsharded("it_works_with_multiple_arithmetic_expressions").await;
     let sql = "CREATE TABLE Car (id int, price int, PRIMARY KEY(id));
-               CREATE CACHE CarPrice FROM SELECT 10 * 10, 2 * price, 10 * price, FROM Car WHERE id = ?;
+               CREATE CACHE CarPrice FROM SELECT 10 * 10, 2 * price, 10 * price FROM Car WHERE id = ?;
                ";
     g.extend_recipe(ChangeList::from_str(sql, Dialect::DEFAULT_MYSQL).unwrap())
         .await


### PR DESCRIPTION
Previously, we were allowing trailing commas to be present in the column
lists of queries (e.g. SELECT x, y, z, FROM t). This is incorrect: this
syntax is not supported by Postgres nor MySQL. This commit removes
support for this trailing comma.

