### PR TITLE
replication-offset: Add tests for backwards compat.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5293,6 +5293,7 @@ dependencies = [
  "readyset-errors",
  "readyset-util",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/replication-offset/Cargo.toml
+++ b/replication-offset/Cargo.toml
@@ -11,3 +11,4 @@ readyset-errors = { path = "../readyset-errors" }
 serde = { version = "1.0", features = ["derive"] }
 readyset-util = { path = "../readyset-util" }
 bytes = "1.0"
+serde_json = "1.0.89"


### PR DESCRIPTION
This adds unit tests that check whether the compiled version of
`ReplicationOffset` is backwards compatible with a serialized version
from the last commit.

Refs: REA-3475 #575
