### PR TITLE
build: Add log info options to debian service config

### DIFF
--- a/readyset/debian/readyset.conf
+++ b/readyset/debian/readyset.conf
@@ -15,8 +15,14 @@ LISTEN_ADDRESS=0.0.0.0:5433
 ## Directory in which to store replicated table data.
 STORAGE_DIR=/var/lib/readyset
 
-## IP:PORT to host endpoint for scraping metrics from the adapter
-# METRICS_ADDRESS=0.0.0.0:6034
+## Optional path to which to write logs.  Logs will be written to
+## `readyset.log` within this path.  If unset, defaults to stdout.  Logs will
+## roll over based on LOG_ROTATION (see below).
+LOG_PATH=/var/lib/readyset
+
+## Log rotation policy to use if LOG_PATH is set.  Possible values: daily,
+## hourly, minutely, never.
+LOG_ROTATION=daily
 
 ## Format to use when emitting log events
 ## Possible values:
@@ -34,6 +40,9 @@ STORAGE_DIR=/var/lib/readyset
 ##    Log at TRACE level for all crates and dependencies except tower which
 ##       should be logged at ERROR level. ```bash LOG_LEVEL=trace,tower=error ```
 # LOG_LEVEL=info
+
+## IP:PORT to host endpoint for scraping metrics from the adapter
+# METRICS_ADDRESS=0.0.0.0:6034
 
 ## By default, ReadySet attempts to snapshot and replicate all tables in the #
 ## database specified in UPSTREAM_DB_URL. However, if the queries to cache in


### PR DESCRIPTION
Sets default log dir for the systemd service to /var/lib/readyset, with
a rotation of daily.

