### PR TITLE
replicators: Fix repl slot exists check

### DIFF
--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -81,6 +81,7 @@ pub struct TestBuilder {
     query_status_cache: Option<&'static QueryStatusCache>,
     persistent: bool,
     authority: Option<Arc<Authority>>,
+    replication_server_id: Option<u32>,
 }
 
 impl Default for TestBuilder {
@@ -102,6 +103,7 @@ impl TestBuilder {
             query_status_cache: None,
             persistent: false,
             authority: None,
+            replication_server_id: None,
         }
     }
 
@@ -156,6 +158,11 @@ impl TestBuilder {
 
     pub fn authority(mut self, authority: Arc<Authority>) -> Self {
         self.authority = Some(authority);
+        self
+    }
+
+    pub fn replication_server_id(mut self, replication_server_id: u32) -> Self {
+        self.replication_server_id = Some(replication_server_id);
         self
     }
 
@@ -221,6 +228,11 @@ impl TestBuilder {
         if let Some((f, _)) = &fallback_url_and_db_name {
             builder.set_replication_url(f.clone());
         }
+
+        if let Some(id) = self.replication_server_id {
+            builder.set_replicator_server_id(id);
+        }
+
         let (mut handle, shutdown_tx) = builder.start(authority.clone()).await.unwrap();
         if self.wait_for_backend {
             handle.backend_ready().await;


### PR DESCRIPTION
Previously, we had hard-coded the name "readyset" in our check to see if
a replication slot already exists for the given deployment upon
replicator startup. This check won't work if the name of the slot was
customized via the "--replication-server-id" flag. This commit removes
the hard-coded string in favor of the variable that would contain the
customized name.

Release-Note-Core: Fixed an issue where ReadySet failed to start up if
  the instance was passed a "--replication-server-id"
