### PR TITLE
server: Restore schema replication offset with caches

### DIFF
--- a/readyset-client/src/consensus/local.rs
+++ b/readyset-client/src/consensus/local.rs
@@ -23,6 +23,7 @@ use failpoint_macros::set_failpoint;
 #[cfg(feature = "failure_injection")]
 use readyset_errors::ReadySetError;
 use readyset_errors::{internal, internal_err, set_failpoint_return_err, ReadySetResult};
+use replication_offset::ReplicationOffset;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -434,6 +435,11 @@ impl AuthorityControl for LocalAuthority {
                     .map(|data| (id, serde_json::from_slice(data).unwrap()))
             })
             .collect())
+    }
+
+    async fn schema_replication_offset(&self) -> ReadySetResult<Option<ReplicationOffset>> {
+        // Unused for LocalAuthority
+        Ok(None)
     }
 }
 

--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -14,6 +14,7 @@ use enum_dispatch::enum_dispatch;
 use nom_sql::SqlIdentifier;
 use readyset_data::Dialect;
 use readyset_errors::{ReadySetError, ReadySetResult};
+use replication_offset::ReplicationOffset;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -40,6 +41,7 @@ pub type WorkerId = String;
 
 const CACHE_DDL_REQUESTS_PATH: &str = "cache_ddl_requests";
 const PERSISTENT_STATS_PATH: &str = "persistent_stats";
+const SCHEMA_REPLICATION_OFFSET_PATH: &str = "schema_replication_offset";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CacheDDLRequest {
@@ -297,6 +299,11 @@ pub trait AuthorityControl: Send + Sync {
         self.read_modify_write(PERSISTENT_STATS_PATH, f)
             .await
             .flatten()
+    }
+
+    /// Returns the stored schema [`ReplicationOffset`], if present. Wrapper around Self::try_read
+    async fn schema_replication_offset(&self) -> ReadySetResult<Option<ReplicationOffset>> {
+        self.try_read(SCHEMA_REPLICATION_OFFSET_PATH).await
     }
 }
 

--- a/readyset-client/src/failpoints/mod.rs
+++ b/readyset-client/src/failpoints/mod.rs
@@ -18,6 +18,12 @@ pub const REPLICATION_HANDLE_ACTION: &str = "replication-handle-action";
 pub const POSTGRES_REPLICATION_NEXT_ACTION: &str = "postgres-replication-next-action";
 /// Imitates a failure right before we begin snapshotting against a Postgres upstream
 pub const POSTGRES_SNAPSHOT_START: &str = "postgres-snapshot-start";
+/// Imitates a failure encountered while performing a full resnapshot
+pub const POSTGRES_FULL_RESNAPSHOT: &str = "postgres-full-resnapshot";
+/// Imitates a failure encountered while performing a partial resnapshot
+pub const POSTGRES_PARTIAL_RESNAPSHOT: &str = "postgres-partial-resnapshot";
+/// Imitates a failure encountered while snapshotting a table
+pub const POSTGRES_SNAPSHOT_TABLE: &str = "postgres-snapshot-table";
 /// Imitates a failure right before we invoke `START_REPLICATION` during Postgres replication
 pub const POSTGRES_START_REPLICATION: &str = "postgres-start-replication";
 /// Imitates a failure when we go to pull the next event from the WAL during Postgres replication

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use readyset_client::consensus::{Authority, StandaloneAuthority};
 use readyset_client_test_helpers::psql_helpers::PostgreSQLAdapter;
 use readyset_client_test_helpers::TestBuilder;
-use readyset_server::Handle;
+use readyset_server::{DurabilityMode, Handle};
 use readyset_util::shutdown::ShutdownSender;
