### PR TITLE
pipeline: Restrict framework test prep to "Framework Tests" group

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,10 +15,12 @@ fi
 docker volume create target || true
 docker volume create cargo-registry || true
 
-## Setup for framework testing
-mkdir -pv .buildkite/gen .buildkite/image
-buildkite-agent artifact download '.buildkite/gen/*' ./ || true
-buildkite-agent artifact download '.buildkite/image/**/*.tar.gz' ./ || true
-find .buildkite/image -type f | while read -r tarball; do
-	docker load < "$tarball"
-done
+if [ -n "${BUILDKITE_GROUP_LABEL+x}" ] && [ "$BUILDKITE_GROUP_LABEL" == "Framework Tests" ]; then
+    ## Setup for framework testing
+    mkdir -pv .buildkite/gen .buildkite/image
+    buildkite-agent artifact download '.buildkite/gen/*' ./ || true
+    buildkite-agent artifact download '.buildkite/image/**/*.tar.gz' ./ || true
+    find .buildkite/image -type f | while read -r tarball; do
+        docker load < "$tarball"
+    done
+fi


### PR DESCRIPTION
The pre-command hook was trying to download the framework test generated
artifacts on every job.  That unnecessarily prolongs jobs (sometimes
over ten minutes!) that run after the framework tests but do not require
the artifacts.  This change will only perform the artifact download for
jobs in the "Framework Tests" group.

This is something of a brute force hammer.  A more precise solution
would be to have each generated framework test job download only the
artifact that it needs, and remove the download step from the
pre-command hook altogether.  However, do not let the Good become the
enemy of the Less Bad.

