### PR TITLE
server: Update disk space check setting

### DIFF
--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -154,7 +154,7 @@ struct Options {
     /// available disk space to prevent potential failures during database snapshot operations.
     /// By default, the program will terminate if there's insufficient space. Enable this
     /// option to bypass the disk space check at startup.
-    #[arg(long)]
+    #[arg(long, hide = true, env = "NO_DISK_SPACE_CHECK")]
     no_disk_space_check: bool,
 }
 


### PR DESCRIPTION
This commit hides the disk space check setting from the help output of
our binaries and adds a `NO_DISK_SPACE_CHECK` env var for the setting.

