### PR TITLE
readyset-client: Add schema offset to AuthorityControl

### DIFF
--- a/readyset-client/src/consensus/local.rs
+++ b/readyset-client/src/consensus/local.rs
@@ -23,6 +23,7 @@ use failpoint_macros::set_failpoint;
 #[cfg(feature = "failure_injection")]
 use readyset_errors::ReadySetError;
 use readyset_errors::{internal, internal_err, set_failpoint_return_err, ReadySetResult};
+use replication_offset::ReplicationOffset;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -434,6 +435,11 @@ impl AuthorityControl for LocalAuthority {
                     .map(|data| (id, serde_json::from_slice(data).unwrap()))
             })
             .collect())
+    }
+
+    async fn schema_replication_offset(&self) -> ReadySetResult<Option<ReplicationOffset>> {
+        // Unused for LocalAuthority
+        Ok(None)
     }
 }
 

--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -14,6 +14,7 @@ use enum_dispatch::enum_dispatch;
 use nom_sql::SqlIdentifier;
 use readyset_data::Dialect;
 use readyset_errors::{ReadySetError, ReadySetResult};
+use replication_offset::ReplicationOffset;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -40,6 +41,7 @@ pub type WorkerId = String;
 
 const CACHE_DDL_REQUESTS_PATH: &str = "cache_ddl_requests";
 const PERSISTENT_STATS_PATH: &str = "persistent_stats";
+const SCHEMA_REPLICATION_OFFSET_PATH: &str = "schema_replication_offset";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CacheDDLRequest {
@@ -297,6 +299,11 @@ pub trait AuthorityControl: Send + Sync {
         self.read_modify_write(PERSISTENT_STATS_PATH, f)
             .await
             .flatten()
+    }
+
+    /// Returns the stored schema [`ReplicationOffset`], if present. Wrapper around Self::try_read
+    async fn schema_replication_offset(&self) -> ReadySetResult<Option<ReplicationOffset>> {
+        self.try_read(SCHEMA_REPLICATION_OFFSET_PATH).await
     }
 }
 


### PR DESCRIPTION
This adds a way to read the schema replication offset that we are now
storing off to the side when updating the controller state. It can be
used to restore the schema replication offset if we fail to load the
ControllerState due to a backwards incompatible change in
ControllerState serialization format.

