### PR TITLE
demo: Allow passwordless connections

### DIFF
--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -18,6 +18,9 @@ services:
       STANDALONE: true
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:3307
+      # We don't have control over whether users are using a password or not for the
+      # demo/quickstart, so use the more permissive mode.
+      ALLOW_UNAUTHENTICATED_CONNECTIONS: true
       UPSTREAM_DB_URL: mysql://root:readyset@mysql/testdb
       CONTROLLER_ADDRESS: 0.0.0.0
     volumes:

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -20,6 +20,9 @@ services:
       LISTEN_ADDRESS: 0.0.0.0:5433
       UPSTREAM_DB_URL: postgresql://postgres:readyset@postgres/testdb
       CONTROLLER_ADDRESS: 0.0.0.0
+      # We don't have control over whether users are using a password or not for the
+      # demo/quickstart, so use the more permissive mode.
+      ALLOW_UNAUTHENTICATED_CONNECTIONS: true
     volumes:
       - "readyset:/state"
     healthcheck:

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -18,6 +18,9 @@ services:
       STANDALONE: true
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:5433
+      ALLOW_UNAUTHENTICATED_CONNECTIONS: true
+      # We don't have control over whether users are using a password or not for the
+      # demo/quickstart, so use the more permissive mode.
       # UPSTREAM_DB_URL:
       CONTROLLER_ADDRESS: 0.0.0.0
     volumes:


### PR DESCRIPTION
The demo is meant as a non-production way for folks to try out readyset,
and our (sane for production) default behavior is to not allow
passwordless connections, which we don't have control over for the demo.

This commit uses the `ALLOW_UNAUTHENTICATED_CONNECTIONS` flag to make
the default for the demo more permissive in case users are testing us
out with their dev postgres that doesn't have a password.

