### PR TITLE
adapter: Fix rebase issue

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1787,11 +1787,9 @@ where
     async fn explain_create_cache(
         &mut self,
         id: QueryId,
-        mut req: ViewCreateRequest,
+        req: ViewCreateRequest,
         migration_state: Option<MigrationState>,
     ) -> ReadySetResult<noria_connector::QueryResult<'static>> {
-        rewrite::process_query(&mut req.statement, self.noria.server_supports_pagination())?;
-
         let (supported, migration_state) = match migration_state {
             Some(m @ MigrationState::Unsupported) | Some(m @ MigrationState::Dropped) => ("no", m),
             // If the migration state is "Inlined", we need to let the migration handler process
@@ -2095,7 +2093,7 @@ where
                         let view_request = match inner {
                             CacheInner::Statement(stmt) => {
                                 let mut stmt = *stmt.clone();
-                                rewrite::process_query(
+                                adapter_rewrites::process_query(
                                     &mut stmt,
                                     self.noria.server_supports_pagination(),
                                 )?;

--- a/readyset-adapter/src/query_status_cache.rs
+++ b/readyset-adapter/src/query_status_cache.rs
@@ -367,7 +367,7 @@ impl QueryStatusCache {
     where
         Q: QueryStatusKey,
     {
-        let id = QueryId::new(hash(&q));
+        let id = q.query_id();
         let query_state = self.id_to_status.get(&id);
 
         (id, query_state.map(|s| s.value().migration_state.clone()))


### PR DESCRIPTION
A few commits were merged in an order that technically should have
caused merge conflicts, but the conflicts weren't detected via diffing,
since the conflicting changes were not in the same parts of the same
files. This commit resolves the issue by properly merging the changes.

