### PR TITLE
nom-sql: Parse `EXPLAIN CREATE CACHE`

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2007,6 +2007,9 @@ where
             SqlQuery::Explain(nom_sql::ExplainStatement::Materializations) => {
                 self.noria.explain_materializations().await
             }
+            SqlQuery::Explain(nom_sql::ExplainStatement::CreateCache { .. }) => Err(
+                ReadySetError::Unsupported("EXPLAIN CREATE CACHE is not yet supported".into()),
+            ),
             SqlQuery::CreateCache(CreateCacheStatement {
                 name,
                 inner,


### PR DESCRIPTION
Adds parser support for a new `EXPLAIN CREATE CACHE` command that will
eventually be used to ask ReadySet if the given query is supported. As
of this commit, the adapter will still return an error upon receiving a
parsed `EXPLAIN CREATE CACHE` statement, since it is still
unimplemented.

