### PR TITLE
Add retries to backwards incompat cache recreation

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -89,6 +89,7 @@ use readyset_client::consensus::{Authority, AuthorityControl, CacheDDLRequest};
 use readyset_client::consistency::Timestamp;
 use readyset_client::query::*;
 use readyset_client::results::Results;
+use readyset_client::utils::retry_with_exponential_backoff;
 use readyset_client::{ColumnSchema, PlaceholderIdx, ViewCreateRequest};
 pub use readyset_client_metrics::QueryDestination;
 use readyset_client_metrics::{
@@ -112,7 +113,7 @@ use crate::query_handler::SetBehavior;
 use crate::query_status_cache::QueryStatusCache;
 use crate::rewrite::ProcessedQueryParams;
 pub use crate::upstream_database::UpstreamPrepare;
-use crate::utils::{create_dummy_column, retry_with_exponential_backoff};
+use crate::utils::create_dummy_column;
 use crate::{create_dummy_schema, rewrite, QueryHandler, UpstreamDatabase, UpstreamDestination};
 
 pub mod noria_connector;

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -648,7 +648,6 @@ use tokio::time::{sleep, Duration};
 ///
 /// This function returns a `Result` indicating whether the operation was successful (`Ok(T)`)
 /// or not (`Err(E)`) after the maximum number of retries has been reached.
-#[allow(dead_code)]
 pub(crate) async fn retry_with_exponential_backoff<F, Fut, T, E>(
     mut operation: F,
     max_retries: usize,

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
+use std::future::Future;
 use std::iter;
 
 use itertools::Itertools;
@@ -626,9 +627,68 @@ macro_rules! create_dummy_schema {
     }
 }
 
+use tokio::time::{sleep, Duration};
+
+/// Attempts to execute an asynchronous operation with exponential backoff and returns a `Result`.
+/// The provided `base_delay` will be doubled up to `max_retries` times.
+///
+/// # Arguments
+///
+/// * `operation` - A closure that returns a future representing the operation to be retried.
+/// * `max_retries` - The maximum number of times to retry the operation before giving up.
+/// * `base_delay` - The initial delay before the first retry, which doubles on each subsequent
+///   retry.
+///
+/// # Examples
+///
+/// ```
+/// // Example usage:
+/// // let result = retry_with_exponential_backoff(my_async_operation, 5, Duration::from_secs(1)).await;
+/// ```
+///
+/// This function returns a `Result` indicating whether the operation was successful (`Ok(T)`)
+/// or not (`Err(E)`) after the maximum number of retries has been reached.
+#[allow(dead_code)]
+pub(crate) async fn retry_with_exponential_backoff<F, Fut, T, E>(
+    mut operation: F,
+    max_retries: usize,
+    base_delay: Duration,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    let mut attempts_completed = 0;
+    let mut delay = base_delay;
+
+    while attempts_completed <= max_retries {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                if attempts_completed == max_retries {
+                    return Err(e);
+                } else {
+                    sleep(delay).await;
+                    attempts_completed += 1;
+                    // Exponential backoff
+                    delay = delay.checked_mul(2).unwrap_or(delay);
+                }
+            }
+        }
+    }
+
+    unreachable!();
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicI32, Ordering};
+    use std::sync::Arc;
+    use std::time::Instant;
+
     use nom_sql::{self, parse_create_table, Dialect, SqlQuery};
+    use readyset_errors::{internal_err, ReadySetError};
 
     use super::*;
 
@@ -947,5 +1007,83 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_retry_success_first_try() {
+        let operation = || async { ReadySetResult::Ok("success") };
+        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        assert_eq!(result, Ok("success"));
+    }
+
+    #[tokio::test]
+    async fn test_retry_eventual_success() {
+        let attempts = Arc::new(AtomicI32::new(0));
+        let operation = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.load(Ordering::SeqCst) < 2 {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        Err(internal_err!("failure"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        };
+        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        assert_eq!(result, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn test_retry_failure() {
+        let operation = || async {
+            ReadySetResult::<()>::Err(ReadySetError::Internal("test failure".to_string()))
+        };
+        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        assert_eq!(
+            result,
+            Err(ReadySetError::Internal("test failure".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backoff_delay_increases() {
+        let start = Instant::now();
+        let attempts = Arc::new(AtomicI32::new(0));
+        let operation = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    ReadySetResult::<()>::Err(internal_err!("failure"))
+                }
+            }
+        };
+        let _ = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        let duration = start.elapsed();
+        // The total wait time should be at least 100ms + 200ms + 400ms = 700ms
+        assert!(duration >= Duration::from_millis(700));
+    }
+
+    #[tokio::test]
+    async fn test_respects_max_retries() {
+        let attempts = Arc::new(AtomicI32::new(0));
+        let operation = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    ReadySetResult::<()>::Err(internal_err!("failure"))
+                }
+            }
+        };
+        let _ = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        // 3 retries means there are 4 total attempts.
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
     }
 }

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
-use std::future::Future;
 use std::iter;
 
 use itertools::Itertools;
@@ -627,67 +626,10 @@ macro_rules! create_dummy_schema {
     }
 }
 
