### PR TITLE
metrics: Change startup timestamp to gauge

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2256,7 +2256,7 @@ where
                 // to create this cache. Extend recipe waits a bit and then returns an
                 // Ok(ExtendRecipeResult::Pending) if it is still creating a cache in the
                 // background, so we don't remove the ddl request for timeouts.
-                if res.is_err() {
+                if let Err(e) = &res {
                     if let Some(ddl_req) = ddl_req {
                         let remove_res = retry_with_exponential_backoff(
                             async || {
@@ -2271,6 +2271,8 @@ where
                             error!("Failed to remove stored 'create cache' request. It will be re-run if there is a backwards incompatible upgrade.");
                         }
                     }
+
+                    error!("Failed to create cache: {}", Sensitive(e));
                 }
                 res
             }

--- a/readyset-adapter/src/metrics_handle.rs
+++ b/readyset-adapter/src/metrics_handle.rs
@@ -122,8 +122,8 @@ impl MetricsHandle {
     pub fn readyset_status(&self) -> Vec<(String, String)> {
         let mut statuses = Vec::new();
 
-        let time_ms = self.sum_counter(client_recorded::NORIA_STARTUP_TIMESTAMP);
-        let time = TimestampTz::from_unix_ms(time_ms);
+        let time_ms = self.sum_gauge(client_recorded::NORIA_STARTUP_TIMESTAMP);
+        let time = TimestampTz::from_unix_ms(time_ms as u64);
         statuses.push(("Process start time".to_string(), time.to_string()));
 
         let val = self.sum_gauge(readyset_client_metrics::recorded::CONNECTED_CLIENTS);

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -14,7 +14,7 @@ pub mod client;
 /// Documents the set of metrics that are currently being recorded within
 /// a ReadySet instance.
 pub mod recorded {
-    /// Counter: Set at startup of a ReadySet service to the current unix
+    /// Gauge: Set at startup of a ReadySet service to the current unix
     /// timestamp in milliseconds, this metric can be used to detect service
     /// restarts. When available, prefer the metrics scraped by whatever
     /// manages orchestration (such as kube-state-metrics's

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -211,12 +211,12 @@ fn main() -> anyhow::Result<()> {
             ("opt_level", READYSET_VERSION.opt_level),
         ]
     );
-    metrics::counter!(
+    metrics::gauge!(
         recorded::NORIA_STARTUP_TIMESTAMP,
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_millis() as u64
+            .as_millis() as f64
     );
 
     if let Some(volume_id) = &opts.worker_options.volume_id {

--- a/readyset-util/src/redacted.rs
+++ b/readyset-util/src/redacted.rs
@@ -8,14 +8,6 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-/// Constant which is set to `true` if the `redact_sensitive` feature is enabled
-#[cfg(not(feature = "redact_sensitive"))]
-pub const REDACT_SENSITIVE: bool = false;
-
-/// Constant which is set to `true` if the `redact_sensitive` feature is enabled
-#[cfg(feature = "redact_sensitive")]
-pub const REDACT_SENSITIVE: bool = false;
-
 /// Wraps a type that implements Display and Debug, overriding both implementations if the
 /// `redact_sensitive` feature is enabled
 pub struct Sensitive<'a, T: ?Sized>(pub &'a T);

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -786,12 +786,12 @@ where
                 ("opt_level", READYSET_VERSION.opt_level),
             ]
         );
-        metrics::counter!(
+        metrics::gauge!(
             recorded::NORIA_STARTUP_TIMESTAMP,
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .as_millis() as u64
+                .as_millis() as f64
         );
 
         let (shutdown_tx, shutdown_rx) = shutdown::channel();


### PR DESCRIPTION
Previously, we were using a counter metric to record startup timestamps.
However, counters should only be used when you don't care about the
absolute value of the metric and rather just its rate of change. This
commit changes the metric type to be a gauge, which is more accurate.

