### PR TITLE
replicators: Add no-op replication message after snapshotting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "rust_decimal",
  "serial_test",
  "test-strategy",
+ "test-utils",
  "tokio",
  "uuid 0.8.2",
  "zipf",

--- a/data-generator/Cargo.toml
+++ b/data-generator/Cargo.toml
@@ -26,3 +26,4 @@ proptest = "1.0.0"
 mysql_async = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 serial_test = "0.5"
+test-utils = { path = "../test-utils" }

--- a/data-generator/tests/mysql.rs
+++ b/data-generator/tests/mysql.rs
@@ -8,6 +8,7 @@ use proptest::prop_assume;
 use rand::rngs::mock::StepRng;
 use serial_test::serial;
 use test_strategy::proptest;
+use test_utils::slow;
 
 async fn mysql_connection() -> mysql_async::Conn {
     mysql_async::Conn::new(
@@ -29,6 +30,7 @@ async fn mysql_connection() -> mysql_async::Conn {
 
 #[proptest]
 #[serial]
+#[slow]
 fn value_of_type_always_valid(
     #[any(generate_arrays = false, dialect = Some(Dialect::MySQL))] ty: SqlType,
 ) {
@@ -56,6 +58,7 @@ fn value_of_type_always_valid(
 
 #[proptest]
 #[serial]
+#[slow]
 fn unique_value_of_type_always_valid(
     #[any(generate_arrays = false, dialect = Some(Dialect::MySQL))] ty: SqlType,
     #[strategy(0..=255u32)] idx: u32,
@@ -86,6 +89,7 @@ fn unique_value_of_type_always_valid(
 
 #[proptest]
 #[serial]
+#[slow]
 fn random_value_of_type_always_valid(
     #[any(generate_arrays = false, dialect = Some(Dialect::MySQL))] ty: SqlType,
     initial: u64,

--- a/readyset-client/src/consensus/local.rs
+++ b/readyset-client/src/consensus/local.rs
@@ -23,6 +23,7 @@ use failpoint_macros::set_failpoint;
 #[cfg(feature = "failure_injection")]
 use readyset_errors::ReadySetError;
 use readyset_errors::{internal, internal_err, set_failpoint_return_err, ReadySetResult};
+use replication_offset::ReplicationOffset;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
@@ -434,6 +435,11 @@ impl AuthorityControl for LocalAuthority {
                     .map(|data| (id, serde_json::from_slice(data).unwrap()))
             })
             .collect())
+    }
+
+    async fn schema_replication_offset(&self) -> ReadySetResult<Option<ReplicationOffset>> {
+        // Unused for LocalAuthority
+        Ok(None)
     }
 }
 

--- a/readyset-client/src/consensus/mod.rs
+++ b/readyset-client/src/consensus/mod.rs
@@ -14,6 +14,7 @@ use enum_dispatch::enum_dispatch;
 use nom_sql::SqlIdentifier;
 use readyset_data::Dialect;
 use readyset_errors::{ReadySetError, ReadySetResult};
+use replication_offset::ReplicationOffset;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tracing::error;
@@ -40,6 +41,7 @@ pub type WorkerId = String;
 
 const CACHE_DDL_REQUESTS_PATH: &str = "cache_ddl_requests";
 const PERSISTENT_STATS_PATH: &str = "persistent_stats";
+const SCHEMA_REPLICATION_OFFSET_PATH: &str = "schema_replication_offset";
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CacheDDLRequest {
@@ -297,6 +299,11 @@ pub trait AuthorityControl: Send + Sync {
         self.read_modify_write(PERSISTENT_STATS_PATH, f)
             .await
             .flatten()
+    }
+
+    /// Returns the stored schema [`ReplicationOffset`], if present. Wrapper around Self::try_read
+    async fn schema_replication_offset(&self) -> ReadySetResult<Option<ReplicationOffset>> {
+        self.try_read(SCHEMA_REPLICATION_OFFSET_PATH).await
     }
 }
 

--- a/readyset-mysql/tests/fallback.rs
+++ b/readyset-mysql/tests/fallback.rs
@@ -9,7 +9,7 @@ use readyset_server::Handle;
 use readyset_util::hash::hash;
 use readyset_util::shutdown::ShutdownSender;
 use serial_test::serial;
-use test_utils::skip_flaky_finder;
+use test_utils::{skip_flaky_finder, slow};
 
 async fn setup_with(
     backend_builder: BackendBuilder,
@@ -26,6 +26,7 @@ async fn setup() -> (mysql_async::Opts, Handle, ShutdownSender) {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn create_table() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -51,6 +52,7 @@ async fn create_table() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn add_column() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -90,6 +92,7 @@ async fn add_column() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn json_column_insert_read() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -119,6 +122,7 @@ async fn json_column_insert_read() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn json_column_partial_update() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -148,6 +152,7 @@ async fn json_column_partial_update() {
 // TODO: remove this once we support range queries again
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn range_query() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -172,6 +177,7 @@ async fn range_query() {
 // TODO: remove this once we support aggregates on parametrized IN
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn aggregate_in() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -197,6 +203,7 @@ async fn aggregate_in() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn set_autocommit() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -219,6 +226,7 @@ async fn set_autocommit() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn proxy_unsupported_sets() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -261,6 +269,7 @@ async fn proxy_unsupported_sets() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn proxy_unsupported_sets_prep_exec() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -293,6 +302,7 @@ async fn proxy_unsupported_sets_prep_exec() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prepare_in_tx_select_out() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -323,6 +333,7 @@ async fn prepare_in_tx_select_out() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prep_and_select_in_tx() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -354,6 +365,7 @@ async fn prep_and_select_in_tx() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prep_then_select_in_tx() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -385,6 +397,7 @@ async fn prep_then_select_in_tx() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prep_then_always_select_in_tx() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -419,6 +432,7 @@ async fn prep_then_always_select_in_tx() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn always_should_bypass_tx() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -454,6 +468,7 @@ async fn always_should_bypass_tx() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prep_select() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -481,6 +496,7 @@ async fn prep_select() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn set_then_prep_and_select() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -508,6 +524,7 @@ async fn set_then_prep_and_select() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn always_should_never_proxy() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -535,6 +552,7 @@ async fn always_should_never_proxy() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn always_should_never_proxy_exec() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -571,6 +589,7 @@ async fn always_should_never_proxy_exec() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prep_then_set_then_select_proxy() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -598,6 +617,7 @@ async fn prep_then_set_then_select_proxy() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn proxy_mode_should_allow_commands() {
     let (opts, _handle, shutdown_tx) = setup_with(
         BackendBuilder::new()
@@ -644,6 +664,7 @@ async fn proxy_mode_should_allow_commands() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn drop_then_recreate_table_with_query() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -677,6 +698,7 @@ async fn drop_then_recreate_table_with_query() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 #[skip_flaky_finder]
 async fn transaction_proxies() {
     let (opts, _handle, shutdown_tx) = setup().await;
@@ -710,6 +732,7 @@ async fn transaction_proxies() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn valid_sql_parsing_failed_shows_proxied() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -737,6 +760,7 @@ async fn valid_sql_parsing_failed_shows_proxied() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn invalid_sql_parsing_failed_doesnt_show_proxied() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let mut conn = mysql_async::Conn::new(opts).await.unwrap();
@@ -755,6 +779,7 @@ async fn invalid_sql_parsing_failed_doesnt_show_proxied() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 #[skip_flaky_finder]
 async fn switch_database_with_use() {
     let (opts, _handle, shutdown_tx) = setup().await;
@@ -785,6 +810,7 @@ async fn switch_database_with_use() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn replication_failure_ignores_table() {
     readyset_tracing::init_test_logging();
     use mysql::serde_json;
@@ -901,6 +927,7 @@ async fn replication_failure_ignores_table() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn show_proxied_queries_show_caches_query_text_matches() {
     readyset_tracing::init_test_logging();
     let (opts, _handle, shutdown_tx) = setup().await;

--- a/readyset-psql/tests/common/mod.rs
+++ b/readyset-psql/tests/common/mod.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use readyset_client::consensus::{Authority, StandaloneAuthority};
 use readyset_client_test_helpers::psql_helpers::PostgreSQLAdapter;
 use readyset_client_test_helpers::TestBuilder;
-use readyset_server::Handle;
+use readyset_server::{DurabilityMode, Handle};
 use readyset_util::shutdown::ShutdownSender;
+use tempfile::TempDir;
 use tokio_postgres::{Client, Config, NoTls};
 
 pub async fn connect(config: Config) -> Client {
@@ -18,10 +19,13 @@ pub async fn connect(config: Config) -> Client {
 pub async fn setup_standalone_with_authority(
     prefix: &str,
     authority: Option<Arc<Authority>>,
+    dir: Option<TempDir>,
     upstream: bool,
     recreate: bool,
-) -> (Config, Handle, Arc<Authority>, ShutdownSender) {
-    let dir = tempfile::tempdir().unwrap();
+) -> (Config, Handle, Arc<Authority>, TempDir, ShutdownSender) {
+    // Since we will be using DurabilityMode::Permanent, we return this tempdir so that it is
+    // cleaned up after the outer test finishes
+    let dir = dir.unwrap_or_else(|| tempfile::tempdir().unwrap());
     let dir_path = dir.path().to_str().unwrap();
     let authority = authority.unwrap_or_else(|| {
         Arc::new(Authority::from(
@@ -30,11 +34,12 @@ pub async fn setup_standalone_with_authority(
     });
     let (config, handle, shutdown_tx) = TestBuilder::default()
         .fallback(upstream)
-        .persistent(true)
+        .durability_mode(DurabilityMode::Permanent)
+        .storage_dir_path(dir.path().into())
         .recreate_database(recreate)
         .authority(authority.clone())
         .build::<PostgreSQLAdapter>()
         .await;
 
-    (config, handle, authority, shutdown_tx)
+    (config, handle, authority, dir, shutdown_tx)
 }

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -11,6 +11,7 @@ use readyset_server::Handle;
 use readyset_util::eventually;
 use readyset_util::shutdown::ShutdownSender;
 use serial_test::serial;
+use test_utils::slow;
 
 mod common;
 use common::connect;
@@ -26,6 +27,7 @@ async fn setup() -> (tokio_postgres::Config, Handle, ShutdownSender) {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn create_table() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -56,6 +58,7 @@ async fn create_table() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn delete_case_sensitive() {
     for (opts, _handle, shutdown_tx) in [
         TestBuilder::default().build::<PostgreSQLAdapter>().await,
@@ -123,6 +126,7 @@ async fn delete_case_sensitive() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prepare_typed_insert() {
     let (opts, _handle, shutdown_tx) = setup().await;
     let conn = connect(opts).await;
@@ -168,6 +172,7 @@ async fn prepare_typed_insert() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn unsupported_query_ad_hoc() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -190,6 +195,7 @@ async fn unsupported_query_ad_hoc() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn prepare_execute_fallback() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -221,6 +227,7 @@ async fn prepare_execute_fallback() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn proxy_unsupported_sets() {
     let (config, _handle, shutdown_tx) = TestBuilder::new(
         BackendBuilder::new()
@@ -249,6 +256,7 @@ async fn proxy_unsupported_sets() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn proxy_unsupported_type() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -293,6 +301,7 @@ async fn proxy_unsupported_type() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn schema_resolution_with_unreplicated_tables() {
     readyset_tracing::init_test_logging();
     let (config, mut handle, shutdown_tx) = setup().await;
@@ -364,6 +373,7 @@ async fn schema_resolution_with_unreplicated_tables() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn generated_columns() {
     // Tests that we handle tables that have generated columns by not snapshotting them and falling
     // back to upstream
@@ -466,6 +476,7 @@ async fn generated_columns() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn unsupported_numeric_scale() {
     // Tests that we handle tables that have NUMERIC values with scales > 28
     // by not snapshotting them and falling back to upstream
@@ -560,6 +571,7 @@ async fn unsupported_numeric_scale() {
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[ignore = "ENG-2548 Test reproduces client panic due to known bug"]
+#[slow]
 async fn add_column_then_read() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -592,6 +604,7 @@ async fn add_column_then_read() {
 #[ignore = "ENG-2575 Test reproduces client error due to known bug"]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn drop_column_then_read() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -626,6 +639,7 @@ async fn drop_column_then_read() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn deletion_propagation_after_alter() {
     readyset_tracing::init_test_logging();
 
@@ -686,6 +700,7 @@ async fn deletion_propagation_after_alter() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn write_propagation_after_alter_and_drop() {
     readyset_tracing::init_test_logging();
 
@@ -733,6 +748,7 @@ async fn write_propagation_after_alter_and_drop() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn rename_column_then_create_view() {
     readyset_tracing::init_test_logging();
 
@@ -774,6 +790,7 @@ async fn rename_column_then_create_view() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn alter_enum_after_drop() {
     readyset_tracing::init_test_logging();
 
@@ -812,6 +829,7 @@ async fn alter_enum_after_drop() {
 #[ignore = "ENG-2823 Test reproduces error due to known bug"]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn alter_enum_rename_value() {
     readyset_tracing::init_test_logging();
 
@@ -845,6 +863,7 @@ async fn alter_enum_rename_value() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn insert_enum_value_appended_after_create_table() {
     readyset_tracing::init_test_logging();
 
@@ -886,6 +905,7 @@ async fn insert_enum_value_appended_after_create_table() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn insert_array_of_enum_value_appended_after_create_table() {
     // This test is based off insert_enum_value_appended_after_create_table but inserts an array of
     // enum values instead of a single value, which triggers a similar bug to the one that the
@@ -1021,6 +1041,7 @@ async fn assert_table_ignored(client: &Client) {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn handle_action_replication_failure_ignores_table() {
     replication_failure_ignores_table(readyset_client::failpoints::REPLICATION_HANDLE_ACTION).await;
 }
@@ -1028,6 +1049,7 @@ async fn handle_action_replication_failure_ignores_table() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn next_action_replication_failure_ignores_table() {
     replication_failure_ignores_table(
         readyset_client::failpoints::POSTGRES_REPLICATION_NEXT_ACTION,
@@ -1087,6 +1109,7 @@ async fn replication_failure_ignores_table(failpoint: &str) {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn handle_action_replication_failure_retries_if_failed_to_drop() {
     replication_failure_retries_if_failed_to_drop(
         readyset_client::failpoints::REPLICATION_HANDLE_ACTION,
@@ -1097,6 +1120,7 @@ async fn handle_action_replication_failure_retries_if_failed_to_drop() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn next_action_replication_failure_retries_if_failed_to_drop() {
     replication_failure_retries_if_failed_to_drop(
         readyset_client::failpoints::POSTGRES_REPLICATION_NEXT_ACTION,
@@ -1205,6 +1229,7 @@ async fn replication_failure_retries_if_failed_to_drop(failpoint: &str) {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn replication_of_other_tables_succeeds_even_after_error() {
     readyset_tracing::init_test_logging();
     use std::time::Duration;
@@ -1265,6 +1290,7 @@ async fn replication_of_other_tables_succeeds_even_after_error() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn drop_cache_implicit_caching() {
     readyset_tracing::init_test_logging();
 
@@ -1376,6 +1402,7 @@ async fn drop_cache_implicit_caching() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn show_proxied_queries_show_caches_query_text_matches() {
     readyset_tracing::init_test_logging();
     let (config, _handle, shutdown_tx) = setup().await;
@@ -1419,6 +1446,7 @@ async fn show_proxied_queries_show_caches_query_text_matches() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn insert_delete_a_record_in_the_same_transaction() {
     readyset_tracing::init_test_logging();
     let (config, _handle, shutdown_tx) = setup().await;
@@ -1453,6 +1481,7 @@ async fn insert_delete_a_record_in_the_same_transaction() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn pgsql_test_replication_after_resnapshot() {
     use std::time::Duration;
 
@@ -1536,6 +1565,7 @@ async fn pgsql_test_replication_after_resnapshot() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn start_replication_in_middle_of_commit() {
     use std::time::Duration;
 
@@ -1659,6 +1689,7 @@ async fn start_replication_in_middle_of_commit() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn column_metadata() {
     let (config, _handle, shutdown_tx) = setup().await;
     let client = connect(config).await;
@@ -1685,6 +1716,7 @@ async fn column_metadata() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn pgsql_test_replication_after_resnapshot_with_catchup() {
     readyset_tracing::init_test_logging();
 
@@ -1769,6 +1801,7 @@ async fn pgsql_test_replication_after_resnapshot_with_catchup() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn create_view_then_drop_table_then_create_view_with_same_name() {
     readyset_tracing::init_test_logging();
 
@@ -1814,6 +1847,7 @@ async fn create_view_then_drop_table_then_create_view_with_same_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn create_view_then_drop_view_then_create_view_with_same_name() {
     readyset_tracing::init_test_logging();
 
@@ -1861,6 +1895,7 @@ async fn create_view_then_drop_view_then_create_view_with_same_name() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn start_replication_invalidated_replication_slot() {
     use readyset_errors::ReadySetError;
 
@@ -1949,6 +1984,7 @@ async fn start_replication_invalidated_replication_slot() {
 #[cfg(feature = "failure_injection")]
 #[tokio::test(flavor = "multi_thread")]
 #[serial]
+#[slow]
 async fn recreate_replication_slot() {
     use readyset_errors::ReadySetError;
 
@@ -2129,6 +2165,7 @@ mod failure_injection_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn caches_recreated_after_backwards_incompatible_upgrade() {
         let queries = [
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
@@ -2145,6 +2182,7 @@ mod failure_injection_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn dropped_caches_not_recreated() {
         let queries = [
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
@@ -2163,6 +2201,7 @@ mod failure_injection_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn dropped_then_recreated_cache_recreated() {
         let queries = [
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
@@ -2182,6 +2221,7 @@ mod failure_injection_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn caches_added_if_extend_recipe_times_out() {
         let queries = [
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
@@ -2211,6 +2251,7 @@ mod failure_injection_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn create_cache_not_added_if_extend_recipe_fails() {
         let queries = [
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
@@ -2231,6 +2272,7 @@ mod failure_injection_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn drop_cache_not_added_if_drop_fails() {
         let queries = [
             "CREATE TABLE users (id INT PRIMARY KEY, name TEXT);",
@@ -2253,6 +2295,7 @@ mod failure_injection_tests {
     // restarting
     #[tokio::test(flavor = "multi_thread")]
     #[serial]
+    #[slow]
     async fn replication_slot_exists_check() {
         use readyset_errors::ReadySetError;
 

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2129,8 +2129,8 @@ mod failure_injection_tests {
     ) {
         readyset_tracing::init_test_logging();
 
-        let (config, handle, authority, shutdown_tx) =
-            setup_standalone_with_authority(prefix, None, true, true).await;
+        let (config, handle, authority, storage_dir, shutdown_tx) =
+            setup_standalone_with_authority(prefix, None, None, true, true).await;
 
         let conn = connect(config).await;
         for query in queries {
@@ -2157,8 +2157,14 @@ mod failure_injection_tests {
         drop(handle);
         sleep().await;
 
-        let (config, handle, authority, shutdown_tx) =
-            setup_standalone_with_authority(prefix, Some(authority), true, false).await;
+        let (config, handle, authority, _, shutdown_tx) = setup_standalone_with_authority(
+            prefix,
+            Some(authority),
+            Some(storage_dir),
+            true,
+            false,
+        )
+        .await;
         sleep().await;
         (config, handle, authority, shutdown_tx)
     }

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -1562,8 +1562,9 @@ async fn same_query_different_search_path() {
 async fn caches_go_in_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("caches_go_in_authority_list", None, false, true).await;
+    let (config, _handle, authority, _, shutdown_tx) =
+        setup_standalone_with_authority("caches_go_in_authority_list", None, None, false, true)
+            .await;
 
     let queries = [
         "CREATE TABLE t (x int);",
@@ -1852,9 +1853,14 @@ mod multiple_create_and_drop {
 async fn drop_caches_go_in_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("drop_caches_go_in_authority_list", None, false, true)
-            .await;
+    let (config, _handle, authority, _, shutdown_tx) = setup_standalone_with_authority(
+        "drop_caches_go_in_authority_list",
+        None,
+        None,
+        false,
+        true,
+    )
+    .await;
 
     let queries = [
         "CREATE TABLE t (x int);",
@@ -1880,8 +1886,8 @@ async fn drop_caches_go_in_authority_list() {
 async fn drop_all_caches_clears_authority_list() {
     readyset_tracing::init_test_logging();
 
-    let (config, _handle, authority, shutdown_tx) =
-        setup_standalone_with_authority("drop_all_caches", None, false, true).await;
+    let (config, _handle, authority, _, shutdown_tx) =
+        setup_standalone_with_authority("drop_all_caches", None, None, false, true).await;
 
     let queries = [
         "CREATE TABLE t (x int);",

--- a/readyset-psql/tests/types.rs
+++ b/readyset-psql/tests/types.rs
@@ -14,7 +14,6 @@ async fn setup() -> (tokio_postgres::Config, Handle, ShutdownSender) {
         .await
 }
 
-#[cfg(test)]
 mod types {
     use std::fmt::Display;
     use std::panic::{AssertUnwindSafe, RefUnwindSafe};

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1036,6 +1036,9 @@ impl AuthorityLeaderElectionState {
                             }
                         }
                     },
+                    |state: &ControllerState| {
+                        state.dataflow_state.schema_replication_offset().clone()
+                    },
                     |state: &mut ControllerState| {
                         state.dataflow_state.touch_up();
                     }

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -1957,6 +1957,9 @@ impl DfStateHandle {
                             Ok(state)
                         }
                     },
+                    |state: &ControllerState| {
+                        state.dataflow_state.schema_replication_offset().clone()
+                    },
                     |state: &mut ControllerState| {
                         state.dataflow_state.touch_up();
                     },

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -571,6 +571,7 @@ impl NoriaAdapter {
                 })?;
 
             if readyset_slot_exists {
+                info!(%full_resnapshot, %resnapshot, pos=?pos, "readyset_slot_exists");
                 if full_resnapshot || resnapshot || pos.is_none() {
                     // This is not an initial connection but we need to resnapshot the latest
                     // schema, therefore we create a new replication slot, just

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -895,7 +895,7 @@ impl<'a> PostgresReplicator<'a> {
         }
 
         // The current schema was replicated, assign the current position
-        debug!(%wal_position, "Setting schema replication offset");
+        debug!(%wal_position, "Setting schema replication offset after schema snapshot");
         self.noria
             .set_schema_replication_offset(Some(&wal_position))
             .await?;


### PR DESCRIPTION
If there aren't any replication events while performing a re-snapshot,
we can get stuck in the 'catching up' phase because the resnapshot
slot's lsn is higher than the main slot, and there aren't any
replication events to advance the current lsn while catching up.

This commit adds a no-op replication event so that we can catch up even
in this case.

