### PR TITLE
Revert "metrics: Add domain packet execution time by type metrics"

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -198,28 +198,6 @@ pub mod recorded {
     /// | tag | The client tag of the request that the Finish packet is required for. |
     pub const DOMAIN_TOTAL_FINISH_REPLAY_TIME: &str = "readyset_domain.total_finish_replay_time_us";
 
-    /// Histogram: The time in microseconds that the domain spends handling an
-    /// incoming messages (packets). This is aggregate metric per packet's type.
-    /// Recorded at the domain following packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the request is recorded in. |
-    /// | shard | The shard the request is recorded in. |
-    /// | packet_type | The packet's type |
-    pub const DOMAIN_HANDLE_PACKET_TIME: &str = "readyset_domain.handle_packet_time_us";
-
-    /// Counter: The total time in microseconds that the domain spends handling
-    /// an incoming messages (packets). This is aggregate metric per packet's type.
-    /// Recorded at the domain following packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the request is recorded in. |
-    /// | shard | The shard the request is recorded in. |
-    /// | packet_type | The packet's type |
-    pub const DOMAIN_TOTAL_HANDLE_PACKET_TIME: &str = "readyset_domain.total_handle_packet_time_us";
-
     /// Histogram: The amount of time spent handling an eviction
     /// request.
     pub const EVICTION_TIME: &str = "readyset_eviction_time_us";

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -48,8 +48,6 @@ pub(super) struct DomainMetrics {
     chunked_replay_time: NodeMap<(Counter, Histogram)>,
     base_table_lookups: NodeMap<Counter>,
     node_state_size: NodeMap<Gauge>,
-    packet_handle_time: [Histogram; PacketDiscriminants::COUNT],
-    total_packet_handle_time: [Counter; PacketDiscriminants::COUNT],
 }
 
 impl DomainMetrics {
@@ -73,26 +71,6 @@ impl DomainMetrics {
             })
             .collect();
 
-        let packet_handle_time: Vec<Histogram> = PacketDiscriminants::iter()
-            .map(|d| {
-                let name: &'static str = d.into();
-                register_histogram!(recorded::DOMAIN_HANDLE_PACKET_TIME,
-                                  "domain" => index.clone(),
-                                  "shard" => shard.clone(),
-                                  "packet_type" => name,
-                )
-            })
-            .collect();
-        let total_packet_handle_time: Vec<Counter> = PacketDiscriminants::iter()
-            .map(|d| {
-                let name: &'static str = d.into();
-                register_counter!(recorded::DOMAIN_TOTAL_HANDLE_PACKET_TIME,
-                                  "domain" => index.clone(),
-                                  "shard" => shard.clone(),
-                                  "packet_type" => name,
-                )
-            })
-            .collect();
         DomainMetrics {
             partial_state_size: register_gauge!(
                 recorded::DOMAIN_PARTIAL_STATE_SIZE_BYTES,
@@ -119,16 +97,9 @@ impl DomainMetrics {
             reader_replay_request_time: Default::default(),
             base_table_lookups: Default::default(),
             node_state_size: Default::default(),
-            packet_handle_time: packet_handle_time.try_into().ok().unwrap(),
-            total_packet_handle_time: total_packet_handle_time.try_into().ok().unwrap(),
             shard,
             index,
         }
-    }
-
-    pub(super) fn rec_packet_handle_time(&self, time: Duration, discriminant: PacketDiscriminants) {
-        self.packet_handle_time[discriminant as usize].record(time.as_micros() as f64);
-        self.total_packet_handle_time[discriminant as usize].increment(time.as_micros() as u64);
     }
 
     pub(super) fn inc_eviction_requests(&self) {

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -451,6 +451,7 @@ impl DomainBuilder {
 
             total_replay_time: Timer::new(),
             total_forward_time: Timer::new(),
+
             aggressively_update_state_sizes: self.config.aggressively_update_state_sizes,
 
             metrics: domain_metrics::DomainMetrics::new(address),
@@ -660,6 +661,7 @@ pub struct Domain {
     total_replay_time: Timer<SimpleTracker, RealTime>,
     /// time spent processing ordinary, forward updates
     total_forward_time: Timer<SimpleTracker, RealTime>,
+
     /// If set to `true`, the metric tracking the in-memory size of materialized state will be
     /// updated after every packet is handled, rather than only when requested by the eviction
     /// worker. This causes a (minor) runtime cost, with the upside being that the materialization
@@ -2362,9 +2364,9 @@ impl Domain {
         // TODO(eta): better error handling here.
         // In particular one dodgy packet can kill the whole domain, which is probably not what we
         // want.
+
         self.metrics.inc_packets_sent(&m);
-        let discriminant = (&m).into();
-        let start = time::Instant::now();
+
         match m {
             Packet::Message { .. } | Packet::Input { .. } => {
                 // WO for https://github.com/rust-lang/rfcs/issues/1403
@@ -2494,8 +2496,7 @@ impl Domain {
                 // spinning as instructed
             }
         }
-        self.metrics
-            .rec_packet_handle_time(start.elapsed(), discriminant);
+
         Ok(())
     }
 
@@ -4507,6 +4508,7 @@ impl Domain {
                 "tried to set state for non-existent node"
             );
         }
+
         Ok(())
     }
 


### PR DESCRIPTION
This reverts commit 487564116b9b5110280311d4bb74d1ff734b49dc.

This metric duplicates a number of other metrics we already have (e.g.
`readyset.readyset_forward_time_us`, `readyset_domain.handle_replay_time`,
`readyset_domain.reader_replay_request_time_us`, etc.). In hindsight, it
probably makes sense to have individual metrics to measure these packet
handle times, since the different metrics will require different labels
(e.g. we will add a `cache_name` label to some of these metrics in a
future commit). To reduce the cost of emitting unnecessary metrics, this
commit reverts 487564116b9b5110280311d4bb74d1ff734b49dc.

Release-Note-Core: Removed an expensive domain-related metric that
  duplicated pre-existing metrics
