### PR TITLE
buildkite: Improve handling of spot instance reclamation

### DIFF
--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -2,8 +2,11 @@
 common_values:
   retry: &retry_on_agent_kill
     automatic: &agent_kill_conditions
-      - exit_status: -1  # Agent was lost
-        limit: 2
+      - signal_reason: agent_stop  # spot instance killed by AWS
+        limit: 3
+      - exit_status: -1            # agent timed out
+        signal_reason: none
+        limit: 3
 
 steps:
   - label: ':clojure: Run jepsen test with --help'

--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -4,9 +4,11 @@
 common_values:
   retry: &retry_on_agent_kill
     automatic: &agent_kill_conditions
-      - exit_status: -1  # Agent was lost
-        limit: 2
-
+      - signal_reason: agent_stop  # spot instance killed by AWS
+        limit: 3
+      - exit_status: -1            # agent timed out
+        signal_reason: none
+        limit: 3
 steps:
 
   - label: ':rust: Check rustfmt'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,8 +6,11 @@
 common_values:
   retry: &retry_on_agent_kill
     automatic: &agent_kill_conditions
-      - exit_status: -1  # Agent was lost
-        limit: 2
+      - signal_reason: agent_stop  # spot instance killed by AWS
+        limit: 3
+      - exit_status: -1            # agent timed out
+        signal_reason: none
+        limit: 3
 
 steps:
   # TODO: ronh: decide what kind of linting we want in the OSS pipeline


### PR DESCRIPTION
The EC2 spot instances we use in CI are subject to sudden reclamation by
AWS.  The retry logic that was being used would auto-retry the job based
on exit status, but spot instance reclamation doesn't return a
consistent exit status.  The approach in this update will also retry if
a kill signal was sent to the job because the agent was stopped. That
should provide more accurate detection of spot instance reclamation.

See: https://buildkite.com/changelog/\
193-signal-and-signal-reason-in-automatic-retry-rules

