### PR TITLE
adapter: Move rewrite to readyset-sql-passes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,6 +5109,7 @@ dependencies = [
 name = "readyset-sql-passes"
 version = "0.0.1"
 dependencies = [
+ "criterion",
  "dataflow-expression",
  "itertools",
  "nom-sql",

--- a/readyset-adapter/Cargo.toml
+++ b/readyset-adapter/Cargo.toml
@@ -77,10 +77,6 @@ rand = "0.8.5"
 path = "src/lib.rs"
 
 [[bench]]
-name = "rewrite"
-harness = false
-
-[[bench]]
 name = "parse"
 harness = false
 

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -23,13 +23,13 @@ use readyset_errors::{
     ReadySetResult,
 };
 use readyset_server::worker::readers::{CallResult, ReadRequestHandler};
+use readyset_sql_passes::adapter_rewrites::{self, ProcessedQueryParams};
 use readyset_util::redacted::Sensitive;
 use readyset_util::shared_cache::{self, LocalCache};
 use tokio::sync::RwLock;
 use tracing::{error, info, instrument, trace, warn};
 
 use crate::backend::SelectSchema;
-use crate::rewrite::{self, ProcessedQueryParams};
 use crate::utils;
 
 #[derive(Clone, Debug)]
@@ -1366,7 +1366,7 @@ impl NoriaConnector {
 
         trace!("select::collapse where-in clauses");
         let processed_query_params =
-            rewrite::process_query(&mut statement, self.server_supports_pagination())?;
+            adapter_rewrites::process_query(&mut statement, self.server_supports_pagination())?;
 
         // check if we already have this query prepared
         trace!("select::access view");

--- a/readyset-adapter/src/lib.rs
+++ b/readyset-adapter/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(async_closure)]
 #![feature(never_type)]
 #![feature(exhaustive_patterns)]
-#![feature(is_sorted)]
 #![feature(if_let_guard)]
 #![deny(unreachable_pub)]
 pub mod backend;
@@ -13,7 +12,6 @@ pub mod migration_handler;
 pub mod proxied_queries_reporter;
 mod query_handler;
 pub mod query_status_cache;
-pub mod rewrite;
 mod status_reporter;
 pub mod upstream_database;
 mod utils;

--- a/readyset-sql-passes/Cargo.toml
+++ b/readyset-sql-passes/Cargo.toml
@@ -16,3 +16,11 @@ nom-sql = { path = "../nom-sql" }
 readyset-errors = { path = "../readyset-errors" }
 readyset-data = { path = "../readyset-data" }
 dataflow-expression = { path = "../dataflow-expression" }
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "adapter_rewrites"
+harness = false
+

--- a/readyset-sql-passes/benches/adapter_rewrites.rs
+++ b/readyset-sql-passes/benches/adapter_rewrites.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Bencher, Criterion};
 use nom_sql::{parse_select_statement, Dialect};
-use readyset_adapter::rewrite;
+use readyset_sql_passes::adapter_rewrites;
 
 fn auto_parametrize_query(c: &mut Criterion) {
     let run_benchmark = |b: &mut Bencher, src: &str| {
@@ -8,7 +8,7 @@ fn auto_parametrize_query(c: &mut Criterion) {
         b.iter_batched(
             || q.clone(),
             |mut q| {
-                rewrite::auto_parametrize_query(&mut q);
+                adapter_rewrites::auto_parametrize_query(&mut q);
                 black_box(q)
             },
             BatchSize::SmallInput,

--- a/readyset-sql-passes/src/adapter_rewrites.rs
+++ b/readyset-sql-passes/src/adapter_rewrites.rs
@@ -96,7 +96,7 @@ pub fn process_query(
 impl ProcessedQueryParams {
     /// If the query has values for OFFSET or LIMIT, get their values, returning a tuple of `limit,
     /// offset`
-    pub(crate) fn limit_offset_params(
+    pub fn limit_offset_params(
         &self,
         params: &[DfValue],
     ) -> ReadySetResult<(Option<usize>, Option<usize>)> {
@@ -163,10 +163,7 @@ impl ProcessedQueryParams {
         }
     }
 
-    pub(crate) fn make_keys<'param, T>(
-        &self,
-        params: &'param [T],
-    ) -> ReadySetResult<Vec<Cow<'param, [T]>>>
+    pub fn make_keys<'param, T>(&self, params: &'param [T]) -> ReadySetResult<Vec<Cow<'param, [T]>>>
     where
         T: Clone + TryFrom<Literal, Error = ReadySetError> + Debug + Default + PartialEq,
     {

--- a/readyset-sql-passes/src/lib.rs
+++ b/readyset-sql-passes/src/lib.rs
@@ -4,9 +4,11 @@
     never_type,
     exhaustive_patterns,
     try_find,
-    let_chains
+    let_chains,
+    is_sorted
 )]
 
+pub mod adapter_rewrites;
 pub mod alias_removal;
 pub mod anonymize;
 mod create_table_columns;

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -7,6 +7,7 @@ use readyset_client::query::QueryId;
 use readyset_client_metrics::{
     recorded, DatabaseType, EventType, QueryExecutionEvent, QueryLogMode, SqlQueryType,
 };
+use readyset_sql_passes::adapter_rewrites;
 use readyset_sql_passes::anonymize::anonymize_literals;
 use readyset_util::shutdown::ShutdownReceiver;
 use tokio::select;
@@ -178,7 +179,7 @@ impl QueryLogger {
         SharedString::from(match query {
             SqlQuery::Select(stmt) => {
                 let mut stmt = stmt.clone();
-                if readyset_adapter::rewrite::process_query(&mut stmt, true).is_ok() {
+                if adapter_rewrites::process_query(&mut stmt, true).is_ok() {
                     anonymize_literals(&mut stmt);
                     // FIXME(REA-2168): Use correct dialect.
                     stmt.display(nom_sql::Dialect::MySQL).to_string()


### PR DESCRIPTION
This commit moves the adapter rewrite passes into the
`readyset-sql-passes` crate. This sets the stage for a future
change, in which the server will need to perform adapter rewrites
when recreating caches after a backwards-incompatible upgrade.

