### PR TITLE
metrics: Remove domain handle request time

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -244,17 +244,6 @@ pub mod recorded {
     /// | packet_type | The packet's type |
     pub const DOMAIN_TOTAL_HANDLE_PACKET_TIME: &str = "readyset_domain.total_handle_packet_time_us";
 
-    /// Histogram: The time in microseconds that the domain spends handling an
-    /// incoming domain request. This is aggregate metric per request's type.
-    /// Recorded at the domain following request handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the request is recorded in. |
-    /// | shard | The shard the request is recorded in. |
-    /// | request_type | The request's type |
-    pub const DOMAIN_HANDLE_REQUEST_TIME: &str = "readyset_domain.handle_request_time_us";
-
     /// Counter: The total time in microseconds that the domain spends handling
     /// an incoming domain request. This is aggregate metric per request's type.
     /// Recorded at the domain following request handling.

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -16,7 +16,6 @@ use readyset_client::metrics::recorded;
 use strum::{EnumCount, IntoEnumIterator};
 
 use crate::domain::{LocalNodeIndex, Tag};
-use crate::payload::DomainRequestDiscriminants;
 use crate::{NodeMap, Packet, PacketDiscriminants};
 
 /// Contains handles to the various metrics collected for a domain.
@@ -51,8 +50,6 @@ pub(super) struct DomainMetrics {
     node_state_size: NodeMap<Gauge>,
     packet_handle_time: [Histogram; PacketDiscriminants::COUNT],
     total_packet_handle_time: [Counter; PacketDiscriminants::COUNT],
-    request_handle_time: [Histogram; DomainRequestDiscriminants::COUNT],
-    total_request_handle_time: [Counter; DomainRequestDiscriminants::COUNT],
 }
 
 impl DomainMetrics {
@@ -96,26 +93,6 @@ impl DomainMetrics {
                 )
             })
             .collect();
-        let request_handle_time: Vec<Histogram> = DomainRequestDiscriminants::iter()
-            .map(|d| {
-                let name: &'static str = d.into();
-                register_histogram!(recorded::DOMAIN_HANDLE_REQUEST_TIME,
-                                  "domain" => index.clone(),
-                                  "shard" => shard.clone(),
-                                  "request_type" => name,
-                )
-            })
-            .collect();
-        let total_request_handle_time: Vec<Counter> = DomainRequestDiscriminants::iter()
-            .map(|d| {
-                let name: &'static str = d.into();
-                register_counter!(recorded::DOMAIN_TOTAL_HANDLE_REQUEST_TIME,
-                                  "domain" => index.clone(),
-                                  "shard" => shard.clone(),
-                                  "request_type" => name,
-                )
-            })
-            .collect();
         DomainMetrics {
             partial_state_size: register_gauge!(
                 recorded::DOMAIN_PARTIAL_STATE_SIZE_BYTES,
@@ -144,20 +121,9 @@ impl DomainMetrics {
             node_state_size: Default::default(),
             packet_handle_time: packet_handle_time.try_into().ok().unwrap(),
             total_packet_handle_time: total_packet_handle_time.try_into().ok().unwrap(),
-            request_handle_time: request_handle_time.try_into().ok().unwrap(),
-            total_request_handle_time: total_request_handle_time.try_into().ok().unwrap(),
             shard,
             index,
         }
-    }
-
-    pub(super) fn rec_request_handle_time(
-        &self,
-        time: Duration,
-        discriminant: DomainRequestDiscriminants,
-    ) {
-        self.request_handle_time[discriminant as usize].record(time.as_micros() as f64);
-        self.total_request_handle_time[discriminant as usize].increment(time.as_micros() as u64);
     }
 
     pub(super) fn rec_packet_handle_time(&self, time: Duration, discriminant: PacketDiscriminants) {

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -48,8 +48,8 @@ use crate::domain::channel::{ChannelCoordinator, DomainReceiver, DomainSender};
 use crate::node::special::EgressTx;
 use crate::node::{NodeProcessingResult, ProcessEnv};
 use crate::payload::{
-    DomainRequestDiscriminants, EvictRequest, MaterializedState, PrepareStateKind,
-    PrettyReplayPath, ReplayPieceContext, SourceSelection,
+    EvictRequest, MaterializedState, PrepareStateKind, PrettyReplayPath, ReplayPieceContext,
+    SourceSelection,
 };
 use crate::prelude::*;
 use crate::processing::ColumnMiss;
@@ -1393,8 +1393,6 @@ impl Domain {
         executor: &mut dyn Executor,
     ) -> ReadySetResult<Option<Vec<u8>>> {
         trace!(?req, "processing domain request");
-        let discriminant: DomainRequestDiscriminants = (&req).into();
-        let start = time::Instant::now();
         let ret = match req {
             DomainRequest::AddNode { node, parents } => {
                 let addr = node.local_addr();
@@ -2349,8 +2347,7 @@ impl Domain {
                 Ok(Some(bincode::serialize(&key)?))
             }
         };
-        self.metrics
-            .rec_request_handle_time(start.elapsed(), discriminant);
+
         // What we just did might have done things like insert into `self.delayed_for_self`, so
         // run the event loop before returning to make sure that gets processed.
         //


### PR DESCRIPTION
This commit removes the metrics we were emitting that tracked the time
spend handling domain requests. These metrics were subject to a
cardinality explosion across the labels we're using, and ultimately, we
decided that this metric is not worth having for the time being. If we
need to, we can track the request times for individual domain request
variants to try to avoid the cardinality explosion.

