### PR TITLE
replicators: Limit maximum snapshot parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,7 @@ dependencies = [
  "mysql_async",
  "native-tls",
  "nom-sql",
+ "num_cpus",
  "postgres-native-tls",
  "readyset-client",
  "readyset-errors",

--- a/database-utils/Cargo.toml
+++ b/database-utils/Cargo.toml
@@ -22,3 +22,4 @@ async-trait = "0.1"
 nom-sql = { path = "../nom-sql" }
 readyset-client = { path = "../readyset-client" }
 deadpool-postgres = "0.10.3"
+num_cpus = "1.15.0"

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -479,6 +479,7 @@ impl MySqlReplicator {
         db_schemas: &mut DatabaseSchemas,
         snapshot_report_interval_secs: u16,
         full_snapshot: bool,
+        _max_parallel_snapshot_tables: usize, // TODO: limit parallelism for MySQL
     ) -> ReadySetResult<()> {
         let result = self
             .replicate_to_noria_with_table_locks(

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -371,6 +371,7 @@ impl NoriaAdapter {
                         &mut db_schemas,
                         config.snapshot_report_interval_secs,
                         full_snapshot,
+                        config.max_parallel_snapshot_tables(),
                     )
                     .instrument(span.clone())
                     .await;
@@ -570,6 +571,7 @@ impl NoriaAdapter {
                 ReadySetError::Internal(format!("Unable to parse postgres version: {}", e))
             })?;
 
+        let max_parallel_snapshot_tables = config.max_parallel_snapshot_tables();
         let mut connector = Box::new(
             PostgresWalConnector::connect(
                 pgsql_opts.clone(),
@@ -673,6 +675,7 @@ impl NoriaAdapter {
                     //  tables we do have a replication offset for that happened while we weren't
                     //  running.
                     pos.is_none() || full_resnapshot,
+                    max_parallel_snapshot_tables,
                 )
                 .await;
 


### PR DESCRIPTION
For smaller instances especially, snapshotting can saturate the CPU and
cause issues for things like background tasks, proxying, and external
health checks.

This commit allows for configuring the maximum number of parallel
snapshotting tables to allow. Note that the previous behavior seems to
have been limited to a parallelism of 50 by tokio itself.

