### PR TITLE
demo: Fix quickstart mysql grafana RS_HOST

### DIFF
--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -52,6 +52,7 @@ services:
       - "4000:4000"
     environment:
       UPSTREAM_DB_URL: mysql://root:readyset@mysql/testdb
+      RS_HOST: cache
       RS_PORT: 3307
       RS_GRAFANA_PORT: 4000
   mysql:


### PR DESCRIPTION
This was unset for the mysql branch of the quickstart, causing the
readyset-grafana image to fail to come up.

