### PR TITLE
server: Refactor DfState internal fields

### DIFF
--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -408,7 +408,7 @@ impl Leader {
                     .into_iter()
                     .filter_map(|ni| {
                         #[allow(clippy::indexing_slicing)]
-                        let n = &ds.ingredients[ni];
+                        let n = &ds.ingredients()[ni];
                         if n.is_internal() {
                             Some((ni, n.name(), n.description(true)))
                         } else if n.is_base() {
@@ -528,7 +528,7 @@ impl Leader {
             (&Method::GET | &Method::POST, "/supports_pagination") => {
                 let ds = self.dataflow_state_handle.read().await;
                 let supports =
-                    ds.recipe.mir_config().allow_paginate && ds.recipe.mir_config().allow_topk;
+                    ds.recipe().mir_config().allow_paginate && ds.recipe().mir_config().allow_topk;
                 return_serialized!(supports)
             }
             (&Method::POST, "/evict_single") => {
@@ -890,7 +890,7 @@ impl Leader {
             #[allow(clippy::indexing_slicing)] // Internal data structure invariant
             let domain_nodes: HashMap<_, HashSet<_>> = domains_to_recover
                 .into_iter()
-                .map(|d| (d, ds.domain_nodes[&d].values().copied().collect()))
+                .map(|d| (d, ds.domain_nodes()[&d].values().copied().collect()))
                 .collect();
             info!(num_domains = %domain_nodes.len(), "Recovering domains");
             let dmp = ds.plan_recovery(&domain_nodes).await?;

--- a/readyset-server/src/controller/migrate/augmentation.rs
+++ b/readyset-server/src/controller/migrate/augmentation.rs
@@ -35,19 +35,19 @@ pub(super) fn inform(
             }
 
             let node = dataflow_state
-                .ingredients
+                .ingredients_mut()
                 .node_weight_mut(ni)
                 .unwrap()
                 .clone()
                 .take();
-            let node = node.finalize(&dataflow_state.ingredients);
+            let node = node.finalize(dataflow_state.ingredients());
             // new parents already have the right child list
             let old_parents = dataflow_state
-                .ingredients
+                .ingredients()
                 .neighbors_directed(ni, petgraph::EdgeDirection::Incoming)
-                .filter(|&ni| ni != dataflow_state.source)
+                .filter(|&ni| ni != *dataflow_state.source())
                 .filter(|ni| !new_nodes.contains(ni))
-                .map(|ni| &dataflow_state.ingredients[ni])
+                .map(|ni| &dataflow_state.ingredients()[ni])
                 .filter(|n| n.domain() == domain)
                 .map(|n| n.local_addr())
                 .collect();

--- a/readyset-server/src/controller/mir_to_flow.rs
+++ b/readyset-server/src/controller/mir_to_flow.rs
@@ -453,7 +453,7 @@ fn make_union_node(
 
         // Union takes columns of first ancestor
         if i == 0 {
-            let parent_cols = mig.dataflow_state.ingredients[ni.address()].columns();
+            let parent_cols = mig.dataflow_state.ingredients_mut()[ni.address()].columns();
             cols = emit_cols
                 .iter()
                 .map(|i| {
@@ -492,7 +492,7 @@ fn make_filter_node(
             mir_node_index: parent.index(),
         }
     })?;
-    let mut parent_cols = mig.dataflow_state.ingredients[parent_na.address()]
+    let mut parent_cols = mig.dataflow_state.ingredients_mut()[parent_na.address()]
         .columns()
         .to_vec();
     let filter_conditions = lower_expression(
@@ -536,7 +536,7 @@ fn make_grouped_node(
         .collect::<ReadySetResult<Vec<_>>>()?;
 
     // Grouped projects the group_by columns followed by computed column
-    let parent_cols = mig.dataflow_state.ingredients[parent_na.address()].columns();
+    let parent_cols = mig.dataflow_state.ingredients()[parent_na.address()].columns();
 
     // group by columns
     let mut cols = group_col_indx
@@ -613,7 +613,7 @@ fn make_identity_node(
         }
     })?;
     // Identity mirrors the parent nodes exactly
-    let mut parent_cols = mig.dataflow_state.ingredients[parent_na.address()]
+    let mut parent_cols = mig.dataflow_state.ingredients_mut()[parent_na.address()]
         .columns()
         .to_vec();
     set_names(&column_names(columns), &mut parent_cols)?;
@@ -653,8 +653,8 @@ fn make_join_node(
         }
     })?;
 
-    let left_cols = mig.dataflow_state.ingredients[left_na.address()].columns();
-    let right_cols = mig.dataflow_state.ingredients[right_na.address()].columns();
+    let left_cols = mig.dataflow_state.ingredients()[left_na.address()].columns();
+    let right_cols = mig.dataflow_state.ingredients()[right_na.address()].columns();
 
     let mut on_idxs = on
         .iter()
@@ -766,8 +766,8 @@ fn make_join_aggregates_node(
             mir_node_index: right.index(),
         }
     })?;
-    let left_cols = mig.dataflow_state.ingredients[left_na.address()].columns();
-    let right_cols = mig.dataflow_state.ingredients[right_na.address()].columns();
+    let left_cols = mig.dataflow_state.ingredients()[left_na.address()].columns();
+    let right_cols = mig.dataflow_state.ingredients()[right_na.address()].columns();
 
     let mut on = vec![];
     // We gather up all of the columns from each respective parent. If a column is in both parents,
@@ -903,7 +903,7 @@ fn make_project_node(
             mir_node_index: parent.index(),
         }
     })?;
-    let parent_cols = mig.dataflow_state.ingredients[parent_na.address()].columns();
+    let parent_cols = mig.dataflow_state.ingredients()[parent_na.address()].columns();
 
     let mut cols = Vec::with_capacity(emit.len());
     let mut exprs = Vec::with_capacity(emit.len());
@@ -962,7 +962,7 @@ fn make_distinct_node(
             mir_node_index: parent.index(),
         }
     })?;
-    let parent_cols = mig.dataflow_state.ingredients[parent_na.address()]
+    let parent_cols = mig.dataflow_state.ingredients()[parent_na.address()]
         .columns()
         .to_vec();
 
@@ -1042,7 +1042,7 @@ fn make_paginate_or_topk_node(
             mir_node_index: parent.index(),
         }
     })?;
