### PR TITLE
adapter: Add `EXPLAIN CREATE CACHE`

### DIFF
--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -11,6 +11,7 @@ use nom_sql::{
 };
 use readyset_client::consistency::Timestamp;
 use readyset_client::internal::LocalNodeIndex;
+use readyset_client::query::QueryId;
 use readyset_client::recipe::changelist::{Change, ChangeList, IntoChanges};
 use readyset_client::results::{ResultIterator, Results};
 use readyset_client::{
@@ -986,6 +987,27 @@ impl NoriaConnector {
         }
     }
 
+    /// Runs a dry run migration for the given query.
+    ///
+    /// Returns `Ok(())` if the dry run succeeds and `Err(_)` otherwise.
+    pub async fn handle_dry_run(
+        &mut self,
+        id: QueryId,
+        req: &ViewCreateRequest,
+    ) -> ReadySetResult<()> {
+        let changelist = ChangeList::from_change(
+            Change::create_cache(id.to_string(), req.statement.clone(), false),
+            self.dialect,
+        )
+        .with_schema_search_path(req.schema_search_path.clone());
+
+        noria_await!(
+            self.inner.get_mut()?,
+            self.inner.get_mut()?.noria.dry_run(changelist)
+        )
+        .map(|_| ())
+    }
+
     pub(crate) async fn get_view_name(
         &mut self,
         q: &nom_sql::SelectStatement,
@@ -1535,6 +1557,19 @@ impl NoriaConnector {
 
     pub fn handle(&self) -> Option<ReadySetHandle> {
         self.inner.inner.as_ref().map(|i| i.noria.clone())
+    }
+
+    /// Returns true if a view exists for the given query and false otherwise.
+    pub(crate) async fn get_view_status(
+        &mut self,
+        query: ViewCreateRequest,
+    ) -> ReadySetResult<bool> {
+        self.inner
+            .get_mut()?
+            .noria
+            .view_statuses(vec![query], self.dialect)
+            .await
+            .map(|statuses| statuses[0])
     }
 }
 

--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -348,6 +348,19 @@ impl QueryStatusCache {
         }
     }
 
+    /// This function returns the id and query migration state of a query, if it exists. Unlike
+    /// [`QueryStatusCache.query_migration_state`], it does not add the query to our mapping of
+    /// queries if it is not present.
+    pub fn try_query_migration_state<Q>(&self, q: &Q) -> (QueryId, Option<MigrationState>)
+    where
+        Q: QueryStatusKey,
+    {
+        let id = QueryId::new(hash(&q));
+        let query_state = self.id_to_status.get(&id);
+
+        (id, query_state.map(|s| s.value().migration_state.clone()))
+    }
+
     /// This function returns the query status of a query. If the query does not exist
     /// within the query status cache, an entry is created and the query is set to
     /// PendingMigration.

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -5,7 +5,7 @@ use readyset_client_test_helpers::{self, sleep, TestBuilder};
 use readyset_server::Handle;
 use readyset_util::eventually;
 use readyset_util::shutdown::ShutdownSender;
-use tokio_postgres::{CommandCompleteContents, SimpleQueryMessage};
+use tokio_postgres::{Client, CommandCompleteContents, SimpleQueryMessage};
 
 mod common;
 use common::connect;
@@ -1906,6 +1906,71 @@ async fn drop_all_caches_clears_authority_list() {
 
     let res = authority.cache_ddl_requests().await.unwrap();
     assert!(res.is_empty());
+
+    shutdown_tx.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explain_create_cache() {
+    readyset_tracing::init_test_logging();
+    let (opts, _handle, shutdown_tx) = setup().await;
+    let conn = connect(opts).await;
+
+    conn.simple_query("DROP TABLE IF EXISTS t").await.unwrap();
+    conn.simple_query("CREATE TABLE t (x int, y int)")
+        .await
+        .unwrap();
+
+    #[derive(Debug)]
+    struct ExplainCreateCacheResult {
+        rewritten_query: String,
+        supported: String,
+    }
+
+    async fn explain_create_cache(query: &'static str, conn: &Client) -> ExplainCreateCacheResult {
+        let row = match conn
+            .simple_query(&format!("EXPLAIN CREATE CACHE FROM {query}"))
+            .await
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+        {
+            SimpleQueryMessage::Row(row) => row,
+            _ => panic!(),
+        };
+
+        ExplainCreateCacheResult {
+            rewritten_query: row.get(1).unwrap().into(),
+            supported: row.get(2).unwrap().into(),
+        }
+    }
+
+    // Wait for t to be replicated
+    eventually!(conn
+        .simple_query("CREATE CACHE FROM SELECT * FROM t")
+        .await
+        .is_ok());
+
+    eventually! {
+        let res = explain_create_cache("SELECT * FROM t WHERE x = 5", &conn).await;
+
+        res.supported == "yes" && res.rewritten_query == r#"SELECT * FROM "t" WHERE ("x" = $1)"#
+    }
+
+    eventually! {
+        let res = explain_create_cache("SELECT * FROM t WHERE t.x = RANDOM()", &conn).await;
+
+        res.supported == "no" && res.rewritten_query == r#"SELECT * FROM "t" WHERE ("t"."x" = RANDOM())"#
+    }
+
+    conn.simple_query("CREATE CACHE FROM SELECT * FROM t WHERE x = 5")
+        .await
+        .unwrap();
+
+    let res = explain_create_cache("SELECT * FROM t WHERE x = 1", &conn).await;
+    assert_eq!(res.supported, "cached");
+    assert_eq!(res.rewritten_query, r#"SELECT * FROM "t" WHERE ("x" = $1)"#);
 
     shutdown_tx.shutdown().await;
 }


### PR DESCRIPTION
Adds a new `EXPLAIN CREATE CACHE` SQL extension that can be used to
ask ReadySet whether the given query is supported. This extension works
by performing a dry run migration for the given query.

Release-Note-Core: Added an `EXPLAIN CREATE CACHE` SQL extension that
  can be used to check if a given query is supported without proxying the
  query through ReadySet or creating a new cache.
