### PR TITLE
readyset-grafana: Make RS_PASS optional

### DIFF
--- a/build/docker/grafana/provisioning/datasources/default.template.mysql.yml
+++ b/build/docker/grafana/provisioning/datasources/default.template.mysql.yml
@@ -17,5 +17,5 @@ datasources:
     jsonData:
       tlsAuth: true
     secureJsonData:
-      password: ${RS_PASS:?}
+      password: ${RS_PASS:-""}
     editable: true

--- a/build/docker/grafana/provisioning/datasources/default.template.postgres.yml
+++ b/build/docker/grafana/provisioning/datasources/default.template.postgres.yml
@@ -15,7 +15,7 @@ datasources:
     database: ${RS_DB_NAME:?}
     user: ${RS_USER:?}
     secureJsonData:
-      password: ${RS_PASS:?}
+      password: ${RS_PASS:-""}
     jsonData:
       sslmode: 'disable'
       postgresVersion: 903


### PR DESCRIPTION
The password is an optional field to connect to postgres, but our
grafana image was requiring it.

