### PR TITLE
server: make readyset-server::check_disk_space() noop

### DIFF
--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -154,7 +154,8 @@ struct Options {
     /// available disk space to prevent potential failures during database snapshot operations.
     /// By default, the program will terminate if there's insufficient space. Enable this
     /// option to bypass the disk space check at startup.
-    #[arg(long, hide = true, env = "NO_DISK_SPACE_CHECK")]
+    // FIXME: REA-3587 temporarily revert - set 'no_disk_space_check' to true by default
+    #[arg(long, default_value = "true", hide = true)]
     no_disk_space_check: bool,
 }
 

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -431,7 +431,8 @@ pub struct Options {
     /// available disk space to prevent potential failures during database snapshot operations.
     /// By default, the program will terminate if there's insufficient space. Enable this
     /// option to bypass the disk space check at startup.
-    #[arg(long)]
+    // FIXME: REA-3587 temporarily revert - set 'no_disk_space_check' to true by default
+    #[arg(long, default_value = "true", hide = true)]
     pub no_disk_space_check: bool,
 }
 


### PR DESCRIPTION
Make this call noop due to bugs in the sys-info crate we use to get available
disk space until we find better solution.
Addresses: REA-3587