-use tokio::time::{sleep, Duration};
-
-/// Attempts to execute an asynchronous operation with exponential backoff and returns a `Result`.
-/// The provided `base_delay` will be doubled up to `max_retries` times.
-///
-/// # Arguments
-///
-/// * `operation` - A closure that returns a future representing the operation to be retried.
-/// * `max_retries` - The maximum number of times to retry the operation before giving up.
-/// * `base_delay` - The initial delay before the first retry, which doubles on each subsequent
-///   retry.
-///
-/// # Examples
-///
-/// ```
-/// // Example usage:
-/// // let result = retry_with_exponential_backoff(my_async_operation, 5, Duration::from_secs(1)).await;
-/// ```
-///
-/// This function returns a `Result` indicating whether the operation was successful (`Ok(T)`)
-/// or not (`Err(E)`) after the maximum number of retries has been reached.
-pub(crate) async fn retry_with_exponential_backoff<F, Fut, T, E>(
-    mut operation: F,
-    max_retries: usize,
-    base_delay: Duration,
-) -> Result<T, E>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<T, E>>,
-    E: std::fmt::Debug,
-{
-    let mut attempts_completed = 0;
-    let mut delay = base_delay;
-
-    while attempts_completed <= max_retries {
-        match operation().await {
-            Ok(result) => return Ok(result),
-            Err(e) => {
-                if attempts_completed == max_retries {
-                    return Err(e);
-                } else {
-                    sleep(delay).await;
-                    attempts_completed += 1;
-                    // Exponential backoff
-                    delay = delay.checked_mul(2).unwrap_or(delay);
-                }
-            }
-        }
-    }
-
-    unreachable!();
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicI32, Ordering};
-    use std::sync::Arc;
-    use std::time::Instant;
 
     use nom_sql::{self, parse_create_table, Dialect, SqlQuery};
-    use readyset_errors::{internal_err, ReadySetError};
 
     use super::*;
 
@@ -1006,83 +948,5 @@ mod tests {
                 },
             ]
         );
-    }
-
-    #[tokio::test]
-    async fn test_retry_success_first_try() {
-        let operation = || async { ReadySetResult::Ok("success") };
-        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
-        assert_eq!(result, Ok("success"));
-    }
-
-    #[tokio::test]
-    async fn test_retry_eventual_success() {
-        let attempts = Arc::new(AtomicI32::new(0));
-        let operation = {
-            let attempts = attempts.clone();
-            move || {
-                let attempts = attempts.clone();
-                async move {
-                    if attempts.load(Ordering::SeqCst) < 2 {
-                        attempts.fetch_add(1, Ordering::SeqCst);
-                        Err(internal_err!("failure"))
-                    } else {
-                        Ok(())
-                    }
-                }
-            }
-        };
-        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
-        assert_eq!(result, Ok(()));
-    }
-
-    #[tokio::test]
-    async fn test_retry_failure() {
-        let operation = || async {
-            ReadySetResult::<()>::Err(ReadySetError::Internal("test failure".to_string()))
-        };
-        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
-        assert_eq!(
-            result,
-            Err(ReadySetError::Internal("test failure".to_string()))
-        );
-    }
-
-    #[tokio::test]
-    async fn test_backoff_delay_increases() {
-        let start = Instant::now();
-        let attempts = Arc::new(AtomicI32::new(0));
-        let operation = {
-            let attempts = attempts.clone();
-            move || {
-                let attempts = attempts.clone();
-                async move {
-                    attempts.fetch_add(1, Ordering::SeqCst);
-                    ReadySetResult::<()>::Err(internal_err!("failure"))
-                }
-            }
-        };
-        let _ = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
-        let duration = start.elapsed();
-        // The total wait time should be at least 100ms + 200ms + 400ms = 700ms
-        assert!(duration >= Duration::from_millis(700));
-    }
-
-    #[tokio::test]
-    async fn test_respects_max_retries() {
-        let attempts = Arc::new(AtomicI32::new(0));
-        let operation = {
-            let attempts = attempts.clone();
-            move || {
-                let attempts = attempts.clone();
-                async move {
-                    attempts.fetch_add(1, Ordering::SeqCst);
-                    ReadySetResult::<()>::Err(internal_err!("failure"))
-                }
-            }
-        };
-        let _ = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
-        // 3 retries means there are 4 total attempts.
-        assert_eq!(attempts.load(Ordering::SeqCst), 4);
     }
 }

