### PR TITLE
df-expr: Fix convert_tz proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5302,6 +5302,7 @@ dependencies = [
  "backoff",
  "bit-vec",
  "chrono",
+ "chrono-tz",
  "cidr",
  "eui48",
  "futures",

--- a/readyset-util/Cargo.toml
+++ b/readyset-util/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 backoff = { version = "0.4.0", features = ["tokio"] }
 proptest = "1.0.0"
 chrono = { version = "0.4.0", features = ["serde"] }
+chrono-tz = "0.5"
 tokio = { workspace = true, features = ["full"] }
 futures = "0.3"
 tracing = { version = "0.1", features = ["release_max_level_debug"] }


### PR DESCRIPTION
In the `convert_tz` proptest, we were not validating that the random
`NaiveDateTime`s being generated represented a valid time in the
"source" timezone being used in the test (Atlantic/Cape_Verde). This
commit adds a new strategy function to generate `NaiveDateTime`s that
represent valid times in the given timezone.

