### PR TITLE
metrics: Rework startup metrics

### DIFF
--- a/benchmarks/src/bin/write_propagation.rs
+++ b/benchmarks/src/bin/write_propagation.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{mpsc, Arc};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use benchmarks::utils::backend::Backend;
 use benchmarks::utils::generate::load_to_backend;
@@ -113,6 +113,7 @@ impl Writer {
                 (Dialect::DEFAULT_POSTGRESQL, nom_sql::Dialect::PostgreSQL)
             }
         };
+        let adapter_start_time = SystemTime::now();
         let noria = NoriaConnector::new(
             ch.clone(),
             auto_increments,
@@ -126,7 +127,7 @@ impl Writer {
         )
         .await;
 
-        let mut b = Backend::new(&self.database_url, noria, authority).await?;
+        let mut b = Backend::new(&self.database_url, noria, authority, adapter_start_time).await?;
 
         let mut view = ch.view("w").await.unwrap();
 

--- a/benchmarks/src/utils/backend.rs
+++ b/benchmarks/src/utils/backend.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use crossbeam_skiplist::SkipSet;
 use database_utils::{DatabaseURL, UpstreamConfig};
@@ -23,6 +24,7 @@ impl Backend {
         url: &str,
         noria: NoriaConnector,
         authority: Arc<Authority>,
+        adapter_start_time: SystemTime,
     ) -> anyhow::Result<Self> {
         let query_status_cache: &'static _ = Box::leak(Box::new(QueryStatusCache::new()));
         let upstream_config = UpstreamConfig::from_url(url);
@@ -49,6 +51,7 @@ impl Backend {
                             query_status_cache,
                             authority,
                             status_reporter,
+                            adapter_start_time,
                         ),
                 ))
             }
@@ -72,6 +75,7 @@ impl Backend {
                             query_status_cache,
                             authority,
                             status_reporter,
+                            adapter_start_time,
                         ),
                 ))
             }

--- a/readyset-adapter/src/metrics_handle.rs
+++ b/readyset-adapter/src/metrics_handle.rs
@@ -4,11 +4,8 @@ use indexmap::IndexMap;
 use metrics::SharedString;
 use metrics_exporter_prometheus::formatting::{sanitize_label_key, sanitize_label_value};
 use metrics_exporter_prometheus::{Distribution, PrometheusHandle};
-// adding an alias to disambiguate vs readyset_client_metrics::recorded
-use readyset_client::metrics::recorded as client_recorded;
 use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_COUNT;
 use readyset_client_metrics::DatabaseType;
-use readyset_data::TimestampTz;
 
 #[derive(Debug, Default, Clone)]
 pub struct MetricsSummary {
@@ -121,10 +118,6 @@ impl MetricsHandle {
     /// `SHOW READYSET STATUS`
     pub fn readyset_status(&self) -> Vec<(String, String)> {
         let mut statuses = Vec::new();
-
-        let time_ms = self.sum_counter(client_recorded::NORIA_STARTUP_TIMESTAMP);
-        let time = TimestampTz::from_unix_ms(time_ms);
-        statuses.push(("Process start time".to_string(), time.to_string()));
 
         let val = self.sum_gauge(readyset_client_metrics::recorded::CONNECTED_CLIENTS);
         statuses.push(("Connected clients count".to_string(), val.to_string()));

--- a/readyset-adapter/src/status_reporter.rs
+++ b/readyset-adapter/src/status_reporter.rs
@@ -7,13 +7,13 @@ use readyset_client::consensus::{Authority, AuthorityControl};
 use readyset_client::debug::stats::PersistentStats;
 use readyset_client::status::ReadySetControllerStatus;
 use readyset_client::ReadySetHandle;
-use readyset_data::TimestampTz;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::warn;
 
 use crate::backend::noria_connector::{MetaVariable, QueryResult};
 use crate::upstream_database::LazyUpstream;
+use crate::utils::time_or_null;
 use crate::UpstreamDatabase;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -174,17 +174,5 @@ where
                 None
             }
         }
-    }
-}
-
-// Helper function for formatting
-fn time_or_null(time_ms: Option<u64>) -> String {
-    if let Some(t) = time_ms {
-        // TimestampTz treats unix ms as not having a timezone, but since we lose the knowledge
-        // that this timestamp came from a unix epoch, adding it back in explicitly helps provide
-        // the timezone context.
-        format!("{} UTC", TimestampTz::from_unix_ms(t))
-    } else {
-        "NULL".to_string()
     }
 }

--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use database_utils::{DatabaseURL, ReplicationServerId};
@@ -277,6 +277,8 @@ impl TestBuilder {
             });
         }
 
