### PR TITLE
build: Expand sccache usage to `readyset-build` image

### DIFF
--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -22,8 +22,8 @@ steps:
           volumes:
           - 'target:/workdir/target'
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
       - ecr#v2.5.0:
@@ -42,8 +42,8 @@ steps:
       - docker#v3.8.0:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/cargo-deny:${BUILDKITE_COMMIT}'
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
       - ecr#v2.5.0:
@@ -65,8 +65,8 @@ steps:
           volumes:
           - 'target:/workdir/target'
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
       - ecr#v2.5.0:
@@ -86,8 +86,8 @@ steps:
       - docker-compose#v3.7.0:
           run: app
           env:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           - MYSQL_HOST=mysql
@@ -122,8 +122,8 @@ steps:
       - docker-compose#v3.7.0:
           run: app
           env:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           config:
@@ -150,8 +150,8 @@ steps:
       - docker-compose#v3.7.0:
           run: app
           env:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           - DISABLE_TELEMETRY=true
@@ -183,8 +183,8 @@ steps:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
           run: app
           environment:
-          - CACHEPOT_BUCKET=readysettech-build-sccache-us-east-2
-          - CACHEPOT_REGION=us-east-2
+          - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
+          - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
           config:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -28,13 +28,12 @@ RUN curl -L https://github.com/docker/compose/releases/download/v2.6.0/docker-co
     chmod a+x /usr/local/bin/docker-compose
 
 RUN set -eux; \
-    cargo install cargo-cache --version 0.6.3; \
-    cargo install --git https://github.com/paritytech/cachepot --rev 2c4b14f4164ae954a1e6241e14c13feada0f1758; \
     cargo install detect_flake; \
-    cargo install critcmp; \
-    cargo cache --remove-dir all,git-db; \
-    mkdir -p ~/.config/cachepot; touch ~/.config/cachepot/config # To clean up cachepot logs
+    cargo install critcmp;
+
+RUN cargo install sccache --locked
+ENV RUSTC_WRAPPER=sccache
 
 # CARGO_HOME is set by the nightly container to be /usr/local/cargo.
 # This is where it reads configs from for cargo and where cargo installs binaries.
-RUN printf '[build]\nrustc-wrapper="/usr/local/cargo/bin/cachepot"\nrustflags = ["-C", "link-arg=-fuse-ld=lld"]' > ${CARGO_HOME}/config
+RUN printf '[build]\nrustflags = ["-C", "link-arg=-fuse-ld=lld"]' > ${CARGO_HOME}/config


### PR DESCRIPTION
Layers of indirection had caused me to misjudge the scope of my
earlier sccache installation.  Specifically, our tests and many other
things run in the `readyset-build` image which does not have the ubuntu
builder base as an ancestor, and thus did not have a functioning
sccache.  This update deploys sccache more widely in the pipeline.

