### PR TITLE
readyset-tracing: Allow configuring log path + rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,9 +237,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.17"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -249,26 +249,25 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "matchit",
  "memchr",
  "mime",
  "percent-encoding",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "sync_wrapper",
- "tokio",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.2.9"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -276,6 +275,7 @@ dependencies = [
  "http",
  "http-body",
  "mime",
+ "rustversion",
  "tower-layer",
  "tower-service",
 ]
@@ -962,11 +962,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -1018,12 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crypto-common"
@@ -1042,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "ryu",
  "serde",
 ]
@@ -1182,17 +1178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391b56fbd302e585b7a9494fb70e40949567b1cf9003a8e4a6041a1687c26573"
-dependencies = [
- "cfg-if 1.0.0",
- "hashbrown 0.12.3",
- "lock_api",
-]
-
-[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1267,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "hashbag",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "lazy_static",
  "notify",
@@ -1588,6 +1573,12 @@ checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1996,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
@@ -2035,7 +2026,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util 0.7.2",
@@ -2177,7 +2168,7 @@ checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.4",
+ "itoa 1.0.10",
 ]
 
 [[package]]
@@ -2190,12 +2181,6 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -2230,7 +2215,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "pin-project-lite",
  "socket2 0.4.9",
  "tokio",
@@ -2329,6 +2314,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.1",
+]
+
+[[package]]
 name = "indicatif"
 version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,7 +2349,7 @@ checksum = "16d4bde3a7105e59c66a4104cfe9606453af1c7a0eac78cb7d5bc263eb762a70"
 dependencies = [
  "ahash 0.7.6",
  "atty",
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "lazy_static",
  "log",
  "num-format",
@@ -2481,9 +2476,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
@@ -2496,9 +2491,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2802,9 +2797,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
-version = "0.5.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -2880,7 +2875,7 @@ source = "git+https://github.com/readysettech/metrics.git#9834afdd26f6dea20cd6bc
 dependencies = [
  "base64 0.21.0",
  "hyper",
- "indexmap",
+ "indexmap 1.9.3",
  "ipnet",
  "metrics",
  "metrics-util",
@@ -2909,10 +2904,10 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.13.1",
- "indexmap",
+ "indexmap 1.9.3",
  "metrics",
  "num_cpus",
- "ordered-float",
+ "ordered-float 3.7.0",
  "quanta",
  "radix_trie",
  "sketches-ddsketch",
@@ -3314,6 +3309,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,59 +3480,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust#bfeda30583f3df6733e8ebce2f5964f6a7b69b5c"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
 dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.11.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust#bfeda30583f3df6733e8ebce2f5964f6a7b69b5c"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http",
- "opentelemetry",
- "opentelemetry-proto",
- "prost",
- "thiserror",
- "tokio",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-proto"
-version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust#bfeda30583f3df6733e8ebce2f5964f6a7b69b5c"
-dependencies = [
- "futures",
- "futures-util",
- "opentelemetry",
- "prost",
- "tonic",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.10.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust#bfeda30583f3df6733e8ebce2f5964f6a7b69b5c"
-dependencies = [
- "opentelemetry",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust#bfeda30583f3df6733e8ebce2f5964f6a7b69b5c"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap",
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.1.0",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3536,19 +3495,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24cda83b20ed2433c68241f918d0f6fdec8b1d43b7a9590ab4420c5095ca930"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
 name = "opentelemetry_sdk"
-version = "0.18.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust#bfeda30583f3df6733e8ebce2f5964f6a7b69b5c"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap 5.3.3",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
+ "glob",
  "once_cell",
- "opentelemetry_api",
+ "opentelemetry",
+ "ordered-float 4.2.0",
  "percent-encoding",
  "rand 0.8.5",
  "thiserror",
@@ -3566,6 +3566,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76df7075c7d4d01fdcb46c912dd17fba5b60c78ea480b475f2b6ab6f666584e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,6 +3582,12 @@ checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 dependencies = [
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -3683,7 +3698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_derive",
 ]
@@ -3708,22 +3723,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3995,9 +4010,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -4005,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.6"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -4422,7 +4437,7 @@ dependencies = [
  "clap 4.3.2",
  "criterion",
  "crossbeam-skiplist",
- "dashmap 4.0.2",
+ "dashmap",
  "database-utils",
  "dataflow-expression",
  "derive_more",
@@ -4432,7 +4447,7 @@ dependencies = [
  "futures-util",
  "health-reporter",
  "hyper",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "lazy_static",
  "lru 0.12.0",
@@ -4748,7 +4763,7 @@ dependencies = [
  "failpoint-macros",
  "futures-util",
  "hashbag",
- "indexmap",
+ "indexmap 1.9.3",
  "itertools",
  "lazy_static",
  "merging-interval-tree",
@@ -5170,12 +5185,14 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "serde",
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-attributes",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5221,7 +5238,7 @@ dependencies = [
  "bytes",
  "combine",
  "futures-util",
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
@@ -5559,9 +5576,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rusty-fork"
@@ -5745,7 +5762,7 @@ version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "ryu",
  "serde",
 ]
@@ -5767,7 +5784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa 1.0.10",
  "ryu",
  "serde",
 ]
@@ -5812,7 +5829,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",
@@ -6198,9 +6215,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -6430,6 +6447,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
+ "itoa 1.0.10",
  "libc",
  "num_threads",
 ]
@@ -6663,14 +6681,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd56bdb54ef93935a6a79dbd1d91f1ebd4c64150fd61654031fd6b8b775c91"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.0",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6682,15 +6699,12 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.2",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -6710,7 +6724,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand 0.8.5",
@@ -6723,29 +6737,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-http"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d342c6d58709c0a6d48d48dabbb62d4ef955cf5f0f3bbfd845838e7ae88dbae"
-dependencies = [
- "bitflags 1.3.2",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "tower-layer"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
 
 [[package]]
 name = "tower-service"
@@ -6755,11 +6750,10 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -6767,21 +6761,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.23"
+name = "tracing-appender"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time 0.3.9",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6799,27 +6805,31 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
 dependencies = [
+ "js-sys",
  "once_cell",
  "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -6834,12 +6844,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "regex",
  "serde",
@@ -7141,9 +7151,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -7151,16 +7161,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
@@ -7178,9 +7188,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote 1.0.33",
  "wasm-bindgen-macro-support",
@@ -7188,22 +7198,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-streams"
@@ -7223,6 +7233,16 @@ name = "web-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [patch.crates-io]
 tokio-postgres = {  git = "https://github.com/readysettech/rust-postgres.git"}
 eui48 = { git = "https://github.com/readysettech/eui48.git", branch = "master" }
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust" }
-opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust" }
-opentelemetry-semantic-conventions = { git = "https://github.com/open-telemetry/opentelemetry-rust" }
 
 [workspace]
 members = [

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -157,10 +157,13 @@ fn main() -> anyhow::Result<()> {
         .thread_name("Worker Runtime")
         .build()?;
 
-    rt.block_on(async {
-        if let Err(error) = opts.tracing.init("readyset", opts.deployment.as_ref()) {
-            error!(%error, "Error initializing tracing");
-            process::exit(1)
+    let _guard = rt.block_on(async {
+        match opts.tracing.init("readyset", opts.deployment.as_ref()) {
+            Ok(guard) => guard,
+            Err(error) => {
+                error!(%error, "Error initializing tracing");
+                process::exit(1);
+            }
         }
     });
     info!(?opts, "Starting ReadySet server");

--- a/readyset-tracing/Cargo.toml
+++ b/readyset-tracing/Cargo.toml
@@ -8,20 +8,22 @@ edition = "2021"
 [dependencies]
 clap = { workspace = true, features = ["derive","env"] }
 once_cell = "1.9.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 parking_lot = "0.12.0"
 rand = "0.8.5"
 serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0.30"
 tokio = { workspace = true, features = ["full"] }
-tracing = "0.1.35"
-tracing-opentelemetry = "0.18.0"
-opentelemetry-otlp = { version = "0.11.0" }
-opentelemetry-semantic-conventions = "0.10"
-tracing-subscriber = { version = "0.3.9", features = ["env-filter", "json"] }
 lazy_static = "1.0"
+
+tracing = "0.1.40"
+opentelemetry = { version = "0.21.0" }
+opentelemetry-otlp = { version = "0.14.0" }
+opentelemetry-semantic-conventions = "0.13"
+tracing-opentelemetry = "0.22.0"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter", "json"] }
+tracing-appender = "0.2.3"
+opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
 
 [dev-dependencies]
 anyhow = "1.0.53"
-tokio = { workspace = true, features = ["full"] }
-tracing-attributes = "0.1.20"
+tracing-attributes = "0.1.27"

--- a/readyset-tracing/src/error.rs
+++ b/readyset-tracing/src/error.rs
@@ -7,4 +7,6 @@ pub enum Error {
     Trace(#[from] TraceError),
     #[error("failed to parse filter: {0}")]
     Parse(#[from] ParseError),
+    #[error("invalid rotation cadence: {0}")]
+    InvalidRotationCadence(String),
 }

--- a/readyset-tracing/src/lib.rs
+++ b/readyset-tracing/src/lib.rs
@@ -17,18 +17,22 @@
 
 #![feature(core_intrinsics)]
 use std::fs::File;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use clap::Args;
-use opentelemetry::sdk::trace::{Sampler, Tracer};
-use opentelemetry::sdk::Resource;
+use clap::{Args, ValueEnum};
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::trace::{Sampler, Tracer};
+use opentelemetry_sdk::Resource;
 use tracing::Subscriber;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::filter::{self, ParseError};
+use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
-use tracing_subscriber::{fmt, EnvFilter, Layer};
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{filter, fmt, EnvFilter, Layer};
 
 mod error;
 pub use error::Error;
@@ -48,13 +52,27 @@ pub fn warn_if_debug_build() {
 #[derive(Debug, Args)]
 #[group(id = "logging")]
 pub struct Options {
+    /// Optional path to write logs to. If set, logs will rollover based on the chosen
+    /// `log_rotation` policy, which defaults to daily. Readyset must have write permissions to
+    /// the provided path.
+    /// Logs will be written to `readyset.log` within this path.
+    #[arg(long, env = "LOG_PATH")]
+    pub log_path: Option<PathBuf>,
+
+    /// Log [`Rotation`](https://docs.rs/tracing-appender/latest/tracing_appender/rolling/struct.Rotation.html)
+    /// to use if a log file is set. Defaults to daily.
+    /// Does nothing if no log file is set.
+    /// Possible Values: [daily, hourly, minutely, never]
+    #[arg(long, env = "LOG_ROTATION", default_value = "daily", value_enum)]
+    pub log_rotation: RotationCadence,
+
     /// Format to use when emitting log events.
     #[arg(long, env = "LOG_FORMAT", default_value = "full", value_enum)]
-    log_format: LogFormat,
+    pub log_format: LogFormat,
 
     /// Disable colors in all log output
     #[arg(long, env = "NO_COLOR", hide = true)]
-    no_color: bool,
+    pub no_color: bool,
 
     /// Log level filter for spans and events. The log level filter string is a comma separated
     /// list of directives.
@@ -73,15 +91,15 @@ pub struct Options {
     /// LOG_LEVEL=trace,tower=error
     /// ```
     #[arg(long, env = "LOG_LEVEL", default_value = "info")]
-    log_level: String,
+    pub log_level: String,
 
     /// Host and port to send OTLP traces/spans data, via GRPC OLTP
     #[arg(long, env = "TRACING_HOST", hide = true)]
-    tracing_host: Option<String>,
+    pub tracing_host: Option<String>,
 
     /// Portion of traces that will be sent to the tracing endpoint; [0.0~1.0]
     #[arg(long, env = "TRACING_SAMPLE_PERCENT", default_value_t = Percent(0.01), hide = true)]
-    tracing_sample_percent: Percent,
+    pub tracing_sample_percent: Percent,
 
     /// Whether to log all statements received by ReadySet via the client or replicators
     #[arg(long, env = "STATEMENT_LOGGING", hide = true)]
@@ -101,6 +119,8 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
+            log_path: None,
+            log_rotation: "daily".try_into().expect("daily is a valid log rotation"),
             log_format: LogFormat::Full,
             no_color: false,
             log_level: "info".to_owned(),
@@ -112,9 +132,140 @@ impl Default for Options {
     }
 }
 
+/// The rotation policy for log files
+// This wrapper allows us to parse from a str since Rotation itself doesn't support that.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
+pub enum RotationCadence {
+    /// Rotate logs daily
+    Daily,
+    /// Rotate logs hourly
+    Hourly,
+    /// Rotate logs minutely
+    Minutely,
+    /// Never rotate logs
+    Never,
+}
+
+impl TryFrom<&str> for RotationCadence {
+    type Error = Error;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "daily" => Ok(Self::Daily),
+            "hourly" => Ok(Self::Hourly),
+            "minutely" => Ok(Self::Minutely),
+            "never" => Ok(Self::Never),
+            _ => Err(Error::InvalidRotationCadence(s.to_owned())),
+        }
+    }
+}
+
+impl From<RotationCadence> for Rotation {
+    fn from(value: RotationCadence) -> Self {
+        match value {
+            RotationCadence::Daily => Rotation::DAILY,
+            RotationCadence::Hourly => Rotation::HOURLY,
+            RotationCadence::Minutely => Rotation::MINUTELY,
+            RotationCadence::Never => Rotation::NEVER,
+        }
+    }
+}
+
 /// Whether the target matches the target set for statement logs
 fn is_statement_log(target: &str) -> bool {
     target == "client_statement" || target == "replicator_statement"
+}
+
+/// Initializes a SubscriberBuilder based on self.log_format.
+// This is a macro rather than a fn because SubscriberBuilder embeds its layering types into the
+// type itself, and to make it variadic
+macro_rules! log_format_init {
+    ($self:expr, $subscriber_builder:expr, $fmt_layer:expr, $tracing_layer:expr) => {
+        match $self.log_format {
+            LogFormat::Compact => $subscriber_builder
+                .with($tracing_layer)
+                .with(
+                    $fmt_layer
+                        .compact()
+                        .with_filter(filter::filter_fn(|metadata| {
+                            !is_statement_log(metadata.target())
+                        })),
+                )
+                .init(),
+            LogFormat::Full => $subscriber_builder
+                .with($tracing_layer)
+                .with($fmt_layer.with_filter(filter::filter_fn(|metadata| {
+                    !is_statement_log(metadata.target())
+                })))
+                .init(),
+            LogFormat::Pretty => $subscriber_builder
+                .with($tracing_layer)
+                .with(
+                    $fmt_layer
+                        .pretty()
+                        .with_filter(filter::filter_fn(|metadata| {
+                            !is_statement_log(metadata.target())
+                        })),
+                )
+                .init(),
+            LogFormat::Json => $subscriber_builder
+                .with($tracing_layer)
+                .with(
+                    $fmt_layer
+                        .json()
+                        .with_current_span(true)
+                        .with_filter(filter::filter_fn(|metadata| {
+                            !is_statement_log(metadata.target())
+                        })),
+                )
+                .init(),
+        };
+    };
+    ($self:expr, $subscriber_builder:expr, $fmt_layer:expr) => {
+        match $self.log_format {
+            LogFormat::Compact => $subscriber_builder
+                .with(
+                    $fmt_layer
+                        .compact()
+                        .with_filter(filter::filter_fn(|metadata| {
+                            !is_statement_log(metadata.target())
+                        })),
+                )
+                .init(),
+            LogFormat::Full => $subscriber_builder
+                .with($fmt_layer.with_filter(filter::filter_fn(|metadata| {
+                    !is_statement_log(metadata.target())
+                })))
+                .init(),
+            LogFormat::Pretty => $subscriber_builder
+                .with(
+                    $fmt_layer
+                        .pretty()
+                        .with_filter(filter::filter_fn(|metadata| {
+                            !is_statement_log(metadata.target())
+                        })),
+                )
+                .init(),
+            LogFormat::Json => $subscriber_builder
+                .with(
+                    $fmt_layer
+                        .json()
+                        .with_current_span(true)
+                        .with_filter(filter::filter_fn(|metadata| {
+                            !is_statement_log(metadata.target())
+                        })),
+                )
+                .init(),
+        };
+    };
+    ($self:expr, $subscriber_builder:expr) => {
+        match &$self.log_format {
+            LogFormat::Compact => $subscriber_builder.compact().init(),
+            LogFormat::Full => $subscriber_builder.init(),
+            LogFormat::Pretty => $subscriber_builder.pretty().init(),
+            LogFormat::Json => $subscriber_builder.json().with_current_span(true).init(),
+        }
+    };
 }
 
 impl Options {
@@ -122,7 +273,7 @@ impl Options {
         &self,
         service_name: &str,
         deployment: &str,
-    ) -> Result<OpenTelemetryLayer<S, Tracer>, Error>
+    ) -> OpenTelemetryLayer<S, Tracer>
     where
         S: Subscriber + for<'span> LookupSpan<'span>,
     {
@@ -145,37 +296,16 @@ impl Options {
                     .with_endpoint(self.tracing_host.as_ref().unwrap()),
             )
             .with_trace_config(
-                opentelemetry::sdk::trace::config()
+                opentelemetry_sdk::trace::config()
                     .with_sampler(Sampler::TraceIdRatioBased(self.tracing_sample_percent.0))
                     .with_max_events_per_span(64)
                     .with_max_attributes_per_span(16)
                     .with_resource(Resource::new(resources)),
             )
-            .install_batch(opentelemetry::runtime::Tokio)
+            .install_batch(opentelemetry_sdk::runtime::Tokio)
             .unwrap();
 
-        Ok(tracing_opentelemetry::layer().with_tracer(tracer))
-    }
-
-    // Anything we do with a templated type alias or a custom trait is just going to make this more
-    // difficult to read/follow
-    #[allow(clippy::type_complexity)]
-    fn logging_layer<S>(&self) -> Result<Box<dyn Layer<S> + Send + Sync>, ParseError>
-    where
-        S: Subscriber + Send + Sync + for<'span> LookupSpan<'span>,
-    {
-        let layer: Box<dyn Layer<S> + Send + Sync> = match self.log_format {
-            LogFormat::Compact => Box::new(fmt::layer().compact().with_ansi(!self.no_color)),
-            LogFormat::Full => Box::new(fmt::layer().with_ansi(!self.no_color)),
-            LogFormat::Pretty => Box::new(fmt::layer().pretty().with_ansi(!self.no_color)),
-            LogFormat::Json => Box::new(
-                fmt::layer()
-                    .json()
-                    .with_current_span(true)
-                    .with_ansi(!self.no_color),
-            ),
-        };
-        Ok(layer)
+        tracing_opentelemetry::layer().with_tracer(tracer)
     }
 
     #[allow(clippy::type_complexity)]
@@ -194,61 +324,31 @@ impl Options {
         }
     }
 
-    fn init_logging_and_tracing(&self, service_name: &str, deployment: &str) -> Result<(), Error> {
-        use tracing_subscriber::prelude::*;
-        tracing_subscriber::registry()
-            .with(tracing_subscriber::EnvFilter::new(&self.log_level))
-            .with(self.tracing_layer(service_name, deployment)?)
-            .with(
-                self.logging_layer()?
-                    .with_filter(filter::filter_fn(|metadata| {
-                        !is_statement_log(metadata.target())
-                    })),
-            )
-            .with(self.statement_logging_layer(&self.statement_log_path_or_default(deployment)))
-            .init();
-        Ok(())
+    /// Sets up a non-blocking filing appender with the configured log rotation policy.
+    /// Note that the returned WorkerGuard should be kept in scope for the duration of the
+    /// process--it's Drop is what flushes the logs before a shutdown or crash.
+    fn setup_file_appender(&self, log_path: &Path) -> (NonBlocking, WorkerGuard) {
+        tracing_appender::non_blocking(RollingFileAppender::new(
+            self.log_rotation.into(),
+            log_path,
+            "readyset.log",
+        ))
     }
 
-    // Initializes logging, and conditionally, statement logging
-    fn init_logging_only(&self, deployment: &str) -> Result<(), ParseError> {
-        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
-        // Avoid using the registry if we are only using one layer
-        if self.statement_logging {
-            use tracing_subscriber::prelude::*;
-            tracing_subscriber::registry()
-                .with(
-                    self.logging_layer()?
-                        .with_filter(filter::filter_fn(|metadata| {
-                            !is_statement_log(metadata.target())
-                        })),
-                )
-                .with(self.statement_logging_layer(&self.statement_log_path_or_default(deployment)))
-                .with(env_filter)
-                .init();
-        } else {
-            let s = tracing_subscriber::fmt().with_env_filter(env_filter);
-            match self.log_format {
-                LogFormat::Compact => s.compact().init(),
-                LogFormat::Full => s.init(),
-                LogFormat::Pretty => s.pretty().init(),
-                LogFormat::Json => s.json().with_current_span(true).init(),
-            }
-        }
-
-        #[cfg(debug)]
-        warn_if_debug_build();
-
-        Ok(())
-    }
-
-    /// This is the primary entrypoint to the combined logging/tracing subsystem.  If tracing is
-    /// not configured, it will initialize logging with static dispatch for the format, saving the
-    /// performance cost.
+    /// This is the primary entrypoint to the combined logging/tracing subsystem.  If
+    /// tracing, statement logging, and the log path are all not configured, it will initialize
+    /// logging with static dispatch for the format, saving some performance cost.
     ///
     /// When the `Options` struct itself goes out of scope, it will take care of the call to
     /// [opentelemetry::global::shutdown_tracer_provider] so that, when developing calling code,
     /// you don't need to remember.
+    ///
+    /// If statement logging is enabled, statement logs will be sent to a separate statement logging
+    /// file, which is <deployment_name>_statments.log by default, or configurable with the
+    /// `statement_log_path` option.
+    ///
+    /// If a log file is configured, it will be rolled over based on the configured rotation, and
+    /// when the WorkerGuard is dropped, the logs will be flushed.
     ///
     /// # Panics
     /// This will panic if called with tracing enabled outside the context of a tokio runtime.
@@ -266,7 +366,7 @@ impl Options {
     /// #[tokio::main]
     /// async fn main() {
     ///     let options = Options::parse();
-    ///     options
+    ///     let _guard = options
     ///         .tracing
     ///         .init("tracing-example", "example-deployment")
     ///         .unwrap();
@@ -274,12 +374,48 @@ impl Options {
     ///     // Perform work!
     /// }
     /// ```
-    pub fn init(&self, service_name: &str, deployment: &str) -> Result<(), Error> {
-        if self.tracing_host.is_some() {
-            self.init_logging_and_tracing(service_name, deployment)
-        } else {
-            self.init_logging_only(deployment).map_err(|e| e.into())
-        }
+    pub fn init(&self, service_name: &str, deployment: &str) -> Result<Option<WorkerGuard>, Error> {
+        // Note: There isn't a great way to make partial builders here and avoid this match, because
+        // the subscriber builder type embeds the layering types.
+        let res = Ok(
+            match (
+                self.tracing_host.is_some(),
+                self.statement_logging,
+                self.log_path.is_some(),
+            ) {
+                (true, true, true) => {
+                    let log_path = self.log_path.as_ref().expect("is some").as_path();
+                    self.setup_tracing_statement_logging_and_log_file(
+                        log_path,
+                        service_name,
+                        deployment,
+                    )
+                }
+                (true, true, false) => {
+                    self.setup_tracing_and_statement_logging(service_name, deployment)
+                }
+                (true, false, true) => {
+                    let log_path = self.log_path.as_ref().expect("is some").as_path();
+                    self.setup_tracing_and_log_file(log_path, service_name, deployment)
+                }
+                (true, false, false) => self.setup_tracing(service_name, deployment),
+                (false, true, true) => {
+                    let log_path = self.log_path.as_ref().expect("is some").as_path();
+                    self.setup_statement_logging_and_log_file(log_path, deployment)
+                }
+                (false, true, false) => self.setup_statement_logging(deployment),
+                (false, false, true) => {
+                    let log_path = self.log_path.as_ref().expect("is some").as_path();
+                    self.setup_log_file(log_path)
+                }
+                (false, false, false) => self.setup_basic(),
+            },
+        );
+
+        #[cfg(debug)]
+        warn_if_debug_build();
+
+        res
     }
 
     // Returns the provided `statement_log_path` or a default filename.
@@ -288,6 +424,138 @@ impl Options {
             Some(ref p) => p.clone(),
             None => format!("{}_statements.log", deployment),
         }
+    }
+
+    fn setup_tracing_statement_logging_and_log_file(
+        &self,
+        log_path: &Path,
+        service_name: &str,
+        deployment: &str,
+    ) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::registry()
+            .with(self.statement_logging_layer(&self.statement_log_path_or_default(deployment)))
+            .with(env_filter);
+
+        let (non_blocking, worker_guard) = self.setup_file_appender(log_path);
+        let fmt_layer = fmt::layer()
+            .with_ansi(!self.no_color)
+            .with_writer(non_blocking);
+        let tracing_layer = self.tracing_layer(service_name, deployment);
+
+        log_format_init!(self, s, fmt_layer, tracing_layer);
+
+        Some(worker_guard)
+    }
+
+    fn setup_tracing_and_statement_logging(
+        &self,
+        service_name: &str,
+        deployment: &str,
+    ) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::registry()
+            .with(self.statement_logging_layer(&self.statement_log_path_or_default(deployment)))
+            .with(env_filter);
+        let fmt_layer = fmt::layer().with_ansi(!self.no_color);
+        let tracing_layer = self.tracing_layer(service_name, deployment);
+
+        log_format_init!(self, s, fmt_layer, tracing_layer);
+
+        None
+    }
+
+    fn setup_tracing_and_log_file(
+        &self,
+        log_path: &Path,
+        service_name: &str,
+        deployment: &str,
+    ) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::registry().with(env_filter);
+
+        let (non_blocking, worker_guard) = self.setup_file_appender(log_path);
+        let fmt_layer = fmt::layer()
+            .with_ansi(!self.no_color)
+            .with_writer(non_blocking);
+        let tracing_layer = self.tracing_layer(service_name, deployment);
+
+        log_format_init!(self, s, fmt_layer, tracing_layer);
+
+        Some(worker_guard)
+    }
+
+    fn setup_tracing(&self, service_name: &str, deployment: &str) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::registry().with(env_filter);
+        let fmt_layer = fmt::layer().with_ansi(!self.no_color);
+        let tracing_layer = self.tracing_layer(service_name, deployment);
+
+        log_format_init!(self, s, fmt_layer, tracing_layer);
+
+        None
+    }
+
+    /// Sets up a subscriber with no tracing, but statement logging and a log file configured
+    fn setup_statement_logging_and_log_file(
+        &self,
+        log_path: &Path,
+        deployment: &str,
+    ) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::registry()
+            .with(self.statement_logging_layer(&self.statement_log_path_or_default(deployment)))
+            .with(env_filter);
+
+        let (non_blocking, worker_guard) = self.setup_file_appender(log_path);
+        let fmt_layer = fmt::layer()
+            .with_ansi(!self.no_color)
+            .with_writer(non_blocking);
+
+        log_format_init!(self, s, fmt_layer);
+
+        Some(worker_guard)
+    }
+
+    /// Sets up a subscriber with no tracing, statement logging and no log file configured
+    fn setup_statement_logging(&self, deployment: &str) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::registry()
+            .with(self.statement_logging_layer(&self.statement_log_path_or_default(deployment)))
+            .with(env_filter);
+
+        let fmt_layer = fmt::layer().with_ansi(!self.no_color);
+
+        log_format_init!(self, s, fmt_layer);
+
+        None
+    }
+
+    /// Sets up a subscriber with no tracing, no statement logging, but a log file configured
+    fn setup_log_file(&self, log_path: &Path) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let (non_blocking, worker_guard) = self.setup_file_appender(log_path);
+        let s = tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_ansi(!self.no_color)
+            .with_writer(non_blocking);
+
+        log_format_init!(self, s);
+
+        Some(worker_guard)
+    }
+
+    /// Sets up a subscriber with no tracing, no statement logging, and no log file configured
+    // In this case we can avoid dynamic dispatch/using the registry
+    fn setup_basic(&self) -> Option<WorkerGuard> {
+        let env_filter = tracing_subscriber::EnvFilter::new(&self.log_level);
+        let s = tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_ansi(!self.no_color);
+
+        log_format_init!(self, s);
+
+        None
     }
 }
 

--- a/readyset-tracing/src/percent.rs
+++ b/readyset-tracing/src/percent.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Percent(pub f64);
+pub struct Percent(pub f64);
 
 impl fmt::Display for Percent {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/readyset-tracing/src/propagation.rs
+++ b/readyset-tracing/src/propagation.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use opentelemetry::propagation::text_map_propagator::TextMapPropagator;
 use opentelemetry::propagation::{Extractor, Injector};
-use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use serde::{Deserialize, Serialize};
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -559,7 +559,8 @@ where
             .thread_name("Adapter Runtime")
             .build()?;
 
-        rt.block_on(async { options.tracing.init("adapter", options.deployment.as_ref()) })?;
+        let _guard =
+            rt.block_on(async { options.tracing.init("adapter", options.deployment.as_ref()) })?;
         info!(?options, "Starting ReadySet adapter");
 
         let deployment_mode = options.deployment_mode();


### PR DESCRIPTION
This commit adds the ability to specify a `LOG_PATH` into which readyset
logs will be written, as well as a log rotation policy for those logs.

Release-Note-Core: ReadySet now allows you to configure a `LOG_PATH` and
  `LOG_ROTATION`. Logs will be written to files prefixed with
  `readyset.log` in the log path if set and will be rotated according to
  the log rotation that is specified (or rotated daily if none is
  specified).

