### PR TITLE
server: Restore schema replication offset with caches

### DIFF
--- a/readyset-client/src/failpoints/mod.rs
+++ b/readyset-client/src/failpoints/mod.rs
@@ -18,6 +18,12 @@ pub const REPLICATION_HANDLE_ACTION: &str = "replication-handle-action";
 pub const POSTGRES_REPLICATION_NEXT_ACTION: &str = "postgres-replication-next-action";
 /// Imitates a failure right before we begin snapshotting against a Postgres upstream
 pub const POSTGRES_SNAPSHOT_START: &str = "postgres-snapshot-start";
+/// Imitates a failure encountered while performing a full resnapshot
+pub const POSTGRES_FULL_RESNAPSHOT: &str = "postgres-full-resnapshot";
+/// Imitates a failure encountered while performing a partial resnapshot
+pub const POSTGRES_PARTIAL_RESNAPSHOT: &str = "postgres-partial-resnapshot";
+/// Imitates a failure encountered while snapshotting a table
+pub const POSTGRES_SNAPSHOT_TABLE: &str = "postgres-snapshot-table";
 /// Imitates a failure right before we invoke `START_REPLICATION` during Postgres replication
 pub const POSTGRES_START_REPLICATION: &str = "postgres-start-replication";
 /// Imitates a failure when we go to pull the next event from the WAL during Postgres replication

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2103,8 +2103,10 @@ async fn recreate_replication_slot() {
 mod failure_injection_tests {
     // TODO: move the above cfg failure_injection tests into this mod
 
+    use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
+    use lazy_static::lazy_static;
     use readyset_client::consensus::{Authority, AuthorityControl, CacheDDLRequest};
     use readyset_client::failpoints;
     use readyset_data::Dialect;
@@ -2362,6 +2364,54 @@ mod failure_injection_tests {
             assert_eq!(res, [1]);
         });
 
+        shutdown_tx.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    #[slow]
+    async fn backwards_incompatible_upgrade_doesnt_resnapshot() {
+        // If we make a backwards-incompatible change to the serialization of the controller state,
+        // we shouldn't have to resnapshot the actual data in the base tables (assuming the schema
+        // hasn't changed since we stopped running)
+        lazy_static! {
+            pub static ref SAW_RESNAPSHOT: AtomicBool = AtomicBool::new(false);
+        }
+
+        // The test should not hit "Snapshotting table", because we create the table after the
+        // initial snapshot finishes.
+        fail::cfg_callback(failpoints::POSTGRES_SNAPSHOT_TABLE, move || {
+            SAW_RESNAPSHOT.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to configure failpoint");
+        // We expect to see neither a partial nor a full re-snapshot
+        fail::cfg_callback(failpoints::POSTGRES_PARTIAL_RESNAPSHOT, move || {
+            SAW_RESNAPSHOT.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to configure failpoint");
+        fail::cfg_callback(failpoints::POSTGRES_FULL_RESNAPSHOT, move || {
+            SAW_RESNAPSHOT.store(true, Ordering::SeqCst);
+        })
+        .expect("failed to configure failpoint");
+        let queries = [
+            "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
+            "CREATE CACHE test_query FROM SELECT * FROM users;",
+        ];
+
+        let (_config, mut handle, _authority, shutdown_tx) =
+            setup_reload_controller_state_test("caches_recreated", &queries).await;
+
+        // Add some sleep time because the replicator is a background task and we want to make sure
+        // it has had a chance to hit the resnapshot error if it is going to.
+        sleep().await;
+
+        assert!(
+            !SAW_RESNAPSHOT.load(Ordering::SeqCst),
+            "We should not have re-snapshotted"
+        );
+
+        let queries = handle.views().await.unwrap();
+        assert!(queries.contains_key(&"test_query".into()));
         shutdown_tx.shutdown().await;
     }
 }

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -246,11 +246,13 @@ impl NoriaAdapter {
         } {
             match err {
                 ReadySetError::ResnapshotNeeded => {
+                    set_failpoint!(failpoints::POSTGRES_PARTIAL_RESNAPSHOT);
                     tokio::time::sleep(WAIT_BEFORE_RESNAPSHOT).await;
                     resnapshot = true;
                     full_snapshot = false;
                 }
                 ReadySetError::FullResnapshotNeeded => {
+                    set_failpoint!(failpoints::POSTGRES_FULL_RESNAPSHOT);
                     tokio::time::sleep(WAIT_BEFORE_RESNAPSHOT).await;
                     resnapshot = true;
                     full_snapshot = true;


### PR DESCRIPTION
If we fail to deserialize the ControllerState due to a backwards
incompatible change in ControllerState serialization format, we don't
want to have to resnapshot the tables. The tables themselves store the
replication offset associated with them, but there is also a schema
replication offset that is used to track changes that are unrelated to
any particular table "e.g. create custom type".

This change re-loads this schema offset from a place we stashed it off
to the side separately from the ControllerState.

Refs: REA-2931 #216
