### PR TITLE
build: Add debian package build to CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "readyset"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,9 @@ metrics-util = { git = "https://github.com/readysettech/metrics.git" }
 
 [profile.release]
 debug=true
+
+[profile.release-dist]
+# configs for distro release packages (i.e. deb, rpm, etc.)
+inherits = "release"
+debug = false
+strip = "debuginfo"

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readyset"
-version = "0.1.0"
+version = "1.0.0"
 publish = false
 authors = ["ReadySet Technology, Inc. <info@readyset.io>"]
 edition = "2021"
@@ -58,3 +58,20 @@ temp-dir = "0.1"
 
 [features]
 failure_injection = ["fail/failpoints", "readyset-client/failure_injection", "readyset-server/failure_injection"]
+
+[package.metadata.deb]
+maintainer = "ReadySet Technology <info@readyset.io>"
+copyright = "2023, ReadySet Technology, Inc."
+license-file = ["../LICENSE", "1"]
+extended-description = """\
+A real-time SQL caching engine for Postgres and MySQL."""
+depends = "$auto"
+section = "Databases"
+priority = "optional"
+assets = [
+    ["target/release/readyset", "usr/bin/", "755"],
+    ["debian/readyset.conf", "/etc/readyset/readyset.conf", "644"],
+    ["debian/systemd/readyset.service", "/lib/systemd/system/readyset.service", "644"],
+]
+maintainer-scripts = "debian/scripts"
+conf-files = ["/etc/readyset/readyset.conf"]

--- a/readyset/debian/readyset.conf
+++ b/readyset/debian/readyset.conf
@@ -1,0 +1,84 @@
+## Environment variables for readyset
+## Uncomment any of the following lines to change the defaults.
+
+## NOTE:  UPSTREAM_DB_URL and LISTEN_ADDRESS are required values and must be
+## updated before starting readyset.
+
+## URL for the upstream database to connect to. Should include username and
+## password if necessary (required).  Example:
+##    postgresql://readyset:readyset@127.0.0.1:5432/testdb
+UPSTREAM_DB_URL="protocol://user:password@hostaddr:port/dbname"
+
+## IP:PORT to listen on (required)
+LISTEN_ADDRESS=0.0.0.0:5433
+
+## Directory in which to store replicated table data.
+STORAGE_DIR=/var/lib/readyset
+
+## IP:PORT to host endpoint for scraping metrics from the adapter
+# METRICS_ADDRESS=0.0.0.0:6034
+
+## Format to use when emitting log events
+## Possible values:
+##   - compact: Corresponds to [`tracing_subscriber::fmt::format::Compact`]
+##   - full:    Corresponds to [`tracing_subscriber::fmt::format::Full`]
+##   - pretty:  Corresponds to [`tracing_subscriber::fmt::format::Pretty`]
+##   - json:    Corresponds to [`tracing_subscriber::fmt::format::Json`]
+# LOG_FORMAT=full
+
+## Log level filter for spans and events. The log level filter string is a
+## comma separated list of directives. See [`tracing_subscriber::EnvFilter`] for
+## full documentation on the directive syntax.
+## Examples:
+##    Log at INFO level for all crates and dependencies. ```bash LOG_LEVEL=info ```
+##    Log at TRACE level for all crates and dependencies except tower which
+##       should be logged at ERROR level. ```bash LOG_LEVEL=trace,tower=error ```
+# LOG_LEVEL=info
+
+## By default, ReadySet attempts to snapshot and replicate all tables in the #
+## database specified in UPSTREAM_DB_URL. However, if the queries to cache in
+## ReadySet access only a subset of tables in the database, this option can be
+## used to limit the tables ReadySet snapshots and replicates. Filtering out
+## tables that will not be used in caches will speed up the snapshotting
+## process. This option accepts a comma-separated list of `<schema>.<table>`
+## (specific table in a schema) or `<schema>.*` (all tables in a schema) for
+## Postgres and `<database>.<table>` for MySQL. Only tables specified in the list
+## will be eligible to be used by caches.
+# REPLICATION_TABLES=
+
+## By default, ReadySet attempts to snapshot and replicate all tables in the
+## database specified in UPSTREAM_DB_URL. However, if the queries to cache in
+## ReadySet will *not* access a subset of tables in the database, this option can
+## be used to limit the tables ReadySet snapshots and replicates. Filtering out
+## tables that will not be used in caches will speed up the snapshotting process.
+## This option accepts a comma-separated list of `<schema>.<table>` (specific
+## table in a schema) or `<schema>.*` (all tables in a schema) for Postgres and
+## `<database>.<table>` for MySQL. Tables specified in the list will not be
+## eligible to be used by caches.
+# REPLICATION_TABLES_IGNORE=
+
+## Memory high water mark, in bytes. If process heap memory exceeds this value,
+## we will perform evictions from partially materialized state. (0 = unlimited)
+# READYSET_MEMORY_LIMIT=0
+
+## The pkcs12 identity file (certificate and key) used by ReadySet for
+## establishing TLS connections as the server.  ReadySet will not accept TLS
+## connections if there is no identity file specified.
+# READYSET_IDENTITY_FILE=/path/to/file.p12
+
+## Authentication method to use for PostgreSQL clients
+## [possible values: cleartext, scram-sha-256]
+# POSTGRES_AUTHENTICATION_METHOD=scram-sha-256
+
+## A path to a pem or der certificate of the root that the upstream connection
+## will trust.
+# SSL_ROOT_CERT=
+
+## Allow ReadySet to start even if the file descriptor limit (ulimit -n) is
+## below our minimum requirement. If set, ReadySet still raises the soft limit to
+## min(our requirement, hard limit). It just doesn't treat (our requirement >
+## hard limit) as a fatal error.
+# IGNORE_ULIMIT_CHECK=
+
+## Whether to disable telemetry reporting.
+# DISABLE_TELEMETRY=false

