### PR TITLE
adapter+server: Refactor query IDs

### DIFF
--- a/nom-sql/src/show.rs
+++ b/nom-sql/src/show.rs
@@ -17,13 +17,11 @@ use crate::expression::expression;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{literal, Dialect, DialectDisplay, Expr, Literal, NomSqlResult};
 
-pub type QueryID = String;
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ShowStatement {
     Events,
     Tables(Tables),
-    CachedQueries(Option<QueryID>),
+    CachedQueries(Option<String>),
     ProxiedQueries(ProxiedQueriesOptions),
     ReadySetStatus,
     ReadySetStatusAdapter,

--- a/readyset-adapter/benches/parse.rs
+++ b/readyset-adapter/benches/parse.rs
@@ -3,7 +3,6 @@ use lru::LruCache;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 use readyset_client::query::QueryId;
-use readyset_util::hash::hash;
 
 fn random_string(len: usize) -> String {
     rand::thread_rng()
@@ -41,7 +40,7 @@ fn lru_benchmarks(c: &mut Criterion) {
             |b, &_| {
                 b.iter(|| {
                     for q in queries.iter() {
-                        let id = QueryId::new(hash(&q));
+                        let id = QueryId::from_unparsed_select(q);
                         lru_cache_hash.put(black_box(id), black_box(q.clone()));
                     }
                 });

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2700,7 +2700,7 @@ where
                     if self.settings.query_log_mode.allow_ad_hoc() {
                         event.query =
                             Some(Arc::new(SqlQuery::Select(view_request.statement.clone())));
-                        event.query_id = Some(QueryId::from_view_create_request(&view_request));
+                        event.query_id = Some(QueryId::from(&view_request));
                     }
                     Self::query_adhoc_select(
                         &mut self.noria,

--- a/readyset-adapter/src/proxied_queries_reporter.rs
+++ b/readyset-adapter/src/proxied_queries_reporter.rs
@@ -99,7 +99,7 @@ mod tests {
         ));
         let proxied_queries_reporter = Arc::new(ProxiedQueriesReporter::new(query_status_cache));
 
-        let query_id = QueryId::new(42);
+        let query_id = QueryId::from_unparsed_select("test");
         let mut init_q = DeniedQuery {
             id: query_id,
             query: Query::ParseFailed(Arc::new(

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use nom_sql::analysis::visit::{self, Visitor};
 use nom_sql::{
     BinaryOperator, Column, ColumnConstraint, CreateTableBody, DeleteStatement, Expr,
-    InsertStatement, Literal, SelectStatement, SqlIdentifier, SqlQuery, TableKey, UpdateStatement,
+    InsertStatement, Literal, SelectStatement, SqlQuery, TableKey, UpdateStatement,
 };
 use readyset_client::{ColumnSchema, Modification, Operation};
 use readyset_data::{DfType, DfValue, Dialect};
@@ -14,7 +14,6 @@ use readyset_errors::{
     bad_request_err, invalid_query, invalid_query_err, invariant, invariant_eq, unsupported,
     unsupported_err, ReadySetResult,
 };
-use readyset_util::hash::hash;
 
 /// Helper for flatten_conditional - returns true if the
 /// expression is "valid" (i.e. not something like `a = 1 AND a = 2`.
@@ -589,13 +588,6 @@ pub(crate) fn coerce_params(
     } else {
         Ok(None)
     }
-}
-
-pub(crate) fn generate_query_name(
-    statement: &nom_sql::SelectStatement,
-    schema_search_path: &[SqlIdentifier],
-) -> String {
-    format!("q_{:x}", hash(&(statement, schema_search_path)))
 }
 
 pub(crate) fn create_dummy_column(name: &str) -> ColumnSchema {

--- a/readyset-clustertest/src/readyset_mysql.rs
+++ b/readyset-clustertest/src/readyset_mysql.rs
@@ -6,7 +6,6 @@ use mysql_async::prelude::Queryable;
 use readyset_adapter::backend::QueryInfo;
 use readyset_client_metrics::QueryDestination;
 use readyset_util::eventually;
-use readyset_util::hash::hash;
 use serial_test::serial;
 use test_utils::slow;
 use tokio::time::{sleep, timeout};
@@ -495,10 +494,10 @@ async fn dry_run_evaluates_support() {
         nom_sql::SqlQuery::Select(s) => s,
         _ => unreachable!(),
     };
-    let query_id = QueryId::new(hash(&ViewCreateRequest::new(
+    let query_id = QueryId::from(&ViewCreateRequest::new(
         select_query,
         vec![deployment.name().into()],
-    )))
+    ))
     .to_string();
     let mut results = EventuallyConsistentResults::new();
     results.write(&[(
@@ -576,10 +575,10 @@ async fn proxied_queries_filtering() {
         nom_sql::SqlQuery::Select(s) => s,
         _ => unreachable!(),
     };
-    let query_id = QueryId::new(hash(&ViewCreateRequest::new(
+    let query_id = QueryId::from(&ViewCreateRequest::new(
         select_query,
         vec![deployment.name().into()],
-    )))
+    ))
     .to_string();
     let mut results = EventuallyConsistentResults::new();
     results.write(&[(

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -76,6 +76,10 @@ pub enum ReadySetError {
     #[error("The provided query is invalid: {0}")]
     InvalidQuery(String),
 
+    /// The query ID is invalid
+    #[error("The provided query ID is invalid: {0}")]
+    InvalidQueryId(String),
+
     /// The adapter received a query id in CREATE CACHE that does not correspond to a known
     /// query
     #[error("No query known by id {id}")]

--- a/readyset-mysql/tests/fallback.rs
+++ b/readyset-mysql/tests/fallback.rs
@@ -6,7 +6,6 @@ use readyset_client_metrics::QueryDestination;
 use readyset_client_test_helpers::mysql_helpers::{last_query_info, MySQLAdapter};
 use readyset_client_test_helpers::{self, sleep, TestBuilder};
 use readyset_server::Handle;
-use readyset_util::hash::hash;
 use readyset_util::shutdown::ShutdownSender;
 use serial_test::serial;
 use test_utils::{skip_flaky_finder, slow};
@@ -747,7 +746,7 @@ async fn valid_sql_parsing_failed_shows_proxied() {
         .query::<(String, String, String), _>("SHOW PROXIED QUERIES;")
         .await
         .unwrap();
-    let id = QueryId::new(hash(&q));
+    let id = QueryId::from_unparsed_select(&q);
 
     assert!(
         proxied_queries.contains(&(id.to_string(), q, "unsupported".to_owned())),

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -26,7 +26,7 @@ use vec1::Vec1;
 
 use self::mir::{LeafBehavior, NodeIndex as MirNodeIndex, SqlToMirConverter};
 use self::query_graph::to_query_graph;
-pub(crate) use self::recipe::{QueryID, Recipe, Schema};
+pub(crate) use self::recipe::{ExprId, Recipe, Schema};
 use self::registry::ExprRegistry;
 use crate::controller::mir_to_flow::{mir_node_to_flow_parts, mir_query_to_flow_parts};
 use crate::controller::sql::registry::RecipeExpr;


### PR DESCRIPTION
Previously, the concept of a "query ID" was overloaded: the term was
used to describe the IDs generated by adapter-rewritten queries in the
query status cache *and* the IDs for expressions that were stored in the
expression registry. Both of these IDs had similar string
representations, making them look equivalent. We had two `QueryID` type
aliases (one for `String` and one for `u128`) and a separate `QueryId`
type, which was inconsistently used.

This commit refactors these type aliases and type into two types:
- `QueryId` (defined in `readyset-client`), which represents the ID of
  the adapter-rewritten query; and
- `ExprId` (defined in `readyset-server`), which represents the ID of an
  expression that is stored in the expression registry

This commit also makes usage of the `QueryId` type more consistent,
replacing parts of the code where we were just using `Strings` to
represent query IDs.