--- a/readyset-client/src/failpoints/mod.rs
+++ b/readyset-client/src/failpoints/mod.rs
@@ -27,3 +27,5 @@ pub const POSTGRES_NEXT_WAL_EVENT: &str = "postgres-next-wal-event";
 pub const START_INNER_POSTGRES: &str = "start-inner-postgres";
 /// Imitate a backwards incompatible deserialization from controller state
 pub const LOAD_CONTROLLER_STATE: &str = "load-controller-state";
+/// Injects a failpoint at the beginning of DfState::extend_recipe
+pub const EXTEND_RECIPE: &str = "extend-recipe";

--- a/readyset-client/src/lib.rs
+++ b/readyset-client/src/lib.rs
@@ -261,6 +261,7 @@ pub mod metrics;
 pub mod query;
 pub mod status;
 mod table;
+pub mod utils;
 mod view;
 use std::convert::TryFrom;
 use std::default::Default;

--- a/readyset-client/src/utils.rs
+++ b/readyset-client/src/utils.rs
@@ -1,0 +1,146 @@
+//! readyset-client utilities
+
+use std::future::Future;
+use std::time::Duration;
+
+use tokio::time::sleep;
+
+/// Attempts to execute an asynchronous operation with exponential backoff and returns a `Result`.
+/// The provided `base_delay` will be doubled up to `max_retries` times.
+///
+/// # Arguments
+///
+/// * `operation` - A closure that returns a future representing the operation to be retried.
+/// * `max_retries` - The maximum number of times to retry the operation before giving up.
+/// * `base_delay` - The initial delay before the first retry, which doubles on each subsequent
+///   retry.
+///
+/// # Examples
+///
+/// ```
+/// // Example usage:
+/// // let result = retry_with_exponential_backoff(my_async_operation, 5, Duration::from_secs(1)).await;
+/// ```
+///
+/// This function returns a `Result` indicating whether the operation was successful (`Ok(T)`)
+/// or not (`Err(E)`) after the maximum number of retries has been reached.
+pub async fn retry_with_exponential_backoff<F, Fut, T, E>(
+    mut operation: F,
+    max_retries: usize,
+    base_delay: Duration,
+) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Debug,
+{
+    let mut attempts_completed = 0;
+    let mut delay = base_delay;
+
+    while attempts_completed <= max_retries {
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                if attempts_completed == max_retries {
+                    return Err(e);
+                } else {
+                    sleep(delay).await;
+                    attempts_completed += 1;
+                    // Exponential backoff
+                    delay = delay.checked_mul(2).unwrap_or(delay);
+                }
+            }
+        }
+    }
+
+    unreachable!();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicI32, Ordering};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use readyset_errors::{internal_err, ReadySetError, ReadySetResult};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_retry_success_first_try() {
+        let operation = || async { ReadySetResult::Ok("success") };
+        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        assert_eq!(result, Ok("success"));
+    }
+
+    #[tokio::test]
+    async fn test_retry_eventual_success() {
+        let attempts = Arc::new(AtomicI32::new(0));
+        let operation = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.load(Ordering::SeqCst) < 2 {
+                        attempts.fetch_add(1, Ordering::SeqCst);
+                        Err(internal_err!("failure"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            }
+        };
+        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        assert_eq!(result, Ok(()));
+    }
+
+    #[tokio::test]
+    async fn test_retry_failure() {
+        let operation = || async {
+            ReadySetResult::<()>::Err(ReadySetError::Internal("test failure".to_string()))
+        };
+        let result = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        assert_eq!(
+            result,
+            Err(ReadySetError::Internal("test failure".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backoff_delay_increases() {
+        let start = Instant::now();
+        let attempts = Arc::new(AtomicI32::new(0));
+        let operation = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    ReadySetResult::<()>::Err(internal_err!("failure"))
+                }
+            }
+        };
+        let _ = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        let duration = start.elapsed();
+        // The total wait time should be at least 100ms + 200ms + 400ms = 700ms
+        assert!(duration >= Duration::from_millis(700));
+    }
+
+    #[tokio::test]
+    async fn test_respects_max_retries() {
+        let attempts = Arc::new(AtomicI32::new(0));
+        let operation = {
+            let attempts = attempts.clone();
+            move || {
+                let attempts = attempts.clone();
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    ReadySetResult::<()>::Err(internal_err!("failure"))
+                }
+            }
+        };
+        let _ = retry_with_exponential_backoff(operation, 3, Duration::from_millis(100)).await;
+        // 3 retries means there are 4 total attempts.
+        assert_eq!(attempts.load(Ordering::SeqCst), 4);
+    }
+}

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -18,6 +18,7 @@ pub async fn connect(config: Config) -> Client {
 pub async fn setup_standalone_with_authority(
     prefix: &str,
     authority: Option<Arc<Authority>>,
+    upstream: bool,
     recreate: bool,
 ) -> (Config, Handle, Arc<Authority>, ShutdownSender) {
     let dir = tempfile::tempdir().unwrap();
@@ -28,6 +29,7 @@ pub async fn setup_standalone_with_authority(
         ))
     });
     let (config, handle, shutdown_tx) = TestBuilder::default()
