### PR TITLE
quickstart: Revert 3eb01bc and 6cdf37a only in quickstart dir

### DIFF
--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -11,11 +11,11 @@ services:
       - "6034:6034"
     environment:
       DEPLOYMENT_ENV: quickstart_docker
-      STORAGE_DIR: /state
+      DB_DIR: /state
       PROMETHEUS_METRICS: true
       QUERY_LOG_MODE: all-queries
       QUERY_CACHING: explicit
-      DEPLOYMENT_MODE: 'standalone'
+      STANDALONE: true
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:3307
       UPSTREAM_DB_URL: mysql://root:readyset@mysql/testdb

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -11,11 +11,11 @@ services:
       - "6034:6034"
     environment:
       DEPLOYMENT_ENV: quickstart_docker
-      STORAGE_DIR: /state
+      DB_DIR: /state
       PROMETHEUS_METRICS: true
       QUERY_CACHING: explicit
       QUERY_LOG_MODE: all-queries
-      DEPLOYMENT_MODE: 'standalone'
+      STANDALONE: true
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:5433
       UPSTREAM_DB_URL: postgresql://postgres:readyset@postgres/testdb

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -11,11 +11,11 @@ services:
       - "6034:6034"
     environment:
       DEPLOYMENT_ENV: quickstart_docker
-      STORAGE_DIR: /state
+      DB_DIR: /state
       PROMETHEUS_METRICS: true
       QUERY_CACHING: explicit
       QUERY_LOG_MODE: all-queries
-      DEPLOYMENT_MODE: 'standalone'
+      STANDALONE: true
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:5433
       # UPSTREAM_DB_URL:


### PR DESCRIPTION
The quickstart compose files have to match the latest release.  These
changes were not working with the Oct release and have to be rolled back
so that the demo will work correctly.

