### PR TITLE
adapter: Reconnect for upstream reachability test

### DIFF
--- a/readyset-adapter/src/upstream_database.rs
+++ b/readyset-adapter/src/upstream_database.rs
@@ -200,7 +200,7 @@ impl<U> LazyUpstream<U>
 where
     U: UpstreamDatabase,
 {
-    async fn connect(&mut self) -> Result<(), U::Error> {
+    pub async fn connect(&mut self) -> Result<(), U::Error> {
         debug!("LazyUpstream connecting to upstream");
         self.upstream = Some(U::connect(self.upstream_config.clone()).await?);
         Ok(())

--- a/readyset-mysql/tests/integration.rs
+++ b/readyset-mysql/tests/integration.rs
@@ -1837,7 +1837,7 @@ async fn show_readyset_status() {
     assert_eq!(ret.len(), 6);
     let row = ret.remove(0);
     assert_eq!(row.get::<String, _>(0).unwrap(), "Database Connection");
-    assert_eq!(row.get::<String, _>(1).unwrap(), "Unreachable");
+    assert_eq!(row.get::<String, _>(1).unwrap(), "Connected");
     let row = ret.remove(0);
     assert_eq!(row.get::<String, _>(0).unwrap(), "Connection Count");
     assert_eq!(row.get::<String, _>(1).unwrap(), "0");

--- a/readyset/tests/http.rs
+++ b/readyset/tests/http.rs
@@ -79,7 +79,7 @@ async fn http_tests() {
 
     let status: ReadySetStatus = serde_json::from_str(&payload).unwrap();
     assert_eq!(status.connection_count, 0);
-    assert_eq!(status.connected, Some(true));
+    assert_eq!(status.upstream_reachable, Some(true));
     assert!(status.persistent_stats.is_some());
     assert!(status.controller_status.is_some());
 }


### PR DESCRIPTION
The status reporter maintains a LazyUpstream connection to the upstream
to report whether the upstream is reachable or not. If the upstream
connection is severed (say, if postgres restarts), this connection was
no longer connected and reported unreachability. Now it attempts to
reconnect in this case and only reports unreachability if the
re-connection fails.

Fixes: REA-4039
