### PR TITLE
upgrades: Handle rewrites during recreation

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2227,7 +2227,7 @@ where
         let proxy_out_of_band = settings.migration_mode != MigrationMode::InRequestPath
             && status.migration_state != MigrationState::Successful;
         let unsupported_or_dropped = matches!(
-            status.migration_state,
+            &status.migration_state,
             MigrationState::Unsupported | MigrationState::Dropped
         );
         let exceeded_network_failure = status

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -43,9 +43,12 @@ use nom_sql::{
 };
 use readyset_data::DfType;
 use readyset_errors::{internal, unsupported, ReadySetError, ReadySetResult};
+use readyset_sql_passes::adapter_rewrites;
 use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 use tracing::error;
+
+use crate::consensus::CacheDDLRequest;
 
 /// The specification for a list of changes that must be made
 /// to the MIR and dataflow graphs.
@@ -475,14 +478,13 @@ impl Change {
         }
     }
 
-    /// Parse a `Change` from the given SQL string, using the given [`Dialect`] and schema search
-    /// path for expression evaluation semantics
-    pub fn from_str<S>(s: S, dialect: nom_sql::Dialect) -> ReadySetResult<Self>
-    where
-        S: AsRef<str>,
-    {
-        let query = s.as_ref();
-
+    /// Parse a `Change` from the given [`CacheDDLRequest`], using the encapsulated [`Dialect`] and
+    /// schema search path for expression evaluation semantics. This function performs the adapter
+    /// rewrites on the parsed query string before passing it to the server via `/extend_recipe`.
+    pub fn from_cache_ddl_request(
+        ddl_req: &CacheDDLRequest,
+        server_supports_pagination: bool,
+    ) -> ReadySetResult<Self> {
         macro_rules! mk_error {
             ($str:expr) => {
                 Err(ReadySetError::UnparseableQuery {
@@ -490,31 +492,29 @@ impl Change {
                 })
             };
         }
-        match parse::query_expr_with_dialect(LocatedSpan::new(query.as_bytes()), dialect) {
+        match parse::query_expr_with_dialect(
+            LocatedSpan::new(ddl_req.unparsed_stmt.as_bytes()),
+            ddl_req.dialect.into(),
+        ) {
             Result::Err(nom::Err::Error(e)) => {
                 mk_error!(std::str::from_utf8(&e.input).unwrap())
             }
             Result::Err(nom::Err::Failure(e)) => {
                 mk_error!(std::str::from_utf8(&e.input).unwrap())
             }
-            Result::Err(_) => mk_error!(query),
+            Result::Err(_) => mk_error!(ddl_req.unparsed_stmt),
             Result::Ok((remainder, parsed)) => {
                 if !remainder.is_empty() {
                     return mk_error!(std::str::from_utf8(&remainder).unwrap());
                 }
                 Ok(match parsed {
-                    SqlQuery::CreateTable(statement) => Change::CreateTable {
-                        statement,
-                        pg_meta: None,
-                    },
-                    SqlQuery::CreateView(cvs) => Change::CreateView(cvs),
                     SqlQuery::CreateCache(CreateCacheStatement {
                         name,
                         inner,
                         always,
                         ..
                     }) => {
-                        let statement = match inner {
+                        let mut statement = match inner {
                             Ok(CacheInner::Statement(stmt)) => stmt,
                             Ok(CacheInner::Id(id)) => {
                                 error!(
@@ -528,27 +528,24 @@ impl Change {
                             }
                             Err(query) => return Err(ReadySetError::UnparseableQuery { query }),
                         };
+
+                        adapter_rewrites::process_query(
+                            &mut statement,
+                            server_supports_pagination,
+                        )?;
+
                         Change::CreateCache(CreateCache {
                             name,
                             statement,
                             always,
                         })
                     }
-                    SqlQuery::AlterTable(ats) => Change::AlterTable(ats),
-                    SqlQuery::DropTable(_) => {
-                        unsupported!("DropTable maps to multiple Changes and can't be contructed with as_str");
-                    }
-                    SqlQuery::DropView(_) => {
-                        unsupported!(
-                            "DropView maps to multiple Changes and can't be contructed with as_str"
-                        );
-                    }
                     SqlQuery::DropCache(dcs) => Change::Drop {
                         name: dcs.name,
                         if_exists: false,
                     },
                     _ => unsupported!(
-                        "Only DDL statements supported as Change (got {})",
+                        "CacheDDLRequests can only contain `CREATE CACHE` or `DROP CACHE` statements (got {})",
                         parsed.query_type()
                     ),
                 })

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -527,8 +527,7 @@ impl Leader {
             }
             (&Method::GET | &Method::POST, "/supports_pagination") => {
                 let ds = self.dataflow_state_handle.read().await;
-                let supports =
-                    ds.recipe.mir_config().allow_paginate && ds.recipe.mir_config().allow_topk;
+                let supports = ds.recipe.supports_pagination();
                 return_serialized!(supports)
             }
             (&Method::POST, "/evict_single") => {

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -194,4 +194,9 @@ impl Recipe {
     pub fn reused_caches(&self, name: &Relation) -> Option<&Vec1<MatchedCache>> {
         self.inc.registry.reused_caches(name)
     }
+
+    /// Returns true only if this recipe supports pagination.
+    pub(crate) fn supports_pagination(&self) -> bool {
+        self.mir_config().allow_paginate && self.mir_config().allow_topk
+    }
 }


### PR DESCRIPTION
Previously, the logic that handles recreating caches after a
backwards-incompatible upgrade was not handling situations where `CREATE
CACHE` statements contained SQL strings that had not been rewritten by
the adapter, which resulted in the creation of incorrect query graphs.
This commit fixes the issue by performing the adapter rewrites on the
SQL strings embedded in the `CacheDDLRequest`s before invoking
"/extend_recipe" on the controller.

Fixes: REA-3894
Release-Note-Core: Fixed an issue where caches sometimes weren't being
  recreated correctly after backwards-incompatible upgrades