-    let mut parent_cols = mig.dataflow_state.ingredients[parent_na.address()]
+    let mut parent_cols = mig.dataflow_state.ingredients_mut()[parent_na.address()]
         .columns()
         .to_vec();
 

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -107,7 +107,10 @@ impl Debug for ControllerState {
                 "schema_replication_offset",
                 &self.dataflow_state.schema_replication_offset(),
             )
-            .field("node_restrictions", &self.dataflow_state.node_restrictions)
+            .field(
+                "node_restrictions",
+                &self.dataflow_state.node_restrictions(),
+            )
             .finish()
     }
 }
@@ -1019,8 +1022,8 @@ impl AuthorityLeaderElectionState {
                                     "Config in authority different than our config, changing to our config"
                                 );
                                 }
-                                state.dataflow_state.domain_config = self.config.domain_config.clone();
-                                state.dataflow_state.replication_strategy = self.config.replication_strategy;
+                                state.dataflow_state.set_domain_config(self.config.domain_config.clone());
+                                state.dataflow_state.set_replication_strategy(self.config.replication_strategy);
                                 state.config = self.config.clone();
                                 Ok(state)
                             }

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -1263,9 +1263,9 @@ impl SqlIncorporator {
         // Look for and remove ingress, egress and reader nodes, which are not present in MIR.
         let next_for = |ni: DfNodeIndex| {
             mig.dataflow_state
-                .ingredients
+                .ingredients()
                 .neighbors_directed(ni.address(), petgraph::EdgeDirection::Outgoing)
-                .filter(|ni| !mig.dataflow_state.ingredients[*ni].is_dropped())
+                .filter(|ni| !mig.dataflow_state.ingredients()[*ni].is_dropped())
                 .map(|ni| DfNodeIndex::new(ni))
         };
         let mut removed = Vec::new();


### PR DESCRIPTION
The end goal of this refactor is to be able to store DfState's
schema_replication_offset field separately from the rest of the
persisted state, so that it can be recovered in the case of a backwards
incompatible change to DfState serialization format and we can avoid an
expensive re-snapshot.

This refactor does a few things to that aim:
1. Split persisted and un-persisted fields in DfState. The fact that
   there are some unpersisted fields was a bit of an abstraction smell, so
   this is a step towards mitigating that.
2. Futher split out a new struct, DfGraph, for the graph and separate
   materializations lookup table we store for it. The motivation for this
   was to be able to continue to mutably borrow both of these fields
   cleanly.
3. Split out replication offsets from the rest of the persisted state.

