### PR TITLE
adapter: Make `SHOW CACHES` persistent

### DIFF
--- a/nom-sql/src/show.rs
+++ b/nom-sql/src/show.rs
@@ -17,13 +17,11 @@ use crate::expression::expression;
 use crate::whitespace::{whitespace0, whitespace1};
 use crate::{literal, Dialect, DialectDisplay, Expr, Literal, NomSqlResult};
 
-pub type QueryID = String;
-
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub enum ShowStatement {
     Events,
     Tables(Tables),
-    CachedQueries(Option<QueryID>),
+    CachedQueries(Option<String>),
     ProxiedQueries(ProxiedQueriesOptions),
     ReadySetStatus,
     ReadySetStatusAdapter,

--- a/readyset-adapter/benches/parse.rs
+++ b/readyset-adapter/benches/parse.rs
@@ -3,7 +3,6 @@ use lru::LruCache;
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 use readyset_client::query::QueryId;
-use readyset_util::hash::hash;
 
 fn random_string(len: usize) -> String {
     rand::thread_rng()
@@ -41,7 +40,7 @@ fn lru_benchmarks(c: &mut Criterion) {
             |b, &_| {
                 b.iter(|| {
                     for q in queries.iter() {
-                        let id = QueryId::new(hash(&q));
+                        let id = QueryId::from_unparsed_select(q);
                         lru_cache_hash.put(black_box(id), black_box(q.clone()));
                     }
                 });

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2700,7 +2700,7 @@ where
                     if self.settings.query_log_mode.allow_ad_hoc() {
                         event.query =
                             Some(Arc::new(SqlQuery::Select(view_request.statement.clone())));
-                        event.query_id = Some(QueryId::from_view_create_request(&view_request));
+                        event.query_id = Some(QueryId::from(&view_request));
                     }
                     Self::query_adhoc_select(
                         &mut self.noria,

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1935,13 +1935,14 @@ where
     /// Responds to a `SHOW CACHES` query
     async fn show_caches(
         &mut self,
-        query_id: &Option<String>,
+        query_id: Option<&str>,
     ) -> ReadySetResult<noria_connector::QueryResult<'static>> {
-        let mut queries = self.state.query_status_cache.allow_list();
+        let mut views = self.noria.verbose_views().await?;
 
         // Filter on query ID
-        if let Some(q_id) = query_id {
-            queries.retain(|(id, _, _)| id.to_string() == *q_id);
+        if let Some(unparsed_query_id) = query_id {
+            let query_id = unparsed_query_id.parse()?;
+            views.retain(|view| view.query_id == query_id);
         }
 
         let select_schema = if let Some(handle) = self.metrics_handle.as_mut() {
@@ -1960,17 +1961,12 @@ where
 
         // Get the cache name for each query from the view cache
         let mut results: Vec<Vec<DfValue>> = vec![];
-        for (id, view, status) in queries {
-            let mut row = vec![
-                id.to_string().into(),
-                self.noria
-                    .get_view_name(&view.statement, false, false, None)
-                    .await?
-                    .display_unquoted()
-                    .to_string()
-                    .into(),
-                Self::format_query_text(view.statement.display(DB::SQL_DIALECT).to_string()).into(),
-                if status.always {
+        for view in views {
+            let mut row: Vec<DfValue> = vec![
+                view.query_id.to_string().into(),
+                view.name.display_unquoted().to_string().into(),
+                Self::format_query_text(view.display(DB::SQL_DIALECT).to_string()).into(),
+                if view.always {
                     "no fallback".into()
                 } else {
                     "fallback allowed".into()
@@ -1979,8 +1975,9 @@ where
 
             // Append metrics if we have them
             if let Some(handle) = self.metrics_handle.as_ref() {
-                let MetricsSummary { sample_count } =
-                    handle.metrics_summary(id.to_string()).unwrap_or_default();
+                let MetricsSummary { sample_count } = handle
+                    .metrics_summary(view.query_id.to_string())
+                    .unwrap_or_default();
                 row.push(DfValue::from(format!("{sample_count}")));
             }
 
@@ -2159,7 +2156,7 @@ where
                     trace!("No telemetry sender. not sending metric for SHOW CACHES");
                 }
 
-                self.show_caches(query_id).await
+                self.show_caches(query_id.as_deref()).await
             }
             SqlQuery::Show(ShowStatement::ReadySetStatus) => Ok(self
                 .status_reporter

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -13,6 +13,7 @@ use readyset_client::consistency::Timestamp;
 use readyset_client::internal::LocalNodeIndex;
 use readyset_client::query::QueryId;
 use readyset_client::recipe::changelist::{Change, ChangeList, IntoChanges};
+use readyset_client::recipe::CacheExpr;
 use readyset_client::results::{ResultIterator, Results};
 use readyset_client::{
     ColumnSchema, GraphvizOptions, ReadQuery, ReaderAddress, ReaderHandle, ReadySetHandle,
@@ -539,9 +540,12 @@ impl NoriaConnector {
         Ok(QueryResult::from_owned(schema, vec![Results::new(data)]))
     }
 
+    pub(crate) async fn verbose_views(&mut self) -> ReadySetResult<Vec<CacheExpr>> {
+        self.inner.get_mut()?.noria.verbose_views().await
+    }
+
     pub(crate) async fn list_create_cache_stmts(&mut self) -> ReadySetResult<Vec<String>> {
-        let noria = &mut self.inner.get_mut()?.noria;
-        Ok(noria
+        Ok(self
             .verbose_views()
             .await?
             .into_iter()

--- a/readyset-adapter/src/proxied_queries_reporter.rs
+++ b/readyset-adapter/src/proxied_queries_reporter.rs
@@ -99,7 +99,7 @@ mod tests {
         ));
         let proxied_queries_reporter = Arc::new(ProxiedQueriesReporter::new(query_status_cache));
 
-        let query_id = QueryId::new(42);
+        let query_id = QueryId::from_unparsed_select("test");
         let mut init_q = DeniedQuery {
             id: query_id,
             query: Query::ParseFailed(Arc::new(

--- a/readyset-adapter/src/utils.rs
+++ b/readyset-adapter/src/utils.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use nom_sql::analysis::visit::{self, Visitor};
 use nom_sql::{
     BinaryOperator, Column, ColumnConstraint, CreateTableBody, DeleteStatement, Expr,
-    InsertStatement, Literal, SelectStatement, SqlIdentifier, SqlQuery, TableKey, UpdateStatement,
+    InsertStatement, Literal, SelectStatement, SqlQuery, TableKey, UpdateStatement,
 };
 use readyset_client::{ColumnSchema, Modification, Operation};
 use readyset_data::{DfType, DfValue, Dialect};
@@ -14,7 +14,6 @@ use readyset_errors::{
     bad_request_err, invalid_query, invalid_query_err, invariant, invariant_eq, unsupported,
     unsupported_err, ReadySetResult,
 };
-use readyset_util::hash::hash;
 
 /// Helper for flatten_conditional - returns true if the
 /// expression is "valid" (i.e. not something like `a = 1 AND a = 2`.
@@ -589,13 +588,6 @@ pub(crate) fn coerce_params(
     } else {
         Ok(None)
     }
-}
-
-pub(crate) fn generate_query_name(
-    statement: &nom_sql::SelectStatement,
-    schema_search_path: &[SqlIdentifier],
-) -> String {
-    format!("q_{:x}", hash(&(statement, schema_search_path)))
 }
 
 pub(crate) fn create_dummy_column(name: &str) -> ColumnSchema {

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use futures_util::future;
 use hyper::client::HttpConnector;
-use nom_sql::{CreateCacheStatement, NonReplicatedRelation, Relation};
+use nom_sql::{NonReplicatedRelation, Relation};
 use parking_lot::RwLock;
 use petgraph::graph::NodeIndex;
 use readyset_errors::{
@@ -29,7 +29,7 @@ use crate::debug::stats;
 use crate::internal::{DomainIndex, ReplicaAddress};
 use crate::metrics::MetricsDump;
 use crate::recipe::changelist::ChangeList;
-use crate::recipe::{ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
+use crate::recipe::{CacheExpr, ExtendRecipeResult, ExtendRecipeSpec, MigrationStatus};
 use crate::status::ReadySetControllerStatus;
 use crate::table::{PersistencePoint, Table, TableBuilder, TableRpc};
 use crate::view::{View, ViewBuilder, ViewRpc};
@@ -489,7 +489,7 @@ impl ReadySetHandle {
     ///
     /// `Self::poll_ready` must have returned `Async::Ready` before you call
     /// this method.
-    pub async fn verbose_views(&mut self) -> ReadySetResult<Vec<CreateCacheStatement>> {
+    pub async fn verbose_views(&mut self) -> ReadySetResult<Vec<CacheExpr>> {
         self.simple_post_request("verbose_views").await
     }
 

--- a/readyset-clustertest/src/readyset_mysql.rs
+++ b/readyset-clustertest/src/readyset_mysql.rs
@@ -6,7 +6,6 @@ use mysql_async::prelude::Queryable;
 use readyset_adapter::backend::QueryInfo;
 use readyset_client_metrics::QueryDestination;
 use readyset_util::eventually;
-use readyset_util::hash::hash;
 use serial_test::serial;
 use test_utils::slow;
 use tokio::time::{sleep, timeout};
@@ -495,10 +494,10 @@ async fn dry_run_evaluates_support() {
         nom_sql::SqlQuery::Select(s) => s,
         _ => unreachable!(),
     };
-    let query_id = QueryId::new(hash(&ViewCreateRequest::new(
+    let query_id = QueryId::from(&ViewCreateRequest::new(
         select_query,
         vec![deployment.name().into()],
-    )))
+    ))
     .to_string();
     let mut results = EventuallyConsistentResults::new();
     results.write(&[(
@@ -576,10 +575,10 @@ async fn proxied_queries_filtering() {
         nom_sql::SqlQuery::Select(s) => s,
         _ => unreachable!(),
     };
-    let query_id = QueryId::new(hash(&ViewCreateRequest::new(
+    let query_id = QueryId::from(&ViewCreateRequest::new(
         select_query,
         vec![deployment.name().into()],
-    )))
+    ))
     .to_string();
     let mut results = EventuallyConsistentResults::new();
     results.write(&[(

--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -76,6 +76,10 @@ pub enum ReadySetError {
     #[error("The provided query is invalid: {0}")]
     InvalidQuery(String),
 
+    /// The query ID is invalid
+    #[error("The provided query ID is invalid: {0}")]
+    InvalidQueryId(String),
+
     /// The adapter received a query id in CREATE CACHE that does not correspond to a known
     /// query
     #[error("No query known by id {id}")]

--- a/readyset-mysql/tests/fallback.rs
+++ b/readyset-mysql/tests/fallback.rs
@@ -6,7 +6,6 @@ use readyset_client_metrics::QueryDestination;
 use readyset_client_test_helpers::mysql_helpers::{last_query_info, MySQLAdapter};
 use readyset_client_test_helpers::{self, sleep, TestBuilder};
 use readyset_server::Handle;
-use readyset_util::hash::hash;
 use readyset_util::shutdown::ShutdownSender;
 use serial_test::serial;
 use test_utils::{skip_flaky_finder, slow};
@@ -747,7 +746,7 @@ async fn valid_sql_parsing_failed_shows_proxied() {
         .query::<(String, String, String), _>("SHOW PROXIED QUERIES;")
         .await
         .unwrap();
-    let id = QueryId::new(hash(&q));
+    let id = QueryId::from_unparsed_select(&q);
 
     assert!(
         proxied_queries.contains(&(id.to_string(), q, "unsupported".to_owned())),

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -30,7 +30,7 @@ use self::query_graph::to_query_graph;
 pub(crate) use self::recipe::{ExprId, Recipe, Schema};
 use self::registry::ExprRegistry;
 use crate::controller::mir_to_flow::{mir_node_to_flow_parts, mir_query_to_flow_parts};
-use crate::controller::sql::registry::RecipeExpr;
+pub(crate) use crate::controller::sql::registry::RecipeExpr;
 use crate::controller::Migration;
 use crate::sql::mir::MirRemovalResult;
 use crate::ReuseConfigType;

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -26,7 +26,7 @@ use vec1::Vec1;
 
 use self::mir::{LeafBehavior, NodeIndex as MirNodeIndex, SqlToMirConverter};
 use self::query_graph::to_query_graph;
-pub(crate) use self::recipe::{QueryID, Recipe, Schema};
+pub(crate) use self::recipe::{ExprId, Recipe, Schema};
 use self::registry::ExprRegistry;
 use crate::controller::mir_to_flow::{mir_node_to_flow_parts, mir_query_to_flow_parts};
 use crate::controller::sql::registry::RecipeExpr;

--- a/readyset-server/src/controller/sql/mod.rs
+++ b/readyset-server/src/controller/sql/mod.rs
@@ -11,6 +11,7 @@ use nom_sql::{
     SelectStatement, SqlIdentifier, SqlType, TableExpr,
 };
 use petgraph::graph::NodeIndex;
+use readyset_client::query::QueryId;
 use readyset_client::recipe::changelist::{AlterTypeChange, Change, PostgresTableMetadata};
 use readyset_client::recipe::ChangeList;
 use readyset_data::{DfType, Dialect, PgEnumMetadata};
@@ -613,6 +614,7 @@ impl SqlIncorporator {
         mig: &mut Migration<'_>,
     ) -> ReadySetResult<Relation> {
         let name = name.unwrap_or_else(|| format!("q_{}", self.num_queries).into());
+        let query_id = QueryId::from_select(&stmt, schema_search_path);
 
         let mut invalidating_tables = vec![];
         let detect_placeholders_config =
@@ -672,6 +674,7 @@ impl SqlIncorporator {
             name: name.clone(),
             statement: stmt,
             always,
+            query_id,
         })?;
         self.registry
             .insert_invalidating_tables(name.clone(), invalidating_tables)?;

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -1,9 +1,6 @@
 use std::{fmt, str};
 
-use nom_sql::{
-    CacheInner, CreateCacheStatement, CreateTableStatement, CreateViewStatement, Relation,
-    SelectStatement, SqlIdentifier, SqlQuery,
-};
+use nom_sql::{Relation, SelectStatement, SqlIdentifier};
 use petgraph::graph::NodeIndex;
 use readyset_client::recipe::changelist::ChangeList;
 use readyset_client::ViewCreateRequest;
@@ -91,34 +88,9 @@ pub(crate) enum Schema<'a> {
 }
 
 impl Recipe {
-    /// Get the id associated with an alias
-    pub(crate) fn expression_by_alias(&self, alias: &Relation) -> Option<SqlQuery> {
-        let expr = self.inc.registry.get(alias).map(|e| match e {
-            RecipeExpr::Table { name, body, .. } => SqlQuery::CreateTable(CreateTableStatement {
-                if_not_exists: false,
-                table: name.clone(),
-                body: Ok(body.clone()),
-                options: Ok(vec![]),
-            }),
-            RecipeExpr::View { name, definition } => SqlQuery::CreateView(CreateViewStatement {
-                name: name.clone(),
-                or_replace: false,
-                fields: vec![],
-                definition: Ok(Box::new(definition.clone())),
-            }),
-            RecipeExpr::Cache {
-                name,
-                statement,
-                always,
-                ..
-            } => SqlQuery::CreateCache(CreateCacheStatement {
-                name: Some(name.clone()),
-                inner: Ok(CacheInner::Statement(Box::new(statement.clone()))),
-                unparsed_create_cache_statement: None, // not relevant after migrating
-                always: *always,
-                concurrently: false, // concurrently not relevant after migrating
-            }),
-        });
+    /// Get the [`RecipeExpr`] associated with an alias
+    pub(crate) fn expression_by_alias(&self, alias: &Relation) -> Option<RecipeExpr> {
+        let expr = self.inc.registry.get(alias).cloned();
         if expr.is_none() {
             warn!(alias = %alias.display_unquoted(), "Query not found in expression registry");
         }

--- a/readyset-server/src/controller/state.rs
+++ b/readyset-server/src/controller/state.rs
@@ -31,7 +31,7 @@ use failpoint_macros::set_failpoint;
 use futures::stream::{self, FuturesUnordered, StreamExt, TryStreamExt};
 use futures::{FutureExt, TryFutureExt, TryStream};
 use metrics::{gauge, histogram};
-use nom_sql::{CreateCacheStatement, NonReplicatedRelation, Relation, SqlIdentifier, SqlQuery};
+use nom_sql::{NonReplicatedRelation, Relation, SqlIdentifier};
 use petgraph::visit::{Bfs, IntoNodeReferences};
 use petgraph::Direction;
 use rand::Rng;
@@ -46,7 +46,7 @@ use readyset_client::failpoints;
 use readyset_client::internal::{MaterializationStatus, ReplicaAddress};
 use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::{Change, ChangeList};
-use readyset_client::recipe::ExtendRecipeSpec;
+use readyset_client::recipe::{CacheExpr, ExtendRecipeSpec};
 use readyset_client::{
     PersistencePoint, SingleKeyEviction, TableReplicationStatus, TableStatus, ViewCreateRequest,
     ViewFilter, ViewRequest, ViewSchema,
@@ -69,7 +69,7 @@ use crate::controller::domain_handle::DomainHandle;
 use crate::controller::migrate::materialization::Materializations;
 use crate::controller::migrate::scheduling::Scheduler;
 use crate::controller::migrate::{routing, DomainMigrationMode, DomainMigrationPlan, Migration};
-use crate::controller::sql::Schema;
+use crate::controller::sql::{RecipeExpr, Schema};
 use crate::controller::{
     schema, ControllerState, DomainPlacementRestriction, NodeRestrictionKey, Worker,
     WorkerIdentifier,
@@ -264,7 +264,7 @@ impl DfState {
     /// Get a map of all known views created from `CREATE CACHE` statements, mapping the name of the
     /// view to a tuple of (`SelectStatement`, always) where always is a bool that indicates whether
     /// the `CREATE CACHE` statement was created with the optional `ALWAYS` argument.
-    pub(super) fn verbose_views(&self) -> Vec<CreateCacheStatement> {
+    pub(super) fn verbose_views(&self) -> Vec<CacheExpr> {
         self.ingredients
             .externals(petgraph::EdgeDirection::Outgoing)
             .filter_map(|n| {
@@ -281,8 +281,17 @@ impl DfState {
 
                     // Only return ingredients created from "CREATE CACHE"
                     match query {
-                        // CacheInner::ID should have been expanded to CacheInner::Statement
-                        SqlQuery::CreateCache(stmt) if stmt.inner.is_ok() => Some(stmt),
+                        RecipeExpr::Cache {
+                            name,
+                            statement,
+                            always,
+                            query_id,
+                        } => Some(CacheExpr {
+                            name,
+                            statement,
+                            always,
+                            query_id,
+                        }),
                         _ => None,
                     }
                 } else {


### PR DESCRIPTION
Previously, `SHOW CACHES` used the query status cache as its source of
truth. This meant that after a restart, `SHOW CACHES` would not reflect
any caches that existed on the server until after the adapter received a
query against that cache.

This commit has `SHOW CACHES` use the expression registry as its source
of truth, which is what `EXPLAIN CACHES` uses. This enables the adapter
to display an accurate, up-to-date list of caches via `SHOW CACHES`,
even after a restart.

Refs: REA-3516, REA-3349
Release-Note-Core: Added the ability for the `SHOW CACHES` SQL extension
  to display an up-to-date list of caches, even after a restart
