### PR TITLE
readyset-psql: Mark types tests as #[slow]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4973,6 +4973,7 @@ dependencies = [
  "streaming-iterator",
  "tempfile",
  "test-strategy",
+ "test-utils",
  "thiserror",
  "tikv-jemallocator",
  "tokio",

--- a/readyset-psql/Cargo.toml
+++ b/readyset-psql/Cargo.toml
@@ -53,6 +53,7 @@ readyset-util = { path = "../readyset-util" }
 readyset-client-test-helpers = { path = "../readyset-client-test-helpers", features = ["postgres"] }
 criterion = { version = "0.3.5", features = ["async_tokio"] }
 readyset-tracing = { path = "../readyset-tracing" }
+test-utils = { path = "../test-utils" }
 
 [[bench]]
 name = "proxy"

--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -14,6 +14,7 @@ async fn setup() -> (tokio_postgres::Config, Handle, ShutdownSender) {
         .await
 }
 
+#[cfg(test)]
 mod types {
     use std::fmt::Display;
     use std::panic::{AssertUnwindSafe, RefUnwindSafe};
@@ -129,6 +130,7 @@ mod types {
                 max_shrink_iters: 200, // May need many shrink iters for large vecs
                 ..ProptestConfig::default()
             })]
+            #[test_utils::slow]
             #[serial_test::serial]
             $(#[$meta])*
             fn $test_name(#[strategy(vec($strategy, 1..20))] vals: Vec<$rust_type>) {


### PR DESCRIPTION
The types tests are proptests that run in serial and make real database
calls. They are taking around 400 seconds to run, and are generally
unlikely to fail for most changes.

So running them in the nightly build only (when RUN_SLOW_TESTS=true is
set) will speed up normal builds significantly.