--- a/readyset/debian/scripts/postinst
+++ b/readyset/debian/scripts/postinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+# Remove existing masks on readyset.service that might have been created by an earlier removal.
+deb-systemd-helper unmask readyset.service > /dev/null || true
+
+# was-enabled defaults to true, so new installations run enable.
+if deb-systemd-helper --quiet was-enabled readyset.service
+then
+    # Enables the unit on first installation, creates new
+    # symlinks on upgrades if the unit file has changed.
+    deb-systemd-helper enable readyset.service > /dev/null || true
+else
+    # Update the statefile to add new symlinks (if any), which need to be
+    # cleaned up on purge. Also remove old symlinks.
+    deb-systemd-helper update-state readyset.service > /dev/null || true
+fi
+
+# Print some instructions if package is being installed or configured.  Require the user to
+# acknowledge the message, since config update must take place before first run.
+if [ "$1" = "configure" ] || [ "$1" = "install" ]; then
+    cat << EOF
+
+Notice: The UPSTREAM_DB_URL and LISTEN_ADDRESS values must be set in
+/etc/readyset/readyset.conf before starting the readyset service.
+
+Press <Enter> to acknowledge this message.
+EOF
+    read -r REPLY
+fi
+
+# Ensure the script exits with a success status
+exit 0

--- a/readyset/debian/scripts/postrm
+++ b/readyset/debian/scripts/postrm
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+READYSET_DIR=/var/lib/readyset
+
+systemctl --system daemon-reload >/dev/null || true
+
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then
+    # Prevents service state from being changed (it was stopped by prerm).
+    deb-systemd-helper mask readyset.service >/dev/null
+fi
+
+if [ "$1" = "purge" ] || [ "$1" = "abort-install" ]; then
+    # Remove the readyset user and data dir.  The conf file will automatically be deleted.
+    if getent passwd readyset >/dev/null;
+    then
+        userdel readyset
+    fi
+    if [ -d ${READYSET_DIR} ] || [ -L ${READYSET_DIR} ];
+    then
+        rm -rf ${READYSET_DIR}
+    fi
+fi

--- a/readyset/debian/scripts/preinst
+++ b/readyset/debian/scripts/preinst
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+READYSET_DIR=/var/lib/readyset
+
+# Create readyset:readyset user/group and set homedir to /var/lib/readyset
+if [ "$1" = "install" ]; then
+    if ! getent group readyset >/dev/null; then
+        addgroup --system readyset >/dev/null
+    fi
+    if ! getent passwd readyset >/dev/null; then
+        adduser --ingroup readyset \
+            --system \
+            --disabled-login \
+            --home ${READYSET_DIR} \
+            --shell /bin/false \
+            --gecos "ReadySet Service" readyset >/dev/null
+    fi
+fi

--- a/readyset/debian/scripts/prerm
+++ b/readyset/debian/scripts/prerm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+deb-systemd-invoke stop readyset

--- a/readyset/debian/systemd/readyset.service
+++ b/readyset/debian/systemd/readyset.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=ReadySet standalone daemon
+AssertPathExists=/usr/bin/readyset
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+User=readyset
+Group=readyset
+Type=simple
+EnvironmentFile=/etc/readyset/readyset.conf
+ExecStart=/usr/bin/readyset
+KillMode=process
+Restart=on-failure
+RestartSec=30


### PR DESCRIPTION
Adds configs and scripts for producing a debian package which installs
readyset and sets it up as a systemd service.

Also adds a pipeline job that produces a debian package artifact as part
of the release pipeline.

