### PR TITLE
adapter: Make SHOW CACHES display query only

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2023,7 +2023,7 @@ where
             let mut row: Vec<DfValue> = vec![
                 view.query_id.to_string().into(),
                 view.name.display_unquoted().to_string().into(),
-                Self::format_query_text(view.display(DB::SQL_DIALECT).to_string()).into(),
+                Self::format_query_text(view.statement.display(DB::SQL_DIALECT).to_string()).into(),
                 if view.always {
                     "no fallback".into()
                 } else {


### PR DESCRIPTION
Previously, `SHOW CACHES` was displaying the entire `CREATE CACHE`
statement for each query as it existed in the expression registry. This
was not necessary: `SHOW CACHES` already includes the cache's name and
fallback behavior in the results. This commit makes a change so that
`SHOW CACHES` only displays the SELECT statement text.

