### PR TITLE
readyset-client: Extend update_controller_state

### DIFF
--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1036,6 +1036,9 @@ impl AuthorityLeaderElectionState {
                             }
                         }
                     },
+                    |state: &ControllerState| {
+                        state.dataflow_state.schema_replication_offset().clone()
+                    },
                     |state: &mut ControllerState| {
                         state.dataflow_state.touch_up();
                     }

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -1957,6 +1957,9 @@ impl DfStateHandle {
                             Ok(state)
                         }
                     },
+                    |state: &ControllerState| {
+                        state.dataflow_state.schema_replication_offset().clone()
+                    },
                     |state: &mut ControllerState| {
                         state.dataflow_state.touch_up();
                     },


### PR DESCRIPTION
Extend the update_controller_state fn of AuthorityControl to allow us to
store the schema ReplicationOffset separately from ControllerState.

This will allow us to recover the schema replication offset if there is
a backwards incompatible change to the serialization format of
ControllerState.

This is implemebnted by having callers of update_controller_state
provide a function that allows the AuthorityControl to extract the
replication offset to store separately. This is a bit strange, but these
opaque functions at this level are (as far as I can tell) due to there
otherwise being either a cyclic dependency between readyset-client and
readyset-server, or else having server-specific types exposed too high
in the dependency graph.

This commit also implements the atomic storing of the schema replication
offset for our different Authority variants.

