### PR TITLE
quickstart: Add readyset_demo.sh script

### DIFF
--- a/.buildkite/test-demo.sh
+++ b/.buildkite/test-demo.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+################################################################################
+# ReadySet Demo Script test
+################################################################################
+#
+# This suite of tests uses expect(1) to interactively check the output of the
+# readyset demo script when provided with different inputs.
+#
+################################################################################
+
+# Path to the main script
+DEMO_SCRIPT="./quickstart/readyset_demo.sh"
+
+DEMO_SCRIPT_TMP=$(mktemp)
+
+# Suppress banner since it is fairly noisy
+sed '/^print_banner$/s/^/#/' "$DEMO_SCRIPT" > "$DEMO_SCRIPT_TMP"
+# rename localhost to work inside a docker container
+# If running locally on a mac, use this line to switch 127.0.0.1 with host.docker.internal.
+# sed 's/HOST="127.0.0.1"/HOST=host.docker.internal/' "$DEMO_SCRIPT_TMP" > "$DEMO_SCRIPT"
+# Use 172.17.0.1 for docker-in-docker on linux
+sed 's/HOST="127.0.0.1"/HOST=172.17.0.1/' "$DEMO_SCRIPT_TMP" > "$DEMO_SCRIPT"
+
+# Figure out how many times we need to press enter to run through the entire psql
+# interactive section of the demo.
+N_ENTERS=$(grep -c "Press enter" "$DEMO_SCRIPT_TMP")
+
+# Function to run the readyset demo automatically
+# Importing the sample data can take a few minutes, so there is a pretty long timeout.
+run_script() {
+    expect -d -c "
+        spawn bash $DEMO_SCRIPT
+
+        set timeout 8
+        send_user -- \"--- Testing colorful terminal prompt \n\"
+        expect -re \"Do you like colorful terminal output.*:\" {
+          send \"$1\r\"
+        }
+        if {\"$1\" == \"y\"} {
+          expect -re \"Good choice!\"
+        } else {
+          expect -re \"Very well.\"
+        }
+
+        send_user -- \"--- Testing Sample data detection \n\"
+        expect -re \".*Downloading the ReadySet Docker Compose file.*\" {}
+        expect -re \".*Running the ReadySet Docker Compose setup.*\" {}
+        expect -re \".*ReadySet Docker Compose setup complete.*\" {}
+        expect -re \".*Checking if sample data is already loaded.*\" {}
+
+        set timeout 30
+        expect {
+          -re \".*Sample data detected!.*\" {}
+          -re \".*No Sample data detected.*\" {}
+          timeout {
+            send_user -- \"FAIL: Timed out waiting for sample data check.\n\"
+            exit 1
+          }
+        }
+
+        send_user -- \"--- Testing import of sample data \n\"
+        expect -re \".*Import sample data.*\" {
+          send \"$2\r\"
+          if {\"$2\" == \"y\"} {
+            # Sample data takes a while to load.
+            set timeout 500
+            expect -re \".*Sample data imported successfully.*\" {}
+            set timeout 8
+          }
+        }
+
+        send_user -- \"--- Testing Explore sample data prompt \n\"
+        if {\"$2\" == \"y\"} {
+          expect -re \".*Explore sample data in psql.*\" {
+            send \"$2\r\"
+          }
+        }
+
+        send_user -- \"--- Testing interactive psql section \n\"
+        set timeout 8
+        if {\"$3\" == \"y\"} {
+            for {set i 0} {\$i < $N_ENTERS} {incr i} {
+                expect {
+                  -re \".*Press enter.*\" {
+                      send \"\r\"
+                    }
+                  -re \".*error:,*\" {
+                    send_user -- psql error encountered
+                    exit 1
+                  }
+                }
+            }
+        }
+
+        send_user -- \"--- Testing conclusion \n\"
+        expect -re \".*testdb\" {
+          send \"exit\r\n\"
+        }
+
+        expect {
+          -re \"Join us on slack:\" { exit 0 }
+          timeout { exit 1}
+        }
+
+        exit 1
+    "
+}
+
+test_combination() {
+    combo=$1;
+    section=$2
+
+    echo -e "Testing combination (colorful input?, import sample data? explore?) ${combo}"
+    read -ra answers <<< "$combo"
+    if ! run_script "${answers[0]}" "${answers[1]}" "${answers[2]}"; then
+        echo "Test failed for combination: $combo $section"
+        exit 1
+    else
+        echo "Test passed for combination: $combo $section"
+    fi
+}
+
+# If testing locally, it's convenient to automatically reset the initial state by
+# stopping the containers and removing the associated volumes.
+reset_docker_compose() {
+  if [ -f "readyset.compose.yml" ]; then
+    echo "'readyset.compose.yml' found. Running 'docker-compose down' to reset the environment."
+    docker-compose -f readyset.compose.yml down -v > /dev/null 2>&1
+  else
+    echo "'readyset.compose.yml' not found. Proceeding with the tests."
+  fi
+}
+
+################################################################################
+# Test different combinations of answers to branching prompts.
+#
+# Prompts:
+# 1. Color ouput? (always provided)
+# (2. Import sample data? (only valid if data is not already loaded))
+# 3. Explore sample data? (only provided if data is loaded)
+################################################################################
+test_all_combinations() {
+    reset_docker_compose
+
+    local combinations=("n n n" "y y y")
+
+    for combo in "${combinations[@]}"; do
+      test_combination "${combo}" "before sample data loaded"
+    done
+}
+
+# Make sure 'expect' is installed
+if ! which expect > /dev/null; then
+  exit 1
+fi
+
+test_all_combinations

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docker-compose.override.yml
 *.db
 *.auth
 .readyset-history
