### PR TITLE
test-helpers: Set durability mode explicitly

### DIFF
--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -22,8 +22,8 @@ steps:
           volumes:
           - 'target:/workdir/target'
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
       - ecr#v2.5.0:
@@ -42,8 +42,8 @@ steps:
       - docker#v3.8.0:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/cargo-deny:${BUILDKITE_COMMIT}'
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
       - ecr#v2.5.0:
@@ -65,8 +65,8 @@ steps:
           volumes:
           - 'target:/workdir/target'
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
       - ecr#v2.5.0:
@@ -86,8 +86,8 @@ steps:
       - docker-compose#v3.7.0:
           run: app
           env:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           - MYSQL_HOST=mysql
@@ -122,8 +122,8 @@ steps:
       - docker-compose#v3.7.0:
           run: app
           env:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           config:
@@ -150,8 +150,8 @@ steps:
       - docker-compose#v3.7.0:
           run: app
           env:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           - DISABLE_TELEMETRY=true
@@ -183,8 +183,8 @@ steps:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
           run: app
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           config:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,13 +28,12 @@ RUN curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-co
     chmod a+x /usr/local/bin/docker-compose
 
 RUN set -eux; \
-    cargo install cargo-cache --version 0.6.3; \
-    cargo install --git https://github.com/paritytech/cachepot --rev 2c4b14f4164ae954a1e6241e14c13feada0f1758; \
     cargo install detect_flake; \
-    cargo install critcmp; \
-    cargo cache --remove-dir all,git-db; \
-    mkdir -p ~/.config/cachepot; touch ~/.config/cachepot/config # To clean up cachepot logs
+    cargo install critcmp;
+
+RUN cargo install sccache --locked
+ENV RUSTC_WRAPPER=sccache
 
 # CARGO_HOME is set by the nightly container to be /usr/local/cargo.
 # This is where it reads configs from for cargo and where cargo installs binaries.
-RUN printf '[build]\nrustc-wrapper="/usr/local/cargo/bin/cachepot"\nrustflags = ["-C", "link-arg=-fuse-ld=lld"]' > ${CARGO_HOME}/config
+RUN printf '[build]\nrustflags = ["-C", "link-arg=-fuse-ld=lld"]' > ${CARGO_HOME}/config

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use readyset_client::consensus::{Authority, StandaloneAuthority};
 use readyset_client_test_helpers::psql_helpers::PostgreSQLAdapter;
 use readyset_client_test_helpers::TestBuilder;
-use readyset_server::Handle;
+use readyset_server::{DurabilityMode, Handle};
 use readyset_util::shutdown::ShutdownSender;
+use tempfile::TempDir;
 use tokio_postgres::{Client, Config, NoTls};
 
 pub async fn connect(config: Config) -> Client {
@@ -18,10 +19,13 @@ pub async fn connect(config: Config) -> Client {
 pub async fn setup_standalone_with_authority(
     prefix: &str,
     authority: Option<Arc<Authority>>,
+    dir: Option<TempDir>,
     upstream: bool,
     recreate: bool,
-) -> (Config, Handle, Arc<Authority>, ShutdownSender) {
-    let dir = tempfile::tempdir().unwrap();
+) -> (Config, Handle, Arc<Authority>, TempDir, ShutdownSender) {
+    // Since we will be using DurabilityMode::Permanent, we return this tempdir so that it is
+    // cleaned up after the outer test finishes
+    let dir = dir.unwrap_or_else(|| tempfile::tempdir().unwrap());
     let dir_path = dir.path().to_str().unwrap();
     let authority = authority.unwrap_or_else(|| {
         Arc::new(Authority::from(
@@ -30,11 +34,12 @@ pub async fn setup_standalone_with_authority(
     });
     let (config, handle, shutdown_tx) = TestBuilder::default()
         .fallback(upstream)
-        .persistent(true)
+        .durability_mode(DurabilityMode::Permanent)
+        .storage_dir_path(dir.path().into())
         .recreate_database(recreate)
         .authority(authority.clone())
         .build::<PostgreSQLAdapter>()
         .await;
 
-    (config, handle, authority, shutdown_tx)
+    (config, handle, authority, dir, shutdown_tx)
 }

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2093,8 +2093,8 @@ mod failure_injection_tests {
     ) {
         readyset_tracing::init_test_logging();
 
-        let (config, handle, authority, shutdown_tx) =
-            setup_standalone_with_authority(prefix, None, true, true).await;
+        let (config, handle, authority, storage_dir, shutdown_tx) =
+            setup_standalone_with_authority(prefix, None, None, true, true).await;
 
         let conn = connect(config).await;
         for query in queries {
@@ -2121,8 +2121,14 @@ mod failure_injection_tests {
         drop(handle);
         sleep().await;
 
-        let (config, handle, authority, shutdown_tx) =
-            setup_standalone_with_authority(prefix, Some(authority), true, false).await;
+        let (config, handle, authority, _, shutdown_tx) = setup_standalone_with_authority(
+            prefix,
+            Some(authority),
+            Some(storage_dir),
+            true,
+            false,
+        )
+        .await;
         sleep().await;
         (config, handle, authority, shutdown_tx)
     }

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -1562,8 +1562,9 @@ async fn same_query_different_search_path() {
 async fn caches_go_in_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("caches_go_in_authority_list", None, false, true).await;
+    let (config, _handle, authority, _, shutdown_tx) =
+        setup_standalone_with_authority("caches_go_in_authority_list", None, None, false, true)
+            .await;
 
     let queries = [
         "CREATE TABLE t (x int);",
@@ -1852,9 +1853,14 @@ mod multiple_create_and_drop {
 async fn drop_caches_go_in_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("drop_caches_go_in_authority_list", None, false, true)
-            .await;
+    let (config, _handle, authority, _, shutdown_tx) = setup_standalone_with_authority(
+        "drop_caches_go_in_authority_list",
+        None,
+        None,
+        false,
+        true,
+    )
+    .await;
 
     let queries = [
         "CREATE TABLE t (x int);",
@@ -1880,8 +1886,8 @@ async fn drop_caches_go_in_authority_list() {
 async fn drop_all_caches_clears_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("drop_all_caches", None, false, true).await;
+    let (config, _handle, authority, _, shutdown_tx) =
+        setup_standalone_with_authority("drop_all_caches", None, None, false, true).await;
 
     let queries = [
         "CREATE TABLE t (x int);",

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -571,6 +571,7 @@ impl NoriaAdapter {
                 })?;
 
             if readyset_slot_exists {
+                info!(%full_resnapshot, %resnapshot, pos=?pos, "readyset_slot_exists");
                 if full_resnapshot || resnapshot || pos.is_none() {
                     // This is not an initial connection but we need to resnapshot the latest
                     // schema, therefore we create a new replication slot, just

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -895,7 +895,7 @@ impl<'a> PostgresReplicator<'a> {
         }
 
         // The current schema was replicated, assign the current position
-        debug!(%wal_position, "Setting schema replication offset");
+        debug!(%wal_position, "Setting schema replication offset after schema snapshot");
         self.noria
             .set_schema_replication_offset(Some(&wal_position))
             .await?;


### PR DESCRIPTION
Before this commit, the TestBuilder had a `fn persistent` that used
DeleteOnExit persistence mode--it writes to disk, but then throws it
away and doesn't have a mechanism for re-using it.

This changes the persistence configuration to be a 1:1 mapping to
`DurabilityMode`, defaulting to MemoryOnly. If `PErmanent` is used, the
caller is responsible for cleaning up the tempdir (it will be
automatically cleaned up when it goes out of scope, so this is fairly
easy to do as the caller).

