### PR TITLE
nom-sql: Fix LimitOffset parsing/display 

### DIFF
--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -42,7 +42,9 @@ pub use self::literal::{
 };
 pub use self::order::{OrderBy, OrderClause, OrderType};
 pub use self::parser::*;
-pub use self::select::{CommonTableExpr, GroupByClause, JoinClause, LimitClause, SelectStatement};
+pub use self::select::{
+    CommonTableExpr, GroupByClause, JoinClause, LimitClause, LimitValue, SelectStatement,
+};
 pub use self::set::{
     PostgresParameterScope, PostgresParameterValue, PostgresParameterValueInner, SetNames,
     SetPostgresParameter, SetPostgresParameterValue, SetStatement, SetVariables, Variable,

--- a/query-generator/src/lib.rs
+++ b/query-generator/src/lib.rs
@@ -85,9 +85,9 @@ use nom_sql::{
     BinaryOperator, Column, ColumnConstraint, ColumnSpecification, CommonTableExpr,
     CreateTableBody, CreateTableStatement, Dialect as ParseDialect, Expr, FieldDefinitionExpr,
     FieldReference, FunctionExpr, InValue, ItemPlaceholder, JoinClause, JoinConstraint,
-    JoinOperator, JoinRightSide, LimitClause, Literal, OrderBy, OrderClause, OrderType, Relation,
-    SelectStatement, SqlIdentifier, SqlType, SqlTypeArbitraryOptions, TableExpr, TableExprInner,
-    TableKey,
+    JoinOperator, JoinRightSide, LimitClause, LimitValue, Literal, OrderBy, OrderClause, OrderType,
+    Relation, SelectStatement, SqlIdentifier, SqlType, SqlTypeArbitraryOptions, TableExpr,
+    TableExprInner, TableKey,
 };
 use parking_lot::Mutex;
 use proptest::arbitrary::{any, any_with, Arbitrary};
@@ -1956,7 +1956,7 @@ impl QueryOperation {
                 });
 
                 query.limit_clause = LimitClause::LimitOffset {
-                    limit: Some(Literal::Integer(*limit as _)),
+                    limit: Some(LimitValue::Literal(Literal::Integer(*limit as _))),
                     offset: None,
                 };
 
@@ -1997,12 +1997,12 @@ impl QueryOperation {
                 // we were using.
                 if matches!(query.limit_clause, LimitClause::OffsetCommaLimit { .. }) {
                     query.limit_clause = LimitClause::OffsetCommaLimit {
-                        limit: Literal::Integer(*limit as _),
+                        limit: LimitValue::Literal(Literal::Integer(*limit as _)),
                         offset: Literal::Integer((*limit * *page_number) as _),
                     }
                 } else {
                     query.limit_clause = LimitClause::LimitOffset {
-                        limit: Some(Literal::Integer(*limit as _)),
+                        limit: Some(LimitValue::Literal(Literal::Integer(*limit as _))),
                         offset: Some(Literal::Integer((*limit * *page_number) as _)),
                     };
                 }

--- a/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
+++ b/readyset-sql-passes/src/normalize_topk_with_aggregate.rs
@@ -106,7 +106,7 @@ impl NormalizeTopKWithAggregate for SqlQuery {
 
 #[cfg(test)]
 mod tests {
-    use nom_sql::{parse_query, Dialect, Expr, OrderClause, OrderType};
+    use nom_sql::{parse_query, Dialect, Expr, LimitValue, OrderClause, OrderType};
 
     use super::*;
 
@@ -194,7 +194,7 @@ mod tests {
                 assert_eq!(
                     stmt.limit_clause,
                     LimitClause::LimitOffset {
-                        limit: Some(4.into()),
+                        limit: Some(LimitValue::Literal(4.into())),
                         offset: None
                     }
                 );


### PR DESCRIPTION
Switch from generic parsing of SQL to having the PostgreSQL and MySQL cases specifically handled and allow for hopefully all of the available syntax choices for `LIMIT` and `OFFSET` for both.

There are 3 tests in `readyset-adapter` which fail with this diff specifically:
- `rewrite::tests::process_query::bare_offset_nonzero`
- `rewrite::tests::process_query::bare_offset_zero`
- `rewrite::tests::process_query::correct_offset_limit`

However they fail because they are trying to use `OFFSET` without `LIMIT` which is not valid for MySQL as far as I can tell. Would you like me to:

-  Change the tests to assert that they fail. I am not sure if that type of test belongs in that crate or not though.
-  Switch the tests to use `Dialect::PostgreSQL` or make that configurable because some use the `LIMIT <offset>, <limit>` syntax from MySQL.
-  Replace the tests with some other test (Recommendations here would be appreciated).
-  Remove the tests that use the invalid syntax (delete `bare_offset_nonzero` and `bare_offset_zero` and remove the specific case that does this from `correct_offset_limit`

I saw from the issue:

> Fully support the postgres limit offset spec and remove the limitations on the Arbitrary derivation that workaround our incomplete parsing so that a round-trip parsing test covers the full behavior.

I was not entirely sure on how to do that step so if there are other tests/cases that I should add please let me know.

Also I was not not entirely sure where certain validation should go and overall structure so feel free to let me know if this isn't idiomatic.

Hopefully resolves #610 