+use tempfile::TempDir;
 use tokio_postgres::{Client, Config, NoTls};
 
 pub async fn connect(config: Config) -> Client {
@@ -18,10 +19,13 @@ pub async fn connect(config: Config) -> Client {
 pub async fn setup_standalone_with_authority(
     prefix: &str,
     authority: Option<Arc<Authority>>,
+    dir: Option<TempDir>,
     upstream: bool,
     recreate: bool,
-) -> (Config, Handle, Arc<Authority>, ShutdownSender) {
-    let dir = tempfile::tempdir().unwrap();
+) -> (Config, Handle, Arc<Authority>, TempDir, ShutdownSender) {
+    // Since we will be using DurabilityMode::Permanent, we return this tempdir so that it is
+    // cleaned up after the outer test finishes
+    let dir = dir.unwrap_or_else(|| tempfile::tempdir().unwrap());
     let dir_path = dir.path().to_str().unwrap();
     let authority = authority.unwrap_or_else(|| {
         Arc::new(Authority::from(
@@ -30,11 +34,12 @@ pub async fn setup_standalone_with_authority(
     });
     let (config, handle, shutdown_tx) = TestBuilder::default()
         .fallback(upstream)
-        .persistent(true)
+        .durability_mode(DurabilityMode::Permanent)
+        .storage_dir_path(dir.path().into())
         .recreate_database(recreate)
         .authority(authority.clone())
         .build::<PostgreSQLAdapter>()
         .await;
 
-    (config, handle, authority, shutdown_tx)
+    (config, handle, authority, dir, shutdown_tx)
 }

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2093,8 +2093,8 @@ mod failure_injection_tests {
     ) {
         readyset_tracing::init_test_logging();
 
-        let (config, handle, authority, shutdown_tx) =
-            setup_standalone_with_authority(prefix, None, true, true).await;
+        let (config, handle, authority, storage_dir, shutdown_tx) =
+            setup_standalone_with_authority(prefix, None, None, true, true).await;
 
         let conn = connect(config).await;
         for query in queries {
@@ -2121,8 +2121,14 @@ mod failure_injection_tests {
         drop(handle);
         sleep().await;
 
-        let (config, handle, authority, shutdown_tx) =
-            setup_standalone_with_authority(prefix, Some(authority), true, false).await;
+        let (config, handle, authority, _, shutdown_tx) = setup_standalone_with_authority(
+            prefix,
+            Some(authority),
+            Some(storage_dir),
+            true,
+            false,
+        )
+        .await;
         sleep().await;
         (config, handle, authority, shutdown_tx)
     }

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -1562,8 +1562,9 @@ async fn same_query_different_search_path() {
 async fn caches_go_in_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("caches_go_in_authority_list", None, false, true).await;
+    let (config, _handle, authority, _, shutdown_tx) =
+        setup_standalone_with_authority("caches_go_in_authority_list", None, None, false, true)
+            .await;
 
     let queries = [
         "CREATE TABLE t (x int);",
@@ -1852,9 +1853,14 @@ mod multiple_create_and_drop {
 async fn drop_caches_go_in_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("drop_caches_go_in_authority_list", None, false, true)
-            .await;
+    let (config, _handle, authority, _, shutdown_tx) = setup_standalone_with_authority(
+        "drop_caches_go_in_authority_list",
+        None,
+        None,
+        false,
+        true,
+    )
+    .await;
 
     let queries = [
         "CREATE TABLE t (x int);",
@@ -1880,8 +1886,8 @@ async fn drop_caches_go_in_authority_list() {
 async fn drop_all_caches_clears_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("drop_all_caches", None, false, true).await;
+    let (config, _handle, authority, _, shutdown_tx) =
+        setup_standalone_with_authority("drop_all_caches", None, None, false, true).await;
 
     let queries = [
         "CREATE TABLE t (x int);",

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1036,6 +1036,9 @@ impl AuthorityLeaderElectionState {
                             }
                         }
                     },
+                    |state: &ControllerState| {
+                        state.dataflow_state.schema_replication_offset().clone()
+                    },
                     |state: &mut ControllerState| {
                         state.dataflow_state.touch_up();
                     }

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -1957,6 +1957,9 @@ impl DfStateHandle {
                             Ok(state)
                         }
                     },
+                    |state: &ControllerState| {
+                        state.dataflow_state.schema_replication_offset().clone()
+                    },
                     |state: &mut ControllerState| {
                         state.dataflow_state.touch_up();
                     },

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -571,6 +571,7 @@ impl NoriaAdapter {
                 })?;
 
             if readyset_slot_exists {
+                info!(%full_resnapshot, %resnapshot, pos=?pos, "readyset_slot_exists");
                 if full_resnapshot || resnapshot || pos.is_none() {
                     // This is not an initial connection but we need to resnapshot the latest
                     // schema, therefore we create a new replication slot, just

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -246,11 +246,13 @@ impl NoriaAdapter {
         } {
             match err {
                 ReadySetError::ResnapshotNeeded => {
+                    set_failpoint!(failpoints::POSTGRES_PARTIAL_RESNAPSHOT);
                     tokio::time::sleep(WAIT_BEFORE_RESNAPSHOT).await;
                     resnapshot = true;
                     full_snapshot = false;
                 }
                 ReadySetError::FullResnapshotNeeded => {
+                    set_failpoint!(failpoints::POSTGRES_FULL_RESNAPSHOT);
                     tokio::time::sleep(WAIT_BEFORE_RESNAPSHOT).await;
                     resnapshot = true;
                     full_snapshot = true;

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -895,7 +895,7 @@ impl<'a> PostgresReplicator<'a> {
         }
 
         // The current schema was replicated, assign the current position
-        debug!(%wal_position, "Setting schema replication offset");
+        debug!(%wal_position, "Setting schema replication offset after schema snapshot");
         self.noria
             .set_schema_replication_offset(Some(&wal_position))
             .await?;

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -5,6 +5,7 @@ use std::fmt::{self, Display};
 use std::future;
 use std::time::Instant;
 
+use failpoint_macros::set_failpoint;
 use futures::stream::FuturesUnordered;
 use futures::{pin_mut, StreamExt, TryFutureExt};
 use itertools::Itertools;
@@ -15,6 +16,8 @@ use nom_sql::{
     NotReplicatedReason, Relation, SqlIdentifier, TableKey,
 };
 use postgres_types::{accepts, FromSql, Kind, Type};
+#[cfg(feature = "failure_injection")]
+use readyset_client::failpoints;
 use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::{Change, ChangeList, PostgresTableMetadata};
 use readyset_client::TableOperation;
@@ -920,6 +923,7 @@ impl<'a> PostgresReplicator<'a> {
         // Finally copy each table into noria
         let mut snapshotting_tables = FuturesUnordered::new();
         for table in &tables {
+            set_failpoint!(failpoints::POSTGRES_SNAPSHOT_TABLE);
             let span =
                 info_span!("Snapshotting table", table = %table.name.display(Dialect::PostgreSQL));
             span.in_scope(|| info!("Snapshotting table"));


### PR DESCRIPTION
If we fail to deserialize the ControllerState due to a backwards
incompatible change in ControllerState serialization format, we don't
want to have to resnapshot the tables. The tables themselves store the
replication offset associated with them, but there is also a schema
replication offset that is used to track changes that are unrelated to
any particular table "e.g. create custom type".

This change re-loads this schema offset from a place we stashed it off
to the side separately from the ControllerState.

It also contains a change to how we wait for lsns since the test
introduced for this behavior uncovered an edge case where we could be
stuck "Catching up" if we don't see any activity on the replication slot
after a restart.

