### PR TITLE
demo: remove --quiet from docker pull.

### DIFF
--- a/quickstart/readyset_demo.sh
+++ b/quickstart/readyset_demo.sh
@@ -74,7 +74,7 @@ download_byo_compose_file() {
 
 run_docker_compose() {
   echo -e "${BLUE}${WHALE}Running the ReadySet Docker Compose setup... ${NOCOLOR}"
-  if ! docker compose -f readyset.compose.yml pull --quiet; then
+  if ! docker compose -f readyset.compose.yml pull; then
     echo -e "${RED}${ROTATING_LIGHT}Unable to pull ReadySet images.${NOCOLOR}"
     exit 1
   fi


### PR DESCRIPTION
We are seeing some docker throttling errors, and the --quiet is
suppressing telling us which image pull that is coming from.

