### PR TITLE
replicators: Allow alphanumeric replication server ids

### DIFF
--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use database_utils::DatabaseURL;
+use database_utils::{DatabaseURL, ReplicationServerId};
 use nom_sql::Relation;
 use readyset_adapter::backend::noria_connector::{NoriaConnector, ReadBehavior};
 use readyset_adapter::backend::{BackendBuilder, MigrationMode};
@@ -88,7 +88,7 @@ pub struct TestBuilder {
     durability_mode: DurabilityMode,
     storage_dir_path: Option<PathBuf>,
     authority: Option<Arc<Authority>>,
-    replication_server_id: Option<u32>,
+    replication_server_id: Option<ReplicationServerId>,
 }
 
 impl Default for TestBuilder {
@@ -180,8 +180,8 @@ impl TestBuilder {
         self
     }
 
-    pub fn replication_server_id(mut self, replication_server_id: u32) -> Self {
-        self.replication_server_id = Some(replication_server_id);
+    pub fn replication_server_id(mut self, replication_server_id: String) -> Self {
+        self.replication_server_id = Some(ReplicationServerId(replication_server_id));
         self
     }
 

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2391,7 +2391,7 @@ mod failure_injection_tests {
 
         let (config, mut handle, shutdown_tx) = TestBuilder::default()
             .migration_mode(MigrationMode::InRequestPath)
-            .replication_server_id(123)
+            .replication_server_id("readyset_123".into())
             .fallback(true)
             .build::<PostgreSQLAdapter>()
             .await;

--- a/readyset-server/src/builder.rs
+++ b/readyset-server/src/builder.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{self, Duration};
 
-use database_utils::UpstreamConfig;
+use database_utils::{ReplicationServerId, UpstreamConfig};
 use dataflow::PersistenceParameters;
 use readyset_client::consensus::{
     Authority, LocalAuthority, LocalAuthorityStore, NodeTypeSchedulingRestriction,
@@ -257,7 +257,7 @@ impl Builder {
     }
 
     /// Set the server ID for replication
-    pub fn set_replicator_server_id(&mut self, server_id: u32) {
+    pub fn set_replicator_server_id(&mut self, server_id: ReplicationServerId) {
         self.config.replicator_config.replication_server_id = Some(server_id);
     }
 

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -428,11 +428,23 @@ impl NoriaAdapter {
             (Some(pos), _) => pos.clone().try_into()?,
         };
 
+        let server_id = config
+            .replication_server_id
+            .as_ref()
+            .map(|id| id.0.parse::<u32>())
+            .transpose()
+            .map_err(|_| {
+                ReadySetError::ReplicationFailed(format!(
+                    "{} is an invalid server id--it must be a valid u32.",
+                    config.replication_server_id.unwrap()
+                ))
+            })?;
+
         let connector = Box::new(
             MySqlBinlogConnector::connect(
                 mysql_options.clone(),
                 pos.clone(),
-                config.replication_server_id,
+                server_id,
                 enable_statement_logging,
             )
             .await?,

--- a/replicators/tests/tests.rs
+++ b/replicators/tests/tests.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use database_utils::UpstreamConfig as Config;
+use database_utils::{ReplicationServerId, UpstreamConfig as Config};
 use itertools::Itertools;
 use mysql_async::prelude::Queryable;
 use mysql_time::MySqlTime;
@@ -499,11 +499,11 @@ async fn replication_test_multiple(url: &str) -> ReadySetResult<()> {
     client.query(POPULATE_SCHEMA).await?;
 
     let config_one = Config {
-        replication_server_id: Some(1),
+        replication_server_id: Some(ReplicationServerId("1".into())),
         ..Default::default()
     };
     let config_two = Config {
-        replication_server_id: Some(2),
+        replication_server_id: Some(ReplicationServerId("2".into())),
         ..Default::default()
     };
     let (mut ctx_one, shutdown_tx_one) =


### PR DESCRIPTION
It may be useful to use alphabetic characters in a replication server id
to uniquely identify a postgres replication slot--this commit expands
replication_server_id to allow for that.

Currently, mysql still requires a numeric server id, so that branch
still enforces that.

Release-Note-Core: REPLICATION_SERVER_ID can now be configured to use
  alphanumeric characters for postgres.

