### PR TITLE
adapter: Add `DROP ALL PROXIED QUERIES`

### DIFF
--- a/nom-sql/src/analysis/visit.rs
+++ b/nom-sql/src/analysis/visit.rs
@@ -19,12 +19,13 @@ use crate::{
     AlterColumnOperation, AlterTableDefinition, AlterTableStatement, CacheInner, CaseWhenBranch,
     Column, ColumnConstraint, ColumnSpecification, CommentStatement, CommonTableExpr,
     CompoundSelectStatement, CreateCacheStatement, CreateTableStatement, CreateViewStatement,
-    DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropTableStatement,
-    DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr,
-    GroupByClause, InValue, InsertStatement, JoinClause, JoinConstraint, JoinRightSide, Literal,
-    OrderBy, OrderClause, Relation, SelectSpecification, SelectStatement, SetNames,
-    SetPostgresParameter, SetStatement, SetVariables, ShowStatement, SqlIdentifier, SqlQuery,
-    SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement, UseStatement,
+    DeleteStatement, DropAllCachesStatement, DropAllProxiedQueriesStatement, DropCacheStatement,
+    DropTableStatement, DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr,
+    FieldReference, FunctionExpr, GroupByClause, InValue, InsertStatement, JoinClause,
+    JoinConstraint, JoinRightSide, Literal, OrderBy, OrderClause, Relation, SelectSpecification,
+    SelectStatement, SetNames, SetPostgresParameter, SetStatement, SetVariables, ShowStatement,
+    SqlIdentifier, SqlQuery, SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement,
+    UseStatement,
 };
 
 /// Each method of the `Visitor` trait is a hook to be potentially overridden when recursively
@@ -368,6 +369,13 @@ pub trait Visitor<'ast>: Sized {
     fn visit_drop_all_caches_statement(
         &mut self,
         _drop_all_caches_statement: &'ast DropAllCachesStatement,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_drop_all_proxied_queries_statement(
+        &mut self,
+        _drop_all_proxied_queries_statement: &'ast DropAllProxiedQueriesStatement,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -1132,6 +1140,9 @@ pub fn walk_sql_query<'a, V: Visitor<'a>>(
         SqlQuery::CreateCache(statement) => visitor.visit_create_cache_statement(statement),
         SqlQuery::DropCache(statement) => visitor.visit_drop_cache_statement(statement),
         SqlQuery::DropAllCaches(statement) => visitor.visit_drop_all_caches_statement(statement),
+        SqlQuery::DropAllProxiedQueries(statement) => {
+            visitor.visit_drop_all_proxied_queries_statement(statement)
+        }
         SqlQuery::DropView(statement) => visitor.visit_drop_view_statement(statement),
         SqlQuery::Use(statement) => visitor.visit_use_statement(statement),
         SqlQuery::Show(statement) => visitor.visit_show_statement(statement),

--- a/nom-sql/src/analysis/visit_mut.rs
+++ b/nom-sql/src/analysis/visit_mut.rs
@@ -19,12 +19,13 @@ use crate::{
     AlterColumnOperation, AlterTableDefinition, AlterTableStatement, CacheInner, CaseWhenBranch,
     Column, ColumnConstraint, ColumnSpecification, CommentStatement, CommonTableExpr,
     CompoundSelectStatement, CreateCacheStatement, CreateTableStatement, CreateViewStatement,
-    DeleteStatement, DropAllCachesStatement, DropCacheStatement, DropTableStatement,
-    DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr, FieldReference, FunctionExpr,
-    GroupByClause, InValue, InsertStatement, JoinClause, JoinConstraint, JoinRightSide, Literal,
-    OrderBy, OrderClause, Relation, SelectSpecification, SelectStatement, SetNames,
-    SetPostgresParameter, SetStatement, SetVariables, ShowStatement, SqlIdentifier, SqlQuery,
-    SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement, UseStatement,
+    DeleteStatement, DropAllCachesStatement, DropAllProxiedQueriesStatement, DropCacheStatement,
+    DropTableStatement, DropViewStatement, ExplainStatement, Expr, FieldDefinitionExpr,
+    FieldReference, FunctionExpr, GroupByClause, InValue, InsertStatement, JoinClause,
+    JoinConstraint, JoinRightSide, Literal, OrderBy, OrderClause, Relation, SelectSpecification,
+    SelectStatement, SetNames, SetPostgresParameter, SetStatement, SetVariables, ShowStatement,
+    SqlIdentifier, SqlQuery, SqlType, TableExpr, TableExprInner, TableKey, UpdateStatement,
+    UseStatement,
 };
 
 /// Each method of the `VisitorMut` trait is a hook to be potentially overridden when recursively
@@ -383,6 +384,13 @@ pub trait VisitorMut<'ast>: Sized {
     fn visit_drop_all_caches_statement(
         &mut self,
         _drop_all_caches_statement: &'ast mut DropAllCachesStatement,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_drop_all_proxied_queries_statement(
+        &mut self,
+        _drop_all_proxied_queries_statement: &'ast mut DropAllProxiedQueriesStatement,
     ) -> Result<(), Self::Error> {
         Ok(())
     }
@@ -1152,6 +1160,9 @@ pub fn walk_sql_query<'a, V: VisitorMut<'a>>(
         SqlQuery::CreateCache(statement) => visitor.visit_create_cache_statement(statement),
         SqlQuery::DropCache(statement) => visitor.visit_drop_cache_statement(statement),
         SqlQuery::DropAllCaches(statement) => visitor.visit_drop_all_caches_statement(statement),
+        SqlQuery::DropAllProxiedQueries(statement) => {
+            visitor.visit_drop_all_proxied_queries_statement(statement)
+        }
         SqlQuery::DropView(statement) => visitor.visit_drop_view_statement(statement),
         SqlQuery::Use(statement) => visitor.visit_use_statement(statement),
         SqlQuery::Show(statement) => visitor.visit_show_statement(statement),

--- a/nom-sql/src/drop.rs
+++ b/nom-sql/src/drop.rs
@@ -78,6 +78,30 @@ pub fn drop_table(
     }
 }
 
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct DropAllProxiedQueriesStatement;
+
+impl DialectDisplay for DropAllProxiedQueriesStatement {
+    fn display(&self, _dialect: Dialect) -> impl fmt::Display + '_ {
+        fmt_with(move |f| write!(f, "DROP ALL PROXIED QUERIES"))
+    }
+}
+
+pub fn drop_all_proxied_queries(
+) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], DropAllProxiedQueriesStatement> {
+    move |i| {
+        let (i, _) = tag_no_case("drop")(i)?;
+        let (i, _) = whitespace1(i)?;
+        let (i, _) = tag_no_case("all")(i)?;
+        let (i, _) = whitespace1(i)?;
+        let (i, _) = tag_no_case("proxied")(i)?;
+        let (i, _) = whitespace1(i)?;
+        let (i, _) = tag_no_case("queries")(i)?;
+
+        Ok((i, DropAllProxiedQueriesStatement))
+    }
+}
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct DropCacheStatement {
     pub name: Relation,
@@ -249,6 +273,14 @@ mod tests {
             ]
         );
         assert!(!res.if_exists);
