### PR TITLE
adapter: Support `DROP CACHE <query string>`

### DIFF
--- a/nom-sql/src/analysis/visit.rs
+++ b/nom-sql/src/analysis/visit.rs
@@ -362,7 +362,7 @@ pub trait Visitor<'ast>: Sized {
         &mut self,
         drop_cache_statement: &'ast DropCacheStatement,
     ) -> Result<(), Self::Error> {
-        walk_relation(self, &drop_cache_statement.name)
+        walk_drop_cache_statement(self, drop_cache_statement)
     }
 
     fn visit_drop_all_caches_statement(
@@ -1090,7 +1090,20 @@ pub fn walk_create_cache_statement<'a, V: Visitor<'a>>(
 ) -> Result<(), V::Error> {
     match &create_cache_statement.inner {
         Ok(CacheInner::Statement(stmt)) => visitor.visit_select_statement(stmt)?,
-        Ok(CacheInner::Id(_)) => {}
+        Ok(CacheInner::Id(id)) => visitor.visit_sql_identifier(id)?,
+        Err(_) => {}
+    }
+
+    Ok(())
+}
+
+pub fn walk_drop_cache_statement<'a, V: Visitor<'a>>(
+    visitor: &mut V,
+    drop_cache_statement: &'a DropCacheStatement,
+) -> Result<(), V::Error> {
+    match &drop_cache_statement.inner {
+        Ok(CacheInner::Statement(stmt)) => visitor.visit_select_statement(stmt)?,
+        Ok(CacheInner::Id(id)) => visitor.visit_sql_identifier(id)?,
         Err(_) => {}
     }
 

--- a/nom-sql/src/analysis/visit_mut.rs
+++ b/nom-sql/src/analysis/visit_mut.rs
@@ -377,7 +377,7 @@ pub trait VisitorMut<'ast>: Sized {
         &mut self,
         drop_cache_statement: &'ast mut DropCacheStatement,
     ) -> Result<(), Self::Error> {
-        walk_relation(self, &mut drop_cache_statement.name)
+        walk_drop_cache_statement(self, drop_cache_statement)
     }
 
     fn visit_drop_all_caches_statement(
@@ -1110,7 +1110,20 @@ pub fn walk_create_cache_statement<'a, V: VisitorMut<'a>>(
 ) -> Result<(), V::Error> {
     match &mut create_cache_statement.inner {
         Ok(CacheInner::Statement(stmt)) => visitor.visit_select_statement(stmt)?,
-        Ok(CacheInner::Id(_)) => {}
+        Ok(CacheInner::Id(id)) => visitor.visit_sql_identifier(id)?,
+        Err(_) => {}
+    }
+
+    Ok(())
+}
+
+pub fn walk_drop_cache_statement<'a, V: VisitorMut<'a>>(
+    visitor: &mut V,
+    drop_cache_statement: &'a mut DropCacheStatement,
+) -> Result<(), V::Error> {
+    match &mut drop_cache_statement.inner {
+        Ok(CacheInner::Statement(stmt)) => visitor.visit_select_statement(stmt)?,
+        Ok(CacheInner::Id(id)) => visitor.visit_sql_identifier(id)?,
         Err(_) => {}
     }
 

--- a/nom-sql/src/explain.rs
+++ b/nom-sql/src/explain.rs
@@ -9,8 +9,9 @@ use readyset_util::fmt::fmt_with;
 use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 
-use crate::common::{parse_fallible, statement_terminator, until_statement_terminator};
-use crate::create::cached_query_inner;
+use crate::common::{
+    cached_query_inner, parse_fallible, statement_terminator, until_statement_terminator,
+};
 use crate::table::relation;
 use crate::whitespace::whitespace1;
 use crate::{CacheInner, Dialect, DialectDisplay, NomSqlResult, Relation};

--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -18,10 +18,10 @@ pub use self::alter::{
 };
 pub use self::column::{Column, ColumnConstraint, ColumnSpecification};
 pub use self::comment::CommentStatement;
-pub use self::common::{FieldDefinitionExpr, FieldReference, IndexType, TableKey};
+pub use self::common::{CacheInner, FieldDefinitionExpr, FieldReference, IndexType, TableKey};
 pub use self::compound_select::{CompoundSelectOperator, CompoundSelectStatement};
 pub use self::create::{
-    CacheInner, CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
+    CreateCacheStatement, CreateTableBody, CreateTableStatement, CreateViewStatement,
     SelectSpecification,
 };
 pub use self::create_table_options::CreateTableOption;

--- a/nom-sql/src/parser.rs
+++ b/nom-sql/src/parser.rs
@@ -204,7 +204,6 @@ fn sql_query_part1(
             map(updating(dialect), SqlQuery::Update),
             map(set(dialect), SqlQuery::Set),
             map(view_creation(dialect), SqlQuery::CreateView),
-            map(drop_cached_query(dialect), SqlQuery::DropCache),
             map(drop_all_caches, SqlQuery::DropAllCaches),
             map(alter_table_statement(dialect), SqlQuery::AlterTable),
             map(start_transaction(dialect), SqlQuery::StartTransaction),
@@ -214,8 +213,9 @@ fn sql_query_part1(
             map(use_statement(dialect), SqlQuery::Use),
             map(show(dialect), SqlQuery::Show),
             map(explain_statement(dialect), SqlQuery::Explain),
-            // This does a more expensive clone of `i`, so process it last.
+            // These parsers do more expensive clones of `i`, so process them last.
             map(create_cached_query(dialect), SqlQuery::CreateCache),
+            map(drop_cached_query(dialect), SqlQuery::DropCache),
         ))(i)
     }
 }


### PR DESCRIPTION
This commit adds support for passing a query string to the `DROP CACHE`
SQL extension. The query string passed need not necessarily be the
rewritten, parameterized query string; similar to `CREATE CACHE FROM`, a
query with bound parameters (i.e. a query with literals instead of the
placeholders) will be parsed and rewritten before it is used to look up
an existing cache.

Release-Note-Core: Added support for passing a query string directly to
  `DROP CACHE`
