### PR TITLE
adapter: Make `SHOW CACHES` persistent

### DIFF
--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -50,7 +50,7 @@ pub use self::set::{
     SetPostgresParameter, SetPostgresParameterValue, SetStatement, SetVariables, Variable,
     VariableScope,
 };
-pub use self::show::ShowStatement;
+pub use self::show::{QueryID, ShowStatement};
 pub use self::sql_identifier::SqlIdentifier;
 pub use self::sql_type::{EnumVariants, SqlType, SqlTypeArbitraryOptions};
 pub use self::table::{

--- a/readyset-adapter/src/migration_handler.rs
+++ b/readyset-adapter/src/migration_handler.rs
@@ -25,7 +25,6 @@ use tracing::{debug, error, info, instrument};
 
 use crate::backend::NoriaConnector;
 use crate::query_status_cache::QueryStatusCache;
-use crate::utils;
 
 pub struct MigrationHandler {
     /// Connection used to issue prepare requests to ReadySet.
@@ -331,8 +330,10 @@ impl MigrationHandler {
                 .update_query_migration_state(view_request, MigrationState::Unsupported);
             return;
         }
-        let qname =
-            utils::generate_query_name(&view_request.statement, &view_request.schema_search_path);
+        let qname = readyset_client::query::generate_id(
+            &view_request.statement,
+            &view_request.schema_search_path,
+        );
 
         // We do not need to provide a real "create cache" String for a dry run migration
         let changelist = ChangeList::from_change(

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use nom_sql::analysis::visit::{self, Visitor};
 use nom_sql::{
     BinaryOperator, Column, ColumnConstraint, CreateTableBody, DeleteStatement, Expr,
-    InsertStatement, Literal, SelectStatement, SqlIdentifier, SqlQuery, TableKey, UpdateStatement,
+    InsertStatement, Literal, SelectStatement, SqlQuery, TableKey, UpdateStatement,
 };
 use readyset_client::{ColumnSchema, Modification, Operation};
 use readyset_data::{DfType, DfValue, Dialect};
@@ -14,7 +14,6 @@ use readyset_errors::{
     bad_request_err, invalid_query, invalid_query_err, invariant, invariant_eq, unsupported,
     unsupported_err, ReadySetResult,
 };
-use readyset_util::hash::hash;
 
 /// Helper for flatten_conditional - returns true if the
 /// expression is "valid" (i.e. not something like `a = 1 AND a = 2`.
@@ -589,13 +588,6 @@ pub(crate) fn coerce_params(
     } else {
         Ok(None)
     }
-}
-
-pub(crate) fn generate_query_name(
-    statement: &nom_sql::SelectStatement,
-    schema_search_path: &[SqlIdentifier],
-) -> String {
-    format!("q_{:x}", hash(&(statement, schema_search_path)))
 }
 
 pub(crate) fn create_dummy_column(name: &str) -> ColumnSchema {

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use futures_util::future;
 use hyper::client::HttpConnector;
-use nom_sql::{CreateCacheStatement, NonReplicatedRelation, Relation};
+use nom_sql::{NonReplicatedRelation, Relation};
 use parking_lot::RwLock;
 use petgraph::graph::NodeIndex;
 use readyset_errors::{
@@ -29,7 +29,7 @@ use crate::debug::stats;
 use crate::internal::{DomainIndex, ReplicaAddress};
 use crate::metrics::MetricsDump;
 use crate::recipe::changelist::ChangeList;
-use crate::recipe::{ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
+use crate::recipe::{CreateCache, ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
 use crate::status::ReadySetControllerStatus;
 use crate::table::{PersistencePoint, Table, TableBuilder, TableRpc};
 use crate::view::{View, ViewBuilder, ViewRpc};
@@ -489,7 +489,7 @@ impl ReadySetHandle {
     ///
     /// `Self::poll_ready` must have returned `Async::Ready` before you call
     /// this method.
-    pub async fn verbose_views(&mut self) -> ReadySetResult<Vec<CreateCacheStatement>> {
+    pub async fn verbose_views(&mut self) -> ReadySetResult<Vec<CreateCache>> {
         self.simple_post_request("verbose_views").await
     }
 

--- a/readyset-client/src/query.rs
+++ b/readyset-client/src/query.rs
@@ -11,7 +11,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use nom_sql::DialectDisplay;
+use nom_sql::{DialectDisplay, QueryID, SelectStatement, SqlIdentifier};
 use readyset_data::DfValue;
 use readyset_sql_passes::anonymize::{Anonymize, Anonymizer};
 use readyset_util::fmt::fmt_with;
@@ -43,6 +43,14 @@ impl Display for QueryId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "q_{:x}", self.0)
     }
+}
+
+/// Generates the ID for a given [`SelectStatement`] and schema search path.
+///
+/// NOTE: The given statement should have already undergone the rewrites via
+/// `readyset_adapter::rewrites::process_query`.
+pub fn generate_id(stmt: &SelectStatement, schema_search_path: &[SqlIdentifier]) -> QueryID {
+    format!("q_{:x}", hash(&(stmt, schema_search_path)))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq)]

--- a/readyset-client/src/recipe/mod.rs
+++ b/readyset-client/src/recipe/mod.rs
@@ -5,11 +5,12 @@ pub mod changelist;
 use std::borrow::Cow;
 use std::fmt::Display;
 
+use nom_sql::{CreateTableBody, SelectSpecification, SelectStatement};
 use readyset_errors::ReadySetError;
 use serde::{Deserialize, Serialize};
 
-pub use crate::recipe::changelist::ChangeList;
-use crate::ReplicationOffset;
+pub use crate::recipe::changelist::{ChangeList, PostgresTableMetadata};
+use crate::{Relation, ReplicationOffset};
 
 /// Represents a request to extend a recipe
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -89,4 +90,25 @@ impl MigrationStatus {
     pub fn is_pending(&self) -> bool {
         matches!(self, Self::Pending)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateCache {
+    pub name: Relation,
+    pub statement: SelectStatement,
+    pub always: bool,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateTable {
+    pub name: Relation,
+    pub body: CreateTableBody,
+    pub pg_meta: Option<PostgresTableMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateView {
+    pub name: Relation,
+    pub definition: SelectSpecification,
 }


### PR DESCRIPTION
Previously, the `SHOW CACHES` command pulled information from the query
status cache. This meant that after a restart, an existing cache would
only be visible via `SHOW CACHES` after the adapter handled a query
against that cache. `EXPLAIN CACHES` was the only source of truth for
the current set of caches, since it relied on querying the controller
to pull information from the expression registry.

This commit changes `SHOW CACHES` to use the expression registry, just
like `EXPLAIN CACHES`. It also adds the query ID to the expression
registry, since that data is needed in `SHOW CACHES`.

Release-Note-Core: Made the list of caches in `SHOW CACHES` persist
  after a restart
