### PR TITLE
metrics: Fix replay misses

### DIFF
--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -307,7 +307,7 @@ impl DomainMetrics {
             ctr.increment(n as u64);
         } else {
             let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
+                recorded::DOMAIN_REPLAY_MISSES,
                 "domain" => self.index.clone(),
                 "shard" => self.shard.clone(),
                 "miss_in" => miss_in.id().to_string(),


### PR DESCRIPTION
Previously, we were using a chunked replay metric in the
`DomainMetrics::inc_replay_misses` method, which is intended to count
the number of misses during a replay for a given domain. This commit
switches in the correct metric.

Release-Note-Core: Fixed an issue where the wrong metric was being
  emitted to count the number of misses during a replay.
