### PR TITLE
metrics: Update node state metrics

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -238,38 +238,21 @@ pub mod recorded {
     /// decision and sending packets.
     pub const EVICTION_WORKER_EVICTION_TIME: &str = "readyset_eviction_worker.eviction_time_us";
 
-    /// Gauge: The amount of bytes required to store a dataflow node's state./
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | node | The LocalNodeIndex of the dataflow node. |
-    pub const NODE_STATE_SIZE_BYTES: &str = "readyset_node_state_size_bytes";
-
-    /// Gauge: The sum of the amount of bytes used to store the dataflow node's
-    /// partial state within a domain.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard identifier of the domain. |
-    pub const DOMAIN_PARTIAL_STATE_SIZE_BYTES: &str = "readyset_domain.partial_state_size_bytes";
-
     /// Gauge: The sum of the amount of bytes used to store a node's reader state
     /// within a domain.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | name | The name of the reader node |
     pub const READER_STATE_SIZE_BYTES: &str = "readyset_reader_state_size_bytes";
 
     /// Gauge: The sum of the amount of bytes used to store a node's base tables
     /// on disk.
-    pub const ESTIMATED_BASE_TABLE_SIZE_BYTES: &str = "readyset_base_tables_estimated_size_bytes";
-
-    /// Gauge: The sum of a domain's total node state and reader state bytes.
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard identifier of the domain. |
-    pub const DOMAIN_TOTAL_NODE_STATE_SIZE_BYTES: &str =
-        "readyset_domain.total_node_state_size_bytes";
+    /// | table_name | The name of the base table. |
+    pub const ESTIMATED_BASE_TABLE_SIZE_BYTES: &str = "readyset_base_tables_estimated_size_bytes";
 
     /// Counter: The number of HTTP requests received at the readyset-server, for either the
     /// controller or worker.

--- a/readyset-dataflow/src/payload.rs
+++ b/readyset-dataflow/src/payload.rs
@@ -346,9 +346,6 @@ pub enum DomainRequest {
         state: PrepareStateKind,
     },
 
-    /// Ask domain to log its state size
-    UpdateStateSize,
-
     /// Inform domain about a new replay path.
     SetupReplayPath {
         tag: Tag,


### PR DESCRIPTION
Previously, we were emitting metrics for base table size, node state
size, partial state size, and reader state size using the node index,
domain, and shard as labels. These values have high cardinality, which
means there is a high cost associated with using these labels.

This commit does two things:
1. Removes the metrics that were being used to track node state and node
   partial state, since we cannot emit gauge metrics on a per-node basis
   without labeling the metrics with the node index; and
2. Updates the base table state size and reader state size gauge metrics
   to use the table name and reader node name, respectively, as labels

Release-Note-Core: Simplified the metrics Readyset emits to keep track
  of internal state size
