### PR TITLE
adapter: QueryStatusCache size metrics

### DIFF
--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -15,9 +15,11 @@ use lru::LruCache;
 use parking_lot::RwLock;
 use readyset_client::query::*;
 use readyset_client::ViewCreateRequest;
+use readyset_client::metrics::recorded;
 use readyset_data::DfValue;
 use readyset_util::hash::hash;
 use tracing::{error, warn};
+use metrics::gauge;
 
 pub const DEFAULT_QUERY_STATUS_CAPACITY: usize = 100_000;
 
@@ -89,6 +91,7 @@ impl PersistentStatusCacheHandle {
         match self.statuses.try_write_for(Duration::from_millis(10)) {
             Some(mut status_guard) => {
                 status_guard.put(id, (q, status));
+                gauge!(recorded::QUERY_STATUS_CACHE_PERSISTENT_CACHE_SIZE, status_guard.len() as f64);
             }
             None => {
                 warn!(query_id=%id, "Avoiding deadlock when trying to insert")
@@ -318,6 +321,7 @@ impl QueryStatusCache {
         let id = QueryId::new(hash(&q));
         self.id_to_status.insert(id, status.clone());
         self.persistent_handle.insert_with_status(q, id, status);
+        gauge!(recorded::QUERY_STATUS_CACHE_SIZE, self.id_to_status.len() as f64);
         id
     }
 

--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -12,14 +12,14 @@ use clap::ValueEnum;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use lru::LruCache;
+use metrics::gauge;
 use parking_lot::RwLock;
+use readyset_client::metrics::recorded;
 use readyset_client::query::*;
 use readyset_client::ViewCreateRequest;
-use readyset_client::metrics::recorded;
 use readyset_data::DfValue;
 use readyset_util::hash::hash;
 use tracing::{error, warn};
-use metrics::gauge;
 
 pub const DEFAULT_QUERY_STATUS_CAPACITY: usize = 100_000;
 
@@ -91,7 +91,10 @@ impl PersistentStatusCacheHandle {
         match self.statuses.try_write_for(Duration::from_millis(10)) {
             Some(mut status_guard) => {
                 status_guard.put(id, (q, status));
-                gauge!(recorded::QUERY_STATUS_CACHE_PERSISTENT_CACHE_SIZE, status_guard.len() as f64);
+                gauge!(
+                    recorded::QUERY_STATUS_CACHE_PERSISTENT_CACHE_SIZE,
+                    status_guard.len() as f64
+                );
             }
             None => {
                 warn!(query_id=%id, "Avoiding deadlock when trying to insert")
@@ -321,7 +324,10 @@ impl QueryStatusCache {
         let id = QueryId::new(hash(&q));
         self.id_to_status.insert(id, status.clone());
         self.persistent_handle.insert_with_status(q, id, status);
-        gauge!(recorded::QUERY_STATUS_CACHE_SIZE, self.id_to_status.len() as f64);
+        gauge!(
+            recorded::QUERY_STATUS_CACHE_SIZE,
+            self.id_to_status.len() as f64
+        );
         id
     }
 

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -498,6 +498,15 @@ pub mod recorded {
     /// Gauge: A stub gague used to report the version information for the server.
     /// Labels are used to convey the version information.
     pub const READYSET_SERVER_VERSION: &str = "readyset_server_version";
+
+    /// Gauge: The size of the dash map that holds query status of each query
+    /// that have been processed by readyset adapter.
+    pub const QUERY_STATUS_CACHE_SIZE: &str = "readyset_query_status_cache.id_to_status.size";
+
+    /// Gauge: The size of the LRUCache that holds full query & query status for a fixed number
+    /// of queries that have been processed by readyset adapter.
+    pub const QUERY_STATUS_CACHE_PERSISTENT_CACHE_SIZE: &str =
+        "readyset_query_status_cache.persistent_cache.statuses.size";
 }
 
 /// A dumped metric's kind.


### PR DESCRIPTION
Having a gauge for the size of id_to_status map and statuses LruCache in the QueryStatusCache allows us to estimate current memory usage in the system and also observe the rate of unique queries that readyset is observing.
resolves #787 
