### PR TITLE
demo: add width to 'pv' command

### DIFF
--- a/quickstart/readyset_demo.sh
+++ b/quickstart/readyset_demo.sh
@@ -129,7 +129,7 @@ import_data() {
 
     echo -e "${BLUE}${ELEPHANT}Importing sample data...${NOCOLOR}"
     if command -v pv &>/dev/null; then
-      pv imdb-postgres.sql | psql $CONNECTION_STRING >/dev/null 2>&1
+      pv -w 80 imdb-postgres.sql | psql $CONNECTION_STRING >/dev/null 2>&1
     else
       echo -e "This may take a few minutes. Install \`pv\` if you would like to see a progress bar for this step."
       psql $CONNECTION_STRING < imdb-postgres.sql >/dev/null 2>&1


### PR DESCRIPTION
This minor tweak adds a fixed width to the 'pv' output so that it
doesn't stretch across a very wide terminal.

Since we are suppressing debug output in the tests now, this also
installs pv on our docker container as it will no longer be overly noisy
in the test logs.

