### PR TITLE
psql-srv: Don't run tls tests on mac os

### DIFF
--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -97,6 +97,7 @@ async fn run_server(backend: ScramSha256Backend) -> u16 {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "macos"))]
 async fn connect_scram_sha256_valid_password() {
     readyset_tracing::init_test_logging();
     let username = "user";
@@ -115,6 +116,7 @@ async fn connect_scram_sha256_valid_password() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "macos"))]
 async fn connect_scram_sha256_invalid_password() {
     readyset_tracing::init_test_logging();
     let username = "user";
@@ -134,6 +136,7 @@ async fn connect_scram_sha256_invalid_password() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "macos"))]
 async fn connect_scram_sha256_with_escapes_in_username_and_password() {
     readyset_tracing::init_test_logging();
     let username = "user=,=,=,user";
@@ -152,6 +155,7 @@ async fn connect_scram_sha256_with_escapes_in_username_and_password() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(not(target_os = "macos"))]
 async fn connect_scram_sha256_over_tls_with_channel_binding_required() {
     readyset_tracing::init_test_logging();
     let username = "user";

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -75,6 +75,7 @@ impl PsqlBackend for TestBackend {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg(not(target_os = "macos"))]
 async fn connect() {
     // Load the identity file as bytes (using relative path)
     let identity_file = include_bytes!("tls_certs/keyStore.p12");


### PR DESCRIPTION
These tests currently fail on mac, so conditionally only run them if the
platform is not mac. This allows our pipeline's `run-tests.sh` to pass
on M1 macs.

