### PR TITLE
buildkite: Upgrade ECR plugin everywhere to latest 2.7.0

### DIFF
--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -18,7 +18,7 @@ steps:
     plugins:
       docker#v3.8.0:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
-      ecr#v2.5.0:
+      ecr#v2.7.0:
         login: true
         retries: 3
     retry: *retry_on_agent_kill
@@ -32,7 +32,7 @@ steps:
     plugins:
       docker#v3.8.0:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
-      ecr#v2.5.0:
+      ecr#v2.7.0:
         login: true
         retries: 3
     retry: *retry_on_agent_kill
@@ -46,7 +46,7 @@ steps:
     plugins:
       docker#v3.8.0:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
-      ecr#v2.5.0:
+      ecr#v2.7.0:
         login: true
         retries: 3
     retry: *retry_on_agent_kill

--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -28,7 +28,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
-      - ecr#v2.5.0:
+      - ecr#v2.7.0:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -48,7 +48,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
-      - ecr#v2.5.0:
+      - ecr#v2.7.0:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -71,7 +71,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
-      - ecr#v2.5.0:
+      - ecr#v2.7.0:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -102,7 +102,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           mount-buildkite-agent: true
           pull-retries: 3
-      - ecr#v2.5.0:
+      - ecr#v2.7.0:
           login: true
           retries: 3
     agents:
@@ -132,7 +132,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           pull-retries: 3
-      - ecr#v2.5.0:
+      - ecr#v2.7.0:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -161,7 +161,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           pull-retries: 3
-      - ecr#v2.5.0:
+      - ecr#v2.7.0:
           login: true
           retries: 3
     retry: *retry_on_agent_kill

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -27,7 +27,7 @@ steps:
     commands:
       - '.buildkite/build-image.sh build/Dockerfile readyset-build .'
     plugins:
-      ecr#v2.5.0:
+      ecr#v2.7.0:
         login: true
         retries: 3
     retry: *retry_on_agent_kill
@@ -39,7 +39,7 @@ steps:
     env:
       VERSION: "${BUILDKITE_COMMIT}"
     plugins:
-      ecr#v2.5.0:
+      ecr#v2.7.0:
         login: true
         retries: 3
     retry: *retry_on_agent_kill


### PR DESCRIPTION
The plugin has moved on, and so should we.  No breaking reason, just
staying up-to-date _before_ there's a breaking reason.