+    }
+
+    #[test]
+    fn parse_drop_all_proxied_queries() {
+        test_parse!(
+            drop_all_proxied_queries(),
+            b"DroP    aLl       PrOXied      querIES"
+        );
     }
 
     mod mysql {

--- a/nom-sql/src/lib.rs
+++ b/nom-sql/src/lib.rs
@@ -28,7 +28,8 @@ pub use self::create_table_options::CreateTableOption;
 pub use self::delete::DeleteStatement;
 pub use self::dialect::{Dialect, DialectDisplay};
 pub use self::drop::{
-    DropAllCachesStatement, DropCacheStatement, DropTableStatement, DropViewStatement,
+    DropAllCachesStatement, DropAllProxiedQueriesStatement, DropCacheStatement, DropTableStatement,
+    DropViewStatement,
 };
 pub use self::explain::ExplainStatement;
 pub use self::expression::{

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1907,6 +1907,15 @@ where
         Ok(noria_connector::QueryResult::Empty)
     }
 
+    /// Handles a `DROP ALL PROXIED QUERIES` request
+    #[instrument(skip(self))]
+    async fn drop_all_proxied_queries(
+        &mut self,
+    ) -> ReadySetResult<noria_connector::QueryResult<'static>> {
+        self.state.query_status_cache.clear_proxied_queries();
+        Ok(noria_connector::QueryResult::Empty)
+    }
+
     /// Responds to a `SHOW PROXIED QUERIES` query
     #[instrument(skip(self))]
     async fn show_proxied_queries(
@@ -2296,6 +2305,7 @@ where
                 }
                 self.drop_all_caches().await
             }
+            SqlQuery::DropAllProxiedQueries(_) => self.drop_all_proxied_queries().await,
             SqlQuery::Show(ShowStatement::CachedQueries(query_id)) => {
                 // Log a telemetry event
                 if let Some(ref telemetry_sender) = self.telemetry_sender {
@@ -2690,6 +2700,7 @@ where
                     SqlQuery::CreateCache(_)
                     | SqlQuery::DropCache(_)
                     | SqlQuery::DropAllCaches(_)
+                    | SqlQuery::DropAllProxiedQueries(_)
                     | SqlQuery::Explain(_) => {
                         unreachable!("path returns prior")
                     }

--- a/readyset-logictest/src/from_query_log.rs
+++ b/readyset-logictest/src/from_query_log.rs
@@ -112,6 +112,7 @@ fn is_ddl(query: &SqlQuery) -> bool {
         | SqlQuery::Use(_)
         | SqlQuery::CreateCache(_)
         | SqlQuery::DropCache(_)
+        | SqlQuery::DropAllProxiedQueries(_)
         | SqlQuery::DropAllCaches(_) => true,
     }
 }


### PR DESCRIPTION
This commit adds a new `DROP ALL PROXIED QUERIES` SQL extension, which
removes all the queries from the query status cache whose statuses are not
"Successful". This is being added to support end-to-end testing of the list
of queries in `SHOW PROXIED QUERIES` by allowing tests to clear the
queries in that list without having to restart ReadySet.