+readyset-compose.yml

--- a/quickstart/readyset_demo.sh
+++ b/quickstart/readyset_demo.sh
@@ -1,0 +1,372 @@
+#!/bin/bash -e
+
+HOST="127.0.0.1"
+CONNECTION_STRING="postgresql://postgres:readyset@${HOST}:5433/testdb"
+
+setup_colors() {
+  read -rp "Do you like colorful terminal output? (y/n, default y): " color_choice
+  color_choice=${color_choice:-y}
+  if [[ $color_choice == "y" ]]; then
+    echo -e "Good choice!"
+    export BLUE="\033[1;34m"
+    export GREEN="\033[1;32m"
+    export NOCOLOR="\033[0m"
+    export RED="\033[1;31m"
+    export YELLOW="\033[1;33m"
+    export APPLE="🍏"
+    export ELEPHANT="🐘"
+    export GLOBE="🌐"
+    export GREEN_CHECK="✅"
+    export INFO="ℹ️ "
+    export MAGNIFYING_GLASS="🔍"
+    export ROCKET="🚀"
+    export WARNING="⚠️ "
+    export WHALE="🐳"
+    export ROTATING_LIGHT="🚨"
+    export SUNGLASSES="😎"
+    export TADA="🎉"
+  else
+    echo -e "Very well."
+  fi
+}
+
+print_banner() {
+  echo ""
+  echo -e "${BLUE}██████╗ ███████╗ █████╗ ██████╗ ██╗   ██╗███████╗███████╗████████╗"
+  echo -e "${BLUE}██╔══██╗██╔════╝██╔══██╗██╔══██╗╚██╗ ██╔╝██╔════╝██╔════╝╚══██╔══╝"
+  echo -e "${BLUE}██████╔╝█████╗  ███████║██║  ██║ ╚████╔╝ ███████╗█████╗     ██║   "
+  echo -e "${BLUE}██╔══██╗██╔══╝  ██╔══██║██║  ██║  ╚██╔╝  ╚════██║██╔══╝     ██║   "
+  echo -e "${BLUE}██║  ██║███████╗██║  ██║██████╔╝   ██║   ███████║███████╗   ██║   "
+  echo -e "${BLUE}╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝    ╚═╝   ╚══════╝╚══════╝   ╚═╝   "
+  echo -e "${NOCOLOR}"
+}
+
+check_docker_dependencies() {
+  if ! command -v docker &>/dev/null; then
+    echo -e "${RED}Docker is not installed. Please install Docker to continue.${NOCOLOR}"
+    exit 1
+  elif ! docker ps &>/dev/null; then
+    echo -e "${RED}Docker is installed but not running. Please start Docker to continue.${NOCOLOR}"
+    exit 1
+  fi
+  if ! command -v docker-compose &>/dev/null; then
+    echo -e "${RED}Docker Compose is not installed. Please install Docker Compose to continue.${NOCOLOR}"
+    exit 1
+  fi
+}
+
+check_dependencies() {
+  if ! command -v psql &>/dev/null; then
+    echo -e "${RED}psql (PostgreSQL client) is not installed. Please install psql to continue.${NOCOLOR}"
+    exit 1
+  fi
+
+  if ! command -v curl &>/dev/null; then
+    echo -e "${RED}curl is not installed. How did you even get this script?! Please install curl to continue.${NOCOLOR}"
+    exit 1
+  fi
+}
+
+download_compose_file() {
+  echo -e "${BLUE}${WHALE}Downloading the ReadySet Docker Compose file... ${NOCOLOR}"
+  curl -Ls -o readyset.compose.yml "https://readyset.io/quickstart/compose.postgres.yml"
+}
+
+run_docker_compose() {
+  echo -e "${BLUE}${WHALE}Running the ReadySet Docker Compose setup... ${NOCOLOR}"
+  docker compose -f readyset.compose.yml pull > /dev/null 2>&1
+  docker compose -f readyset.compose.yml up -d > /dev/null 2>&1
+  echo -e "${GREEN}${GREEN_CHECK}ReadySet Docker Compose setup complete! ${NOCOLOR}"
+  echo -e "${INFO}To clean up, run \`docker-compose down\`"
+}
+
+check_sample_data() {
+  retry_count=0
+  max_retries=5
+  sleep_interval_secs=1
+
+  echo -e "${BLUE}${ELEPHANT}Checking if sample data is already loaded...${NOCOLOR}"
+  dots=""
+
+  while :; do
+    tables_exist=$(psql $CONNECTION_STRING -tAc "SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename IN ('title_basics', 'title_ratings'));" 2>/dev/null | head -n 1 | tr -d '[:space:]')
+
+    if [[ $tables_exist == "t" ]] || [[ $retry_count -eq $max_retries ]]; then
+      break
+    fi
+
+    dots+="."
+    echo -ne "$dots"
+    ((retry_count++))
+    sleep $sleep_interval_secs
+  done
+
+  echo ""
+  if [[ $tables_exist == "t" ]]; then
+    echo -e "${GREEN}${GREEN_CHECK}Sample data detected!${NOCOLOR}"
+  else
+    echo -e "${YELLOW}No Sample data detected.${NOCOLOR}"
+  fi
+}
+
+prompt_for_import() {
+  if [[ $tables_exist == "f" ]]; then
+    read -rp "Import sample data? (y/n, default: y): " import_choice
+    import_choice=${import_choice:-y}
+  fi
+}
+
+import_data() {
+  if [[ $import_choice == "y" ]]; then
+    if [ ! -f imdb-postgres.sql ]; then
+      echo -e "${BLUE}${ELEPHANT}Downloading IMDB sample data to imdb-postgres.sql...${NOCOLOR}"
+      curl -L "https://readyset.io/quickstart/imdb-postgres.sql" -o imdb-postgres.sql
+    else
+      echo "Sample data found."
+    fi
+
+    echo -e "${BLUE}${ELEPHANT}Importing sample data...${NOCOLOR}"
+    if command -v pv &>/dev/null; then
+      pv imdb-postgres.sql | psql $CONNECTION_STRING >/dev/null 2>&1
+    else
+      psql $CONNECTION_STRING <imdb-postgres.sql >/dev/null 2>&1
+    fi
+
+    echo -e "${GREEN}${GREEN_CHECK}Sample data imported successfully!${NOCOLOR}"
+  fi
+}
+
+display_arm_warning() {
+  if [[ $(uname -m) == "arm64" ]]; then
+    echo -e "${YELLOW}${WARNING}You are running on an ARM-based Machine, but ReadySet is currently built for x86_64."
+    echo -e "Query performance will be slower due to virtualization overhead.${NOCOLOR}"
+  fi
+}
+
+explore_data() {
+  if [[ $tables_exist == "t" ]] || [[ $import_choice == "y" ]]; then
+    read -rp "Explore sample data in psql? (y/n, default: y): " explore_choice
+    explore_choice=${explore_choice:-y}
+    if [[ $explore_choice == "y" ]]; then
+      echo -e "${BLUE}${MAGNIFYING_GLASS}Connecting to ReadySet to explore the dataset.${NOCOLOR}"
+  psql $CONNECTION_STRING <<EOF
+\set QUIET 1
+\o /dev/null
+-- In case we ran this before, reset the value that we will be changing.
+UPDATE title_ratings
+   SET averagerating = 2.5
+ WHERE tconst = 'tt0185183';
+-- Also drop the cache so that the uncached->miss->hit latencies work.
+-- TODO: Broken until REA-3724 is fixed
+-- DROP CACHE q_bccd97aea07c545f;
+\o
+\timing
+\! echo "${BLUE}Let's cache a query with ReadySet!${NOCOLOR}"
+\set QUIET 1
+\! echo 'Press enter to continue.'
+\prompt c
+\! echo "${BLUE}Here's the query we want to cache:${NOCOLOR}"
+\echo ''
+\echo '    SELECT count(*)'
+\echo '      FROM title_ratings'
+\echo '      JOIN title_basics'
+\echo '        ON title_ratings.tconst = title_basics.tconst'
+\echo '     WHERE title_basics.startyear = 2000'
+\echo '       AND title_ratings.averagerating > 5;'
+\echo ''
+\! echo "${BLUE}Let's run it once before caching.${NOCOLOR}"
+\echo 'Press enter to run query.'
+\prompt c
+
+\! echo '${YELLOW}Query Results:'
+SELECT count(*) FROM title_ratings
+JOIN title_basics ON title_ratings.tconst = title_basics.tconst
+WHERE title_basics.startyear = 2000
+AND title_ratings.averagerating > 5;
+\echo '${NOCOLOR}'
+\! echo "${RED}${ROTATING_LIGHT}Too slow! ${BLUE}Let's cache it.${SUNGLASSES}${NOCOLOR}"
+\echo ''
+\echo 'Press enter to continue.'
+\prompt c
+\echo '    CREATE CACHE FROM'
+\echo '       SELECT count(*)'
+\echo '         FROM title_ratings'
+\echo '         JOIN title_basics'
+\echo '           ON title_ratings.tconst = title_basics.tconst'
+\echo '        WHERE title_basics.startyear = 2000'
+\echo '          AND title_ratings.averagerating > 5;'
+\echo ''
+\echo 'Press enter to create the cache.'
+\prompt c
+\! echo '${GREEN}Query Results:'
+CREATE CACHE FROM
+    SELECT count(*)
+      FROM title_ratings
+      JOIN title_basics
+        ON title_ratings.tconst = title_basics.tconst
+     WHERE title_basics.startyear = 2000
+       AND title_ratings.averagerating > 5;
+\! echo "${NOCOLOR}"
+\! echo "${GREEN}${GREEN_CHECK}Cache created${NOCOLOR}"
+\! echo '${BLUE}Lets take a look at the cache we created.${NOCOLOR}'
+\echo ''
+\echo 'Press enter to run SHOW CACHES.'
+\prompt c
+SHOW CACHES;
+\! echo ''
+\! echo "${BLUE}It worked!${NOCOLOR}"
+\! echo "Press enter to continue."
+\prompt c
+\! echo "Let's re-run the query twice."
+\! echo "The first time will be a cache miss and populate the cache."
+\! echo "The second time will be a cache hit."
+\! echo ''
+\echo 'Press enter to re-run query.'
+\prompt c
+\! echo '${BLUE}Cache Miss Results:'
+SELECT count(*) FROM title_ratingsdt
+JOIN title_basics ON title_ratings.tconst = title_basics.tconst
+WHERE title_basics.startyear = 2000
+AND title_ratings.averagerating > 5;
+\! echo "${NOCOLOR}"
+\! echo "Press enter to re-run the query again."
+\prompt c
+\! echo '${GREEN}Cache Hit Results:'
+SELECT count(*) FROM title_ratings
+JOIN title_basics ON title_ratings.tconst = title_basics.tconst
+WHERE title_basics.startyear = 2000
+AND title_ratings.averagerating > 5;
+\! echo "${NOCOLOR}"
+\! echo "${GREEN}${TADA}Yay, it's faster!${NOCOLOR}"
+\! echo "Press enter to continue."
+\prompt c
+\! echo "${BLUE}Next, let's see how ReadySet updates the cache automatically when we change it.${NOCOLOR}"
+\echo 'Press enter to continue.'
+\prompt c
+\! echo "The query we have been running returns the count of movies in the year"
+\! echo "2000 that had a rating greater than 5/10 (2,418 movies)."
+\! echo ''
+\echo 'Press enter to continue.'
+\prompt c
+\! echo "'Battlefield Earth' was a movie released in '00 that received poor ratings."
+\! echo ''
+\echo 'Press enter to run query and see just how bad.'
+\prompt c
+\echo '    SELECT'
+\echo '      title_basics.tconst,'
+\echo '      title_basics.primarytitle,'
+\echo '      title_ratings.averagerating,'
+\echo '      title_ratings.numvotes '
+\echo '    FROM'
+\echo '      title_basics'
+\echo '    INNER JOIN'
+\echo '      title_ratings'
+\echo '    ON'
+\echo '      title_ratings.tconst = title_basics.tconst'
+\echo '    WHERE'
+\echo '      title_basics.primarytitle = 'Battlefield Earth';'
+\echo ''
+\! echo "${YELLOW}"
+SELECT
+ title_basics.tconst,
+ title_basics.primarytitle,
+ title_ratings.averagerating,
+ title_ratings.numvotes
+FROM
+ title_basics
+INNER JOIN
+ title_ratings
+ON
+ title_ratings.tconst = title_basics.tconst
+WHERE
+ title_basics.primarytitle = 'Battlefield Earth';
+\! echo "${NOCOLOR}"
+\echo 'Press enter to continue.'
+\prompt c
+\! echo "Looks like it scored an average rating of 2.5. Yikes."
+\! echo "It was, indeed, an awful movie. Nevertheless, historical revisionism is fun"
+\! echo "when you have full control of the data."
+\echo ''
+\echo 'Press enter to continue.'
+\prompt c
+\! echo "${BLUE}Let's grab the id for 'Battlefield Earth' (tt0185183) and update its average rating accordingly:${NOCOLOR}"
+\echo 'Press enter to change the course of cinematic history.'
+\prompt c
+\! echo "    UPDATE title_ratings"
+\! echo "       SET averagerating = 5.1"
+\! echo "     WHERE tconst = 'tt0185183';"
+\! echo ""
+UPDATE title_ratings
+   SET averagerating = 5.1
+ WHERE tconst = 'tt0185183';
+\! echo "${BLUE}Let's re-run the previously cached query that returns the count of movies:${NOCOLOR}"
+\echo 'Press enter to re-run query.'
+\prompt c
+\! echo '${GREEN}New Results:'
+SELECT count(*) FROM title_ratings
+JOIN title_basics ON title_ratings.tconst = title_basics.tconst
+WHERE title_basics.startyear = 2000
+AND title_ratings.averagerating > 5;
+
+\! echo "And bingo! The count has been increased by one (i.e 2,419 vs 2,418)."
+\! echo "${GREEN}${TADA}The cache is auto-updated!${NOCOLOR}"
+\! echo "And this time was still a cache hit. Not too shabby."
+\echo ''
+\echo 'Press enter to continue.'
+\prompt c
+\echo ''
+\! echo '${BLUE}This concludes our guided exploration.${NOCOLOR}'
+\echo ''
+\echo 'Press enter continue.'
+\prompt c
+\! echo '${BLUE}Give these commands a try next!${NOCOLOR}'
+\! echo ''
+\! echo ' ${BLUE}Show status info. about ReadySet.${NOCOLOR}'
+\! echo '    SHOW READYSET STATUS;'
+\! echo ' ${BLUE}List information about current caches${NOCOLOR}'
+\! echo '    SHOW CACHES;'
+\! echo ' ${BLUE}List tables that ReadySet has snapshotted${NOCOLOR}'
+\! echo '    SHOW READYSET TABLES;'
+\! echo ' ${BLUE}Show queries that havent been cached and if they are supported or not.${NOCOLOR}'
+\! echo '    SHOW PROXIED QUERIES;'
+\! echo " ${BLUE}Drop an existing cache.${NOCOLOR}"
+\! echo "    DROP CACHE [query_id];"
+\echo ''
+\echo 'Press enter to conclude and connect to readyset via psql.'
+\prompt c
+\unset QUIET
+\q
+EOF
+    fi
+  fi
+}
+
+free_form_connect() {
+  echo -e "${BLUE}Connecting to ReadySet...${NOCOLOR}"
+  echo -e "${BLUE}Type \q to exit.${NOCOLOR}"
+  psql $CONNECTION_STRING
+}
+
+
+print_exit_message() {
+  echo ""
+  echo -e "${BLUE}See ${NOCOLOR}https://docs.readyset.io/demo${BLUE} for more fun things to try.${NOCOLOR}"
+  echo ""
+  echo -e "${BLUE}Join us on slack:${NOCOLOR}"
+  echo "https://join.slack.com/t/readysetcommunity/shared_invite/zt-2272gtiz4-0024xeRJUPGWlRETQrGkFw"
+}
+
+# Main
+setup_colors
+print_banner
+check_docker_dependencies
+check_dependencies
+download_compose_file
+run_docker_compose
+check_sample_data
+prompt_for_import
+import_data
+display_arm_warning
+explore_data
+free_form_connect
+print_exit_message


### PR DESCRIPTION
This adds a bash script with the intention of automating the existing
demo. It provides some automation around running the docker containers
and seeding the sample database and an interactive prompt to guide a
user through the quickstart flow.

Along with the script is a testing script that uses `expect` to assert
on the main branches through the script, and pipelines to run the tests
and release the artifact when appropriate.

We run the demo script tests even if the demo script hasn't changed in
nightly to ensure that the demo hasn't broken because of a change in
readyset itself.

This commit also adds a Docker-in-Docker pipeline step to run the test,
and a Dockerfile to run that step locally for debugging. It was easier
to copy the simple install command into the step itself rather than have
a separate build step and to use the dockerfile in the pipeline itself.

