### PR TITLE
readyset-client: Rename ReadySetStatus

### DIFF
--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -30,7 +30,7 @@ use crate::internal::{DomainIndex, ReplicaAddress};
 use crate::metrics::MetricsDump;
 use crate::recipe::changelist::ChangeList;
 use crate::recipe::{ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
-use crate::status::ReadySetStatus;
+use crate::status::ReadySetControllerStatus;
 use crate::table::{PersistencePoint, Table, TableBuilder, TableRpc};
 use crate::view::{View, ViewBuilder, ViewRpc};
 use crate::{
@@ -920,8 +920,8 @@ impl ReadySetHandle {
     );
 
     simple_request!(
-        /// Returns the ReadySetStatus struct returned by the leader.
-        status() -> ReadySetStatus
+        /// Returns the ReadySetControllerStatus struct returned by the leader.
+        status() -> ReadySetControllerStatus
     );
 
     simple_request!(

--- a/readyset-client/src/status.rs
+++ b/readyset-client/src/status.rs
@@ -1,11 +1,11 @@
 //! System status information that can sent to a noria-client.
 //!
-//! When introducing new fields to the [`ReadySetStatus`] type, be sure to
+//! When introducing new fields to the [`ReadySetControllerStatus`] type, be sure to
 //! update support for converting the object to strings:
-//!   * `ReadySetStatus::try_from(_: Vec<(String, String)>)`
-//!   * `Vec<(String, String)>::from(_: ReadySetStatus)`
+//!   * `ReadySetControllerStatus::try_from(_: Vec<(String, String)>)`
+//!   * `Vec<(String, String)>::from(_: ReadySetControllerStatus)`
 //!
-//! These two conversions are used to convert the [`ReadySetStatus`] structs to a format
+//! These two conversions are used to convert the [`ReadySetControllerStatus`] structs to a format
 //! that can be passed to various SQL clients.
 use std::fmt::{self, Display};
 
@@ -18,12 +18,14 @@ const SNAPSHOT_STATUS_VARIABLE: &str = "Snapshot Status";
 const MAX_REPLICATION_OFFSET: &str = "Maximum Replication Offset";
 const MIN_REPLICATION_OFFSET: &str = "Minimum Replication Offset";
 
-/// ReadySetStatus holds information regarding the status of ReadySet, similar to
+/// ReadySetControllerStatus holds information regarding the controller status of ReadySet, similar
+/// to
+///
 /// [`SHOW STATUS`](https://dev.mysql.com/doc/refman/8.0/en/show-status.html) in MySQL.
 ///
 /// Returned via the /status RPC and SHOW READYSET STATUS.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-pub struct ReadySetStatus {
+pub struct ReadySetControllerStatus {
     /// The snapshot status of the current leader.
     pub snapshot_status: SnapshotStatus,
     /// The current maximum replication offset known by the leader.
@@ -32,8 +34,8 @@ pub struct ReadySetStatus {
     pub min_replication_offset: Option<ReplicationOffset>,
 }
 
-impl From<ReadySetStatus> for Vec<(String, String)> {
-    fn from(status: ReadySetStatus) -> Vec<(String, String)> {
+impl From<ReadySetControllerStatus> for Vec<(String, String)> {
+    fn from(status: ReadySetControllerStatus) -> Vec<(String, String)> {
         let mut res = vec![(
             SNAPSHOT_STATUS_VARIABLE.to_string(),
             status.snapshot_status.to_string(),

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -25,7 +25,7 @@ use readyset_client::debug::stats::PersistentStats;
 use readyset_client::internal::ReplicaAddress;
 use readyset_client::metrics::recorded;
 use readyset_client::recipe::{ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
-use readyset_client::status::{ReadySetStatus, SnapshotStatus};
+use readyset_client::status::{ReadySetControllerStatus, SnapshotStatus};
 use readyset_client::{GraphvizOptions, SingleKeyEviction, ViewCreateRequest, WorkerDescriptor};
 use readyset_errors::{internal_err, ReadySetError, ReadySetResult};
 use readyset_telemetry_reporter::TelemetrySender;
@@ -495,7 +495,7 @@ impl Leader {
                     None
                 };
 
-                let status = ReadySetStatus {
+                let status = ReadySetControllerStatus {
                     // Use whether the leader is ready or not as a proxy for if we have
                     // completed snapshotting.
                     snapshot_status: if leader_ready {


### PR DESCRIPTION
Rename the struct ReadySetStatus, which has the controller specific
fields the end up getting combined with other information at the adapter
layer to provide the response to a Show::ReadySetStatus request, so that
we can consolidate the fields together in a new struct named
ReadySetStatus that matches the full information for the `show readyset
status` request.