+        let adapter_start_time = SystemTime::now();
+
         let mut backend_shutdown_rx = shutdown_tx.subscribe();
         let fallback_url = fallback_url_and_db_name.as_ref().map(|(f, _)| f.clone());
         tokio::spawn(async move {
@@ -332,6 +334,7 @@ impl TestBuilder {
                             query_status_cache,
                             authority.clone(),
                             status_reporter,
+                            adapter_start_time,
                         );
 
                     let mut backend_shutdown_rx_clone = backend_shutdown_rx_connection.clone();

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -14,12 +14,13 @@ pub mod client;
 /// Documents the set of metrics that are currently being recorded within
 /// a ReadySet instance.
 pub mod recorded {
-    /// Counter: Set at startup of a ReadySet service to the current unix
-    /// timestamp in milliseconds, this metric can be used to detect service
-    /// restarts. When available, prefer the metrics scraped by whatever
-    /// manages orchestration (such as kube-state-metrics's
-    /// kube_pod_container_status_restarts metric)
-    pub const NORIA_STARTUP_TIMESTAMP: &str = "readyset_startup_timestamp";
+    /// Counter: The number of times the adapter has started up. In standalone mode, this metric
+    /// can be used to count the number of system startups.
+    pub const READYSET_ADAPTER_STARTUPS: &str = "readyset_adapter_startups";
+
+    /// Counter: The number of times the server has started up. In standalone mode, this metric
+    /// should track [`READYSET_ADAPTER_STARTUPS`] exactly.
+    pub const READYSET_SERVER_STARTUPS: &str = "readyset_server_startups";
 
     /// Counter: The number of lookup misses that occurred during replay
     /// requests. Recorded at the domain on every lookup miss during a

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use std::{io, mem};
 
 use anyhow::{anyhow, bail, Context};
@@ -552,6 +552,7 @@ impl TestScript {
         let mut rh = ReadySetHandle::new(authority.clone()).await;
 
         let server_supports_pagination = rh.supports_pagination().await.unwrap();
+        let adapter_start_time = SystemTime::now();
 
         let task = tokio::spawn(async move {
             let (s, _) = listener.accept().await.unwrap();
@@ -608,6 +609,7 @@ impl TestScript {
                             query_status_cache,
                             authority,
                             status_reporter,
+                            adapter_start_time,
                         )
                 }};
             }

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use clap::builder::NonEmptyStringValueParser;
 use clap::Parser;
@@ -211,13 +211,7 @@ fn main() -> anyhow::Result<()> {
             ("opt_level", READYSET_VERSION.opt_level),
         ]
     );
-    metrics::counter!(
-        recorded::NORIA_STARTUP_TIMESTAMP,
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64
-    );
+    metrics::counter!(recorded::READYSET_SERVER_STARTUPS, 1);
 
     if let Some(volume_id) = &opts.worker_options.volume_id {
         info!(%volume_id);

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
@@ -786,13 +786,8 @@ where
                 ("opt_level", READYSET_VERSION.opt_level),
             ]
         );
-        metrics::counter!(
-            recorded::NORIA_STARTUP_TIMESTAMP,
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64
-        );
+        metrics::counter!(recorded::READYSET_ADAPTER_STARTUPS, 1);
+        let adapter_start_time = SystemTime::now();
 
         let (shutdown_tx, shutdown_rx) = shutdown::channel();
 
@@ -1161,6 +1156,7 @@ where
                                     query_status_cache,
                                     adapter_authority.clone(),
                                     status_reporter_clone,
+                                    adapter_start_time,
                                 );
                                 connection_handler.process_connection(s, backend).await;
                             }


### PR DESCRIPTION
Previously, we were using a counter metric to track the startup
timestamps of the adapter and server. Using a counter in this way makes
it difficult to graph the number of times Readyset has started up as a
time series. Really, all we have is a sum of a bunch of timestamps over
time, so the only way to get the number of startups over a given time
period is to count the number of *samples* of the counter metric. Since
metrics are already time series data, there's no real need to emit the
actual timestamp itself as a counter.

This commit removes the previous counter metric and replaces it with two
new ones, `READYSET_ADAPTER_STARTUPS` and `READYSET_SERVER_STARTUPS`,
which just count the number of startups for the adapter and the server,
respectively.

The `SHOW READYSET STATUS ADAPTER` command was relying upon the old
counter metric to return the process start time, though I believe there
may have been a bug here, since the unix timestamps were being summed to
produce this timestamp. To replace this, this commit also adds a proper
timestamp to `Backend` that is used in the `SHOW READYSET STATUS
ADAPTER` command.

Release-Note-Core: Simplified the metrics Readyset emits to count the
  number of times it starts up