+        .fallback(upstream)
         .persistent(true)
         .recreate_database(recreate)
         .authority(authority.clone())

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -873,7 +873,7 @@ async fn insert_enum_value_appended_after_create_table() {
     //    this doesn't have to be the same table we later insert into)
     //  - Specifically insert the enum value that was added in the ALTER TYPE statement
     //  - Insert using a parameter, not a hardcoded query (hence the use of `query_raw` here)
-    // This turned out to be caused by an interation with a client library that cached types from
+    // This turned out to be caused by an integration with a client library that cached types from
     // upstream queries and didn't update the cached definitions after the type was altered.
     let params: Vec<DfValue> = vec!["b".into()];
     client
@@ -2067,7 +2067,11 @@ async fn recreate_replication_slot() {
 mod failure_injection_tests {
     // TODO: move the above cfg failure_injection tests into this mod
 
+    use std::sync::Arc;
+
+    use readyset_client::consensus::{Authority, AuthorityControl, CacheDDLRequest};
     use readyset_client::failpoints;
+    use readyset_data::Dialect;
     use readyset_errors::ReadySetError;
     use tracing::debug;
 
@@ -2081,7 +2085,12 @@ mod failure_injection_tests {
     async fn setup_reload_controller_state_test(
         prefix: &str,
         queries: &[&str],
-    ) -> (tokio_postgres::Config, Handle, ShutdownSender) {
+    ) -> (
+        tokio_postgres::Config,
+        Handle,
+        Arc<Authority>,
+        ShutdownSender,
+    ) {
         readyset_tracing::init_test_logging();
 
         let (config, handle, authority, shutdown_tx) =
@@ -2090,7 +2099,7 @@ mod failure_injection_tests {
         let conn = connect(config).await;
         for query in queries {
             debug!(%query, "Running Query");
-            let _res = conn.simple_query(query).await.expect("query failed");
+            let _res = conn.simple_query(query).await;
             // give it some time to propagate
             sleep().await;
         }
@@ -2110,10 +2119,12 @@ mod failure_injection_tests {
         // Stop the server and start a new one
         shutdown_tx.shutdown().await;
         drop(handle);
+        sleep().await;
 
-        let (config, handle, _authority, shutdown_tx) =
+        let (config, handle, authority, shutdown_tx) =
             setup_standalone_with_authority(prefix, Some(authority), true, false).await;
-        (config, handle, shutdown_tx)
+        sleep().await;
+        (config, handle, authority, shutdown_tx)
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2123,7 +2134,7 @@ mod failure_injection_tests {
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
             "CREATE CACHE test_query FROM SELECT * FROM users;",
         ];
-        let (_config, mut handle, shutdown_tx) =
+        let (_config, mut handle, _authority, shutdown_tx) =
             setup_reload_controller_state_test("caches_recreated", &queries).await;
 
         let queries = handle.views().await.unwrap();
@@ -2141,7 +2152,7 @@ mod failure_injection_tests {
             "CREATE CACHE cached_query FROM SELECT * FROM users where id = 1;",
             "DROP CACHE dropped_query",
         ];
-        let (_config, mut handle, shutdown_tx) =
+        let (_config, mut handle, _authority, shutdown_tx) =
             setup_reload_controller_state_test("caches_not_recreated", &queries).await;
 
         let queries = handle.views().await.unwrap();
@@ -2162,10 +2173,79 @@ mod failure_injection_tests {
             "CREATE CACHE cached_query FROM SELECT * FROM users",
         ];
 
-        let (_config, mut handle, _shutdown_tx) =
+        let (_config, mut handle, _authority, _shutdown_tx) =
             setup_reload_controller_state_test("caches_dropped_then_recreated", &queries).await;
         let queries = handle.views().await.unwrap();
         assert!(!queries.contains_key(&"dropped_query".into()));
         assert!(queries.contains_key(&"cached_query".into()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn caches_added_if_extend_recipe_times_out() {
+        let queries = [
+            "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
+            "CREATE CACHE test_query FROM SELECT * FROM users;",
+        ];
+
+        // This is set to be larger than  EXTEND_RECIPE_MAX_SYNC_TIME, which is 5 seconds
+        // The `create cache` is the 3rd extend_recipe run
+        fail::cfg(failpoints::EXTEND_RECIPE, "2*off->1*sleep(6000)").expect("failed at failing");
+
+        let (_config, mut handle, authority, shutdown_tx) =
+            setup_reload_controller_state_test("extend_recipe_timeout", &queries).await;
+
+        let cache_ddl_requests = authority.cache_ddl_requests().await.unwrap();
+        let expected = CacheDDLRequest {
+            unparsed_stmt: "CREATE CACHE test_query FROM SELECT * FROM users;".to_string(),
+            schema_search_path: vec!["postgres".into(), "public".into()],
+            dialect: Dialect::DEFAULT_POSTGRESQL,
+        };
+        assert_eq!(expected, *cache_ddl_requests.get(0).unwrap());
+
+        let queries = handle.views().await.unwrap();
+        assert!(queries.contains_key(&"test_query".into()));
+
+        shutdown_tx.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn create_cache_not_added_if_extend_recipe_fails() {
+        let queries = [
+            "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
+            "CREATE CACHE test_query FROM SELECT * FROM idontexist;",
+        ];
+
+        let (_config, mut handle, authority, shutdown_tx) =
+            setup_reload_controller_state_test("extend_recipe_create_fail", &queries).await;
+
+        let cache_ddl_requests = authority.cache_ddl_requests().await.unwrap();
+        assert!(cache_ddl_requests.is_empty());
+
+        let queries = handle.views().await.unwrap();
+        assert!(queries.is_empty());
+
+        shutdown_tx.shutdown().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn drop_cache_not_added_if_drop_fails() {
+        let queries = [
+            "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
+            "DROP CACHE idontexist;",
+        ];
+
+        let (_config, mut handle, authority, shutdown_tx) =
+            setup_reload_controller_state_test("extend_recipe_drop_fail", &queries).await;
+
+        let cache_ddl_requests = authority.cache_ddl_requests().await.unwrap();
+        assert!(cache_ddl_requests.is_empty());
+
+        let queries = handle.views().await.unwrap();
+        assert!(queries.is_empty());
+
+        shutdown_tx.shutdown().await;
     }
 }

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -22,6 +22,7 @@ use readyset_client::failpoints;
 use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::Change;
 use readyset_client::recipe::ChangeList;
+use readyset_client::utils::retry_with_exponential_backoff;
 use readyset_client::ControllerDescriptor;
 use readyset_data::Dialect;
 use readyset_errors::{internal, internal_err, ReadySetError, ReadySetResult};
@@ -812,12 +813,21 @@ impl Controller {
             for changelist in changelists {
                 let mut guard = self.inner.write().await;
                 if let Some(ref mut inner) = *guard {
-                    let mut writer = inner.dataflow_state_handle.write().await;
-                    let ds = writer.as_mut();
-
                     let n_caches = changelist.changes.len();
-                    match ds.extend_recipe(changelist.into(), false).await {
-                        Ok(_res) => {
+                    match retry_with_exponential_backoff(
+                        || async {
+                            let changelist = changelist.clone();
+                            let mut writer = inner.dataflow_state_handle.write().await;
+                            let ds = writer.as_mut();
+                            ds.extend_recipe(changelist.into(), false).await?;
+                            ReadySetResult::Ok(writer)
+                        },
+                        5,
+                        Duration::from_millis(250),
+                    )
+                    .await
+                    {
+                        Ok(writer) => {
                             inner
                                 .dataflow_state_handle
                                 .commit(writer, &self.authority)


### PR DESCRIPTION
This moves a recently created retry function to a place where it can be
imported by both the adapter and the server, and then uses it when
trying to recreate caches after a backwards incompatible upgrade, so
that we have a lower chance of false negatives due to transient
failures.

