### PR TITLE
metrics: Remove domain/shard/node labels

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -28,35 +28,17 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay miss is recorded in |
-    /// | shard | The shard the replay miss is recorded in |
-    /// | miss_in | The LocalNodeIndex of the data flow node where the miss occurred |
-    /// | needed_for | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_MISSES: &str = "readyset_domain.replay_misses";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling and forwarding a Message or Input packet. Recorded at
     /// the domain following handling each Message and Input packet.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | from_node | The src node of the packet. |
-    /// | to_node |The dst node of the packet. |
-    /// | domain | The index of the domain handling the packet. |
-    /// | shard | The shard the domain handling the packet. |
     pub const DOMAIN_FORWARD_TIME: &str = "readyset_forward_time_us";
 
     /// Counter: The total time the domain spends handling and forwarding
     /// a Message or Input packet. Recorded at the domain following handling
     /// each Message and Input packet.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | from_node | The src node of the packet. |
-    /// | to_node |The dst node of the packet. |
-    /// | domain | The index of the domain handling the packet. |
-    /// | shard | The shard the domain handling the packet. |
     pub const DOMAIN_TOTAL_FORWARD_TIME: &str = "readyset_total_forward_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
@@ -65,9 +47,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay miss is recorded in. |
-    /// | shard | The shard the replay miss is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_TIME: &str = "readyset_domain.handle_replay_time";
 
@@ -77,9 +56,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay miss is recorded in. |
-    /// | shard | The shard the replay miss is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_REPLAY_TIME: &str = "readyset_domain.total_handle_replay_time";
 
@@ -90,9 +66,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the reader replay request is recorded in. |
-    /// | shard | The shard the reader replay request is recorded in. |
-    /// | node | The LocalNodeIndex of the reader node handling the packet. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_READER_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_replay_request_time_us";
@@ -104,9 +77,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the reader replay request is recorded in. |
-    /// | shard | The shard the reader replay request is recorded in. |
-    /// | node | The LocalNodeIndex of the reader node handling the packet. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_total_replay_request_time_us";
@@ -117,9 +87,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard |The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_SEED_REPLAY_TIME: &str = "readyset_domain.seed_replay_time_us";
 
@@ -129,9 +96,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard |The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_SEED_REPLAY_TIME: &str = "readyset_domain.total_seed_replay_time_us";
 
