### PR TITLE
readyset-server: configure persistence threads based on cpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,15 +2133,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
@@ -3340,11 +3331,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 
@@ -4316,27 +4307,22 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
- "num_cpus",
 ]
 
 [[package]]
@@ -5042,6 +5028,7 @@ dependencies = [
  "mysql",
  "nom",
  "nom-sql",
+ "num_cpus",
  "once_cell",
  "parking_lot 0.11.2",
  "petgraph",

--- a/readyset-server/Cargo.toml
+++ b/readyset-server/Cargo.toml
@@ -101,6 +101,7 @@ health-reporter = { path = "../health-reporter" }
 database-utils = { path = "../database-utils" }
 catalog-tables = { path = "../catalog-tables" }
 replication-offset = { path = "../replication-offset" }
+num_cpus = "1.16.0"
 
 [dev-dependencies]
 dataflow = { path = "../readyset-dataflow", package = "readyset-dataflow", features = ["bench"] }

--- a/readyset-server/src/builder.rs
+++ b/readyset-server/src/builder.rs
@@ -1,3 +1,4 @@
+use std::cmp::max;
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
@@ -12,6 +13,7 @@ use readyset_client::consensus::{
 };
 use readyset_telemetry_reporter::TelemetrySender;
 use readyset_util::shutdown::{self, ShutdownSender};
+use tracing::info;
 
 use crate::controller::replication::ReplicationStrategy;
 use crate::handle::Handle;
@@ -103,7 +105,24 @@ impl Builder {
         let persistence_params = PersistenceParameters::new(
             opts.durability,
             Some(deployment.into()),
-            opts.persistence_threads,
+            opts.persistence_threads.unwrap_or_else(|| {
+                // RocksDB optimizes for 8 threads, so we use that as the default if we have more
+                // than 8 logical cpu cores. But since compaction can be cpu-heavy, leave a logical
+                // core free to handle other things.
+                let n_cpus = num_cpus::get();
+                let n_threads = if n_cpus > 8 {
+                    8
+                } else {
+                    max(
+                        1,
+                        (n_cpus - 1)
+                            .try_into()
+                            .expect("n_cpus >= 0 and <= i32::max"),
+                    )
+                };
+                info!("Using {n_threads} persistence threads");
+                n_threads
+            }),
             Some(deployment_dir),
             builder
                 .config

--- a/readyset-server/src/lib.rs
+++ b/readyset-server/src/lib.rs
@@ -559,8 +559,10 @@ pub struct WorkerOptions {
     pub durability: DurabilityMode,
 
     /// Number of background threads used by RocksDB
-    #[arg(long, default_value = "6", hide = true)]
-    pub persistence_threads: i32,
+    /// If not specified, readyset will automatically set this at startup based on the number of
+    /// cpu cores available.
+    #[arg(long, hide = true)]
+    pub persistence_threads: Option<i32>,
 
     /// Memory high water mark, in bytes. If process heap memory exceeds this value, we
     /// will perform evictions from partially materialized state. (0 = unlimited)


### PR DESCRIPTION
If we are running on an instance that has limited cpu cores, we dont
want to give too many of them to rocksdb, especially since during
snapshotting and compaction they can use quite a lot of CPU and cause
other things like health checks or proxied queries to experience
degradation.

This commit changes the default of persistnce_threads to be based on the
number of CPUS rather than a straight '6'.

