### PR TITLE
adapter: Fix views sync shutdown signal

### DIFF
--- a/readyset-adapter/src/views_synchronizer.rs
+++ b/readyset-adapter/src/views_synchronizer.rs
@@ -19,8 +19,6 @@ pub struct ViewsSynchronizer {
     poll_interval: std::time::Duration,
     /// Dialect to pass to ReadySet to control the expression semantics used for all queries
     dialect: Dialect,
-    /// Receiver to return the shutdown signal on
-    shutdown_recv: ShutdownReceiver,
 }
 
 impl ViewsSynchronizer {
@@ -29,36 +27,38 @@ impl ViewsSynchronizer {
         query_status_cache: &'static QueryStatusCache,
         poll_interval: std::time::Duration,
         dialect: Dialect,
-        shutdown_recv: ShutdownReceiver,
     ) -> Self {
         ViewsSynchronizer {
             controller,
             query_status_cache,
             poll_interval,
             dialect,
-            shutdown_recv,
         }
     }
 
     //TODO(DAN): add metrics on views synchronizer performance (e.g., number of queries polled,
     //time spent processing)
     #[instrument(level = "info", name = "views_synchronizer", skip(self))]
-    pub async fn run(&mut self) {
+    pub async fn run(&mut self, mut shutdown_recv: ShutdownReceiver) {
         let mut interval = tokio::time::interval(self.poll_interval);
-        loop {
-            select! {
-                // We use `biased` here to ensure that our shutdown signal will be received and
-                // acted upon even if the other branches in this `select!` are constantly in a
-                // ready state (e.g. a stream that has many messages where very little time passes
-                // between receipt of these messages). More information about this situation can
-                // be found in the docs for `tokio::select`.
-                biased;
-                _ = self.shutdown_recv.recv() => {
-                    info!("Views Synchronizer shutting down after shut down signal received");
-                    break;
-                }
-                _ = interval.tick() => self.poll().await,
+
+        let fut = async {
+            loop {
+                interval.tick().await;
+                self.poll().await;
             }
+        };
+        select! {
+            // We use `biased` here to ensure that our shutdown signal will be received and
+            // acted upon even if the other branches in this `select!` are constantly in a
+            // ready state (e.g. a stream that has many messages where very little time passes
+            // between receipt of these messages). More information about this situation can
+            // be found in the docs for `tokio::select`.
+            biased;
+            _ = shutdown_recv.recv() => {
+                info!("Views Synchronizer shutting down after shut down signal received");
+            }
+            _ = fut => unreachable!(),
         }
     }
 

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -992,9 +992,8 @@ where
                     query_status_cache,
                     std::time::Duration::from_secs(loop_interval),
                     expr_dialect,
-                    shutdown_rx,
                 );
-                views_synchronizer.run().await
+                views_synchronizer.run(shutdown_rx).await
             };
             rt.handle().spawn(abort_on_panic(fut));
         }


### PR DESCRIPTION
Previously, we were not correctly waiting for the shutdown signal in the
`ViewsSynchronizer` -- when the `Interval::tick` future resolved, we
invoked `ViewsSynchronizer::poll` in a context where a shutdown signal
would be ignored. This commit ensures that the `tokio::select!`
invocation is invoked on a future that contains both the `tick` *and*
the `poll`, so a shutdown signal that occurs during the polling step
would still be respected.