@@ -139,48 +103,24 @@ pub mod recorded {
     /// chunker at a node during the processing of a StartReplay packet.
     /// Recorded at the domain when the state chunker thread is finished
     /// executing.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the start replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | from_node | The first node on the replay path. |
     pub const DOMAIN_CHUNKED_REPLAY_TIME: &str = "readyset_domain.chunked_replay_time_us";
 
     /// Counter: The total time in microseconds that a domain spawning a state
     /// chunker at a node during the processing of a StartReplay packet.
     /// Recorded at the domain when the state chunker thread is finished
     /// executing.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the start replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | from_node | The first node on the replay path. |
     pub const DOMAIN_TOTAL_CHUNKED_REPLAY_TIME: &str =
         "readyset_domain.total_chunked_replay_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling a StartReplay packet. Recorded at the domain
     /// following StartReplay packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     pub const DOMAIN_CHUNKED_REPLAY_START_TIME: &str =
         "readyset_domain.chunked_replay_start_time_us";
 
     /// Counter: The total time in microseconds that a domain spends
     /// handling a StartReplay packet. Recorded at the domain
     /// following StartReplay packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     pub const DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME: &str =
         "readyset_domain.total_chunked_replay_start_time_us";
 
@@ -190,9 +130,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the Finish packet is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_FINISH_REPLAY_TIME: &str = "readyset_domain.finish_replay_time_us";
 
@@ -202,9 +139,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the Finish packet is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_FINISH_REPLAY_TIME: &str = "readyset_domain.total_finish_replay_time_us";
 
@@ -223,10 +157,6 @@ pub mod recorded {
 
     /// Counter: The number of evicitons performed at a worker. Incremented each
     /// time `do_eviction` is called at the worker.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The domain that the eviction is performed in. |
     pub const EVICTION_WORKER_EVICTIONS_REQUESTED: &str =
         "readyset_eviction_worker.evictions_requested";
 
@@ -266,29 +196,16 @@ pub mod recorded {
 
     /// Counter: The number of lookup requests to a base table nodes state.
     ///
-    ///
     /// | Tag | Description |
     /// | --- | ----------- |
     /// | table_name | The name of the base table. |
-    /// | shard | The shard of the base table the lookup is requested in. |
-    /// | node | The LocalNodeIndex of the base table node handling the packet. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const BASE_TABLE_LOOKUP_REQUESTS: &str = "readyset_base_table.lookup_requests";
 
     /// Counter: The number of packets dropped by an egress node.
-    ///
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | node | The NodeIndex of the ingress node that was supposed to receive the packet. |
     pub const EGRESS_NODE_DROPPED_PACKETS: &str = "readyset_egress.dropped_packets";
 
     /// Counter: The number of packets sent by an egress node.
-    ///
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | node | The NodeIndex of the ingress node were the packet was sent. |
     pub const EGRESS_NODE_SENT_PACKETS: &str = "readyset_egress.sent_packets";
 
     /// Counter: The number of eviction packets received.
@@ -313,23 +230,20 @@ pub mod recorded {
     /// | Tag | Description |
     /// | --- | ----------- |
     /// | ntype | The dataflow node type. |
-    /// | node  | The index of the dataflow node. |
     pub const NODE_ADDED: &str = "readyset_node_added";
 
     /// Counter: The number of times a dataflow packet has been propagated
     /// for each domain.
     ///
     /// | Tag | Description |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard of the base table the lookup is requested in. |
+    /// | --- | ----------- |
     /// | packet_type | The type of packet |
     pub const DOMAIN_PACKET_SENT: &str = "readyset_domain.packet_sent";
 
     /// Gauge: The number of dataflow packets queued for each domain.
     ///
     /// | Tag | Description |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard of the base table the lookup is requested in. |
+    /// | --- | ----------- |
     /// | packet_type | The type of packet |
     pub const DOMAIN_PACKETS_QUEUED: &str = "readyset_domain.packets_queued";
 
@@ -360,12 +274,14 @@ pub mod recorded {
     /// snapshot begins.
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | status | SnapshotStatusTag |
     pub const REPLICATOR_SNAPSHOT_STATUS: &str = "readyset_replicator.snapshot_status";
 
     /// Gauge: Progress (in percent, 0-100) in snapshotting the given table
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | schema | Schema the relevant table exists in |
     /// | name | Name of the table being snapshot |
     pub const REPLICATOR_SNAPSHOT_PERCENT: &str = "readyset_replicator.snapshot.percent";
@@ -387,6 +303,7 @@ pub mod recorded {
     /// Counter: The total amount of time spent servicing controller RPCs.
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | path | The http path associated with the rpc request. |
     pub const CONTROLLER_RPC_OVERALL_TIME: &str = "readyset_controller.rpc_overall_time";
 
@@ -394,6 +311,7 @@ pub mod recorded {
     /// for each request.
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | path | The http path associated with the rpc request. |
     pub const CONTROLLER_RPC_REQUEST_TIME: &str = "readyset_controller.rpc_request_time";
 

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -3,340 +3,120 @@
 //! To make the metrics performant, it holds handles to all the required metrics for
 //! fast operations, wherever possible.
 
-use std::collections::BTreeMap;
-use std::convert::TryInto;
 use std::time::Duration;
 
-use metrics::{gauge, register_counter, register_histogram, Counter, Histogram, SharedString};
+use metrics::{counter, gauge, histogram};
 use nom_sql::Relation;
 use readyset_client::metrics::recorded;
-use strum::{EnumCount, IntoEnumIterator};
 
-use crate::domain::{LocalNodeIndex, ReplicaAddress, Tag};
-use crate::{NodeMap, Packet, PacketDiscriminants};
+use crate::{Packet, PacketDiscriminants};
 
 /// Contains handles to the various metrics collected for a domain.
 /// Whenever possible the handles are generated at init time, others
 /// that require dynamic labels are created on demand and stored in
 /// a BTreeMap or a NodeMap.
-pub(super) struct DomainMetrics {
-    index: SharedString,
-    shard: SharedString,
-    eviction_requests: Counter,
-    eviction_time: Histogram,
-    eviction_size: Histogram,
-
-    packets_sent: [Counter; PacketDiscriminants::COUNT],
-
-    // using a BTree to look up metrics by tag/node, BTree is faster than HashMap for u32/u64 keys
-    chunked_replay_start_time: BTreeMap<Tag, (Counter, Histogram)>,
-    total_replay_time: BTreeMap<Tag, (Counter, Histogram)>,
-    seed_replay_time: BTreeMap<Tag, (Counter, Histogram)>,
-    finish_replay_time: BTreeMap<Tag, (Counter, Histogram)>,
-    total_forward_time: BTreeMap<(LocalNodeIndex, LocalNodeIndex), (Counter, Histogram)>,
-    replay_misses: BTreeMap<(LocalNodeIndex, Tag), Counter>,
-
-    reader_replay_request_time: NodeMap<(Counter, Histogram)>,
-    chunked_replay_time: NodeMap<(Counter, Histogram)>,
-    base_table_lookups: NodeMap<Counter>,
-}
+pub(super) struct DomainMetrics;
 
 impl DomainMetrics {
-    pub(super) fn new(replica_address: ReplicaAddress) -> Self {
-        let index: SharedString = replica_address.domain_index.index().to_string().into();
-        let shard: SharedString = replica_address.shard.to_string().into();
-
-        let packets_sent: Vec<Counter> = PacketDiscriminants::iter()
-            .map(|d| {
-                let name: &'static str = d.into();
-                register_counter!(recorded::DOMAIN_PACKET_SENT,
-                                  "domain" => index.clone(),
-                                  "shard" => shard.clone(),
-                                  "packet_type" => name,
-                )
-            })
-            .collect();
-
-        DomainMetrics {
-            eviction_requests: register_counter!(recorded::EVICTION_REQUESTS, vec![],),
-            eviction_time: register_histogram!(recorded::EVICTION_TIME, vec![]),
-            eviction_size: register_histogram!(recorded::EVICTION_FREED_MEMORY, vec![],),
-            chunked_replay_start_time: Default::default(),
-            chunked_replay_time: Default::default(),
-            total_replay_time: Default::default(),
-            seed_replay_time: Default::default(),
-            finish_replay_time: Default::default(),
-            total_forward_time: Default::default(),
-            replay_misses: Default::default(),
-            packets_sent: packets_sent.try_into().ok().unwrap(),
-            reader_replay_request_time: Default::default(),
-            base_table_lookups: Default::default(),
-            shard,
-            index,
-        }
+    pub(super) fn new() -> Self {
+        DomainMetrics
     }
 
     pub(super) fn inc_eviction_requests(&self) {
-        self.eviction_requests.increment(1);
+        counter!(recorded::EVICTION_REQUESTS, 1)
     }
 
     pub(super) fn rec_eviction_time(&self, time: Duration, total_freed: u64) {
-        self.eviction_time.record(time.as_micros() as f64);
-        self.eviction_size.record(total_freed as f64);
+        histogram!(recorded::EVICTION_TIME, time.as_micros() as f64);
+        histogram!(recorded::EVICTION_FREED_MEMORY, total_freed as f64);
     }
 
-    pub(super) fn rec_chunked_replay_start_time(&mut self, tag: Tag, time: Duration) {
-        if let Some((ctr, histo)) = self.chunked_replay_start_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string()
-            );
+    pub(super) fn rec_chunked_replay_start_time(&mut self, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
+            time.as_micros() as u64,
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_CHUNKED_REPLAY_START_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string()
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.chunked_replay_start_time.insert(tag, (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_CHUNKED_REPLAY_START_TIME,
+            time.as_micros() as f64,
+        );
     }
 
-    pub(super) fn recorders_for_chunked_replay(
-        &mut self,
-        from_node: LocalNodeIndex,
-    ) -> (Counter, Histogram) {
-        if let Some(recorders) = self.chunked_replay_time.get(from_node) {
-            recorders.clone()
-        } else {
-            let recorders = (
-                register_counter!(
-                    recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_TIME,
-                    "domain" => self.index.clone(),
-                    "shard" => self.shard.clone(),
-                    "from_node" => from_node.to_string()
-                ),
-                register_histogram!(
-                    recorded::DOMAIN_CHUNKED_REPLAY_TIME,
-                    "domain" => self.index.clone(),
-                    "shard" => self.shard.clone(),
-                    "from_node" => from_node.to_string()
-                ),
-            );
+    pub(super) fn rec_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_REPLAY_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            self.chunked_replay_time
-                .insert(from_node, recorders.clone());
-            recorders
-        }
+        histogram!(
+            recorded::DOMAIN_REPLAY_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_replay_time(&mut self, tag: Tag, cache_name: &Relation, time: Duration) {
-        if let Some((ctr, histo)) = self.total_replay_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
+    pub(super) fn rec_seed_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.total_replay_time.insert(tag, (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_SEED_REPLAY_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_seed_replay_time(&mut self, tag: Tag, cache_name: &Relation, time: Duration) {
-        if let Some((ctr, histo)) = self.seed_replay_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
+    pub(super) fn rec_finish_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_SEED_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.seed_replay_time.insert(tag, (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_FINISH_REPLAY_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_finish_replay_time(
-        &mut self,
-        tag: Tag,
-        cache_name: &Relation,
-        time: Duration,
-    ) {
-        if let Some((ctr, histo)) = self.finish_replay_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            let histo = register_histogram!(
-                recorded::DOMAIN_FINISH_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.finish_replay_time.insert(tag, (ctr, histo));
-        }
+    pub(super) fn rec_forward_time(&mut self, time: Duration) {
+        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64);
+        histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64);
     }
 
-    pub(super) fn rec_forward_time(
-        &mut self,
-        src: LocalNodeIndex,
-        dst: LocalNodeIndex,
-        time: Duration,
-    ) {
-        if let Some((ctr, histo)) = self.total_forward_time.get(&(src, dst)) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_FORWARD_TIME,
-                "from_node" => src.to_string(),
-                "to_node" => dst.to_string(),
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-            );
+    pub(super) fn rec_reader_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_FORWARD_TIME,
-                "from_node" => src.to_string(),
-                "to_node" => dst.to_string(),
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.total_forward_time.insert((src, dst), (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_reader_replay_time(
-        &mut self,
-        node: LocalNodeIndex,
-        cache_name: &Relation,
-        time: Duration,
-    ) {
-        if let Some((ctr, histo)) = self.reader_replay_request_time.get(node) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "node" => node.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            let histo = register_histogram!(
-                recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "node" => node.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.reader_replay_request_time.insert(node, (ctr, histo));
-        }
-    }
-
-    pub(super) fn inc_replay_misses(
-        &mut self,
-        miss_in: LocalNodeIndex,
-        needed_for: Tag,
-        cache_name: &Relation,
-        n: usize,
-    ) {
-        if let Some(ctr) = self.replay_misses.get(&(miss_in, needed_for)) {
-            ctr.increment(n as u64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_REPLAY_MISSES,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "miss_in" => miss_in.id().to_string(),
-                "needed_for" => needed_for.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(n as u64);
-            self.replay_misses.insert((miss_in, needed_for), ctr);
-        }
+    pub(super) fn inc_replay_misses(&mut self, cache_name: &Relation, n: usize) {
+        counter!(
+            recorded::DOMAIN_REPLAY_MISSES,
+            n as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
     pub(super) fn inc_packets_sent(&mut self, packet: &Packet) {
         let discriminant: PacketDiscriminants = packet.into();
-        self.packets_sent[discriminant as usize].increment(1);
-    }
+        let packet_type: &'static str = discriminant.into();
 
-    pub(super) fn inc_base_table_lookups(&mut self, node: LocalNodeIndex, cache_name: &Relation) {
-        if let Some(ctr) = self.base_table_lookups.get(node) {
-            ctr.increment(1);
-        } else {
-            let ctr = register_counter!(
-                recorded::BASE_TABLE_LOOKUP_REQUESTS,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "node" => node.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-            ctr.increment(1);
-            self.base_table_lookups.insert(node, ctr);
-        }
+        counter!(recorded::DOMAIN_PACKET_SENT, 1, "packet_type" => packet_type);
     }
 
     pub(super) fn set_reader_state_size(&self, name: &Relation, size: u64) {
@@ -352,6 +132,15 @@ impl DomainMetrics {
             recorded::ESTIMATED_BASE_TABLE_SIZE_BYTES,
             size as f64,
             "table_name" => cache_name_to_string(name),
+        );
+    }
+
+    pub(super) fn inc_base_table_lookups(&mut self, cache_name: &Relation, table_name: &Relation) {
+        counter!(
+            recorded::BASE_TABLE_LOOKUP_REQUESTS,
+            1,
+            "cache_name" => cache_name_to_string(cache_name),
+            "table_name" => cache_name_to_string(table_name)
         );
     }
 }

--- a/readyset-dataflow/src/node/special/egress.rs
+++ b/readyset-dataflow/src/node/special/egress.rs
@@ -23,11 +23,6 @@ pub struct EgressTx {
     domain_index: DomainIndex,
     shard: usize,
     replication: SenderReplication,
-
-    #[serde(skip)]
-    sent_ctr: Option<metrics::Counter>,
-    #[serde(skip)]
-    dropped_ctr: Option<metrics::Counter>,
 }
 
 impl EgressTx {
@@ -44,8 +39,6 @@ impl EgressTx {
             domain_index,
             shard,
             replication,
-            sent_ctr: None,
-            dropped_ctr: None,
         }
     }
 
@@ -59,27 +52,11 @@ impl EgressTx {
     }
 
     fn inc_sent(&mut self) {
-        if let Some(ctr) = &self.sent_ctr {
-            ctr.increment(1);
-        } else {
-            let node = self.node.index().to_string();
-            let ctr =
-                metrics::register_counter!(recorded::EGRESS_NODE_SENT_PACKETS, "node" => node);
-            ctr.increment(1);
-            self.sent_ctr.replace(ctr);
-        }
+        metrics::counter!(recorded::EGRESS_NODE_SENT_PACKETS, 1)
     }
 
     fn inc_dropped(&mut self) {
-        if let Some(ctr) = &self.dropped_ctr {
-            ctr.increment(1);
-        } else {
-            let node = self.node.index().to_string();
-            let ctr =
-                metrics::register_counter!(recorded::EGRESS_NODE_DROPPED_PACKETS, "node" => node);
-            ctr.increment(1);
-            self.dropped_ctr.replace(ctr);
-        }
+        metrics::counter!(recorded::EGRESS_NODE_DROPPED_PACKETS, 1);
     }
 }
 

--- a/readyset-server/src/controller/migrate/mod.rs
+++ b/readyset-server/src/controller/migrate/mod.rs
@@ -1161,7 +1161,6 @@ fn plan_add_nodes(
                         recorded::NODE_ADDED,
                         1,
                         "ntype" => dataflow_state.ingredients[ni].node_type_string(),
-                        "node" => nnodes.to_string()
                     );
                 }
                 dataflow_state

--- a/readyset-server/src/worker/mod.rs
+++ b/readyset-server/src/worker/mod.rs
@@ -627,11 +627,7 @@ async fn do_eviction(
                         )
                     });
 
-                    counter!(
-                        recorded::EVICTION_WORKER_EVICTIONS_REQUESTED,
-                        1,
-                        "domain" => target.domain_index.index().to_string(),
-                    );
+                    counter!(recorded::EVICTION_WORKER_EVICTIONS_REQUESTED, 1);
 
                     let tx = match domain_senders.entry(target) {
                         Occupied(entry) => entry.into_mut(),


### PR DESCRIPTION
Many of our metrics were labeled with domain, shard, or node. These
values have the potential to have very high cardinality for deployments
that have many base tables and/or caches. To reduce cost, this commit
removes these labels from the metrics, leaning on the "cache_name" label
added in an earlier commit. This commit also removes altogether any
gauge metrics that were only labeled by domain/shard/node, since we
cannot report changes in domain-specific gauges without labeling the
gauges with the domain.

Release-Note-Core: Removed labels from certain metrics that had very
  high cardinality to reduce the cost of ingesting and plotting metrics
