### PR TITLE
readyset-grafana: Parse passwordless connection strings

### DIFF
--- a/build/docker/grafana/config-then-run.sh
+++ b/build/docker/grafana/config-then-run.sh
@@ -3,12 +3,24 @@
 set -euxo pipefail
 
 # Parse the upstream database URL
-RE='(.+):\/\/(.+):(.+)@([^:\/]+)(:[0-9]+)?(\/(.+))?'
+RE='(.+):\/\/([^:@]*)(:([^@]*))?@([^:\/]+)(:[0-9]+)?(\/(.+))?'
+#   ^  ^^   ^^      ^^^^       ^^^       ^^        ^^       ^
+#   |1 ||2  ||3     ||4|5      |||6      ||7       ||8      |
+#   |  ||   ||      ||||       |||       ||        |└-------> Database name [optional]
+#   |  ||   ||      ||||       |||       |└--------> Port [optional]
+#   |  ||   ||      ||||       ||└-------> Host [required]
+#   |  ||   ||      ||||       |└-> "@" character separator [required]
+#   |  ||   ||      |||└-------> Password [optional]
+#   |  ||   ||      |└> ":" separator [optional unless password is supplied]
+#   |  ||   |└------> Username [required]
+#   |  |└---> "://" Separator [required]
+#   └--> Protocol [required] (e.g., postgresql, mysql)
+
 [[ $UPSTREAM_DB_URL =~ $RE ]]
 RS_DB_TYPE=${BASH_REMATCH[1]}
 RS_USER=${BASH_REMATCH[2]}
-RS_PASS=${BASH_REMATCH[3]}
-RS_DB_NAME=${BASH_REMATCH[7]}
+RS_PASS=${BASH_REMATCH[4]}
+RS_DB_NAME=${BASH_REMATCH[8]}
 
 if [[ $RS_DB_TYPE = "mysql" ]]; then
     CONFIG_FILE=/etc/grafana/provisioning/datasources/default.template.mysql.yml


### PR DESCRIPTION
The regex used to detect the components of a connection string for the
readyset-grafana config-then-run.sh script weren't able to handle
connection strings without passwords. This commit updates the regex and
adds some documentation about the different parts and their optionality.

