### PR TITLE
metrics: Differentiate between input and msg

### DIFF
--- a/benchmarks/src/bin/write_propagation.rs
+++ b/benchmarks/src/bin/write_propagation.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{mpsc, Arc};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 use benchmarks::utils::backend::Backend;
 use benchmarks::utils::generate::load_to_backend;
@@ -113,6 +113,7 @@ impl Writer {
                 (Dialect::DEFAULT_POSTGRESQL, nom_sql::Dialect::PostgreSQL)
             }
         };
+        let adapter_start_time = SystemTime::now();
         let noria = NoriaConnector::new(
             ch.clone(),
             auto_increments,
@@ -126,7 +127,7 @@ impl Writer {
         )
         .await;
 
-        let mut b = Backend::new(&self.database_url, noria, authority).await?;
+        let mut b = Backend::new(&self.database_url, noria, authority, adapter_start_time).await?;
 
         let mut view = ch.view("w").await.unwrap();
 

--- a/benchmarks/src/utils/backend.rs
+++ b/benchmarks/src/utils/backend.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use crossbeam_skiplist::SkipSet;
 use database_utils::{DatabaseURL, UpstreamConfig};
@@ -23,6 +24,7 @@ impl Backend {
         url: &str,
         noria: NoriaConnector,
         authority: Arc<Authority>,
+        adapter_start_time: SystemTime,
     ) -> anyhow::Result<Self> {
         let query_status_cache: &'static _ = Box::leak(Box::new(QueryStatusCache::new()));
         let upstream_config = UpstreamConfig::from_url(url);
@@ -49,6 +51,7 @@ impl Backend {
                             query_status_cache,
                             authority,
                             status_reporter,
+                            adapter_start_time,
                         ),
                 ))
             }
@@ -72,6 +75,7 @@ impl Backend {
                             query_status_cache,
                             authority,
                             status_reporter,
+                            adapter_start_time,
                         ),
                 ))
             }

--- a/readyset-adapter/src/metrics_handle.rs
+++ b/readyset-adapter/src/metrics_handle.rs
@@ -4,11 +4,8 @@ use indexmap::IndexMap;
 use metrics::SharedString;
 use metrics_exporter_prometheus::formatting::{sanitize_label_key, sanitize_label_value};
 use metrics_exporter_prometheus::{Distribution, PrometheusHandle};
-// adding an alias to disambiguate vs readyset_client_metrics::recorded
-use readyset_client::metrics::recorded as client_recorded;
 use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_COUNT;
 use readyset_client_metrics::DatabaseType;
-use readyset_data::TimestampTz;
 
 #[derive(Debug, Default, Clone)]
 pub struct MetricsSummary {
@@ -121,10 +118,6 @@ impl MetricsHandle {
     /// `SHOW READYSET STATUS`
     pub fn readyset_status(&self) -> Vec<(String, String)> {
         let mut statuses = Vec::new();
-
-        let time_ms = self.sum_counter(client_recorded::NORIA_STARTUP_TIMESTAMP);
-        let time = TimestampTz::from_unix_ms(time_ms);
-        statuses.push(("Process start time".to_string(), time.to_string()));
 
         let val = self.sum_gauge(readyset_client_metrics::recorded::CONNECTED_CLIENTS);
         statuses.push(("Connected clients count".to_string(), val.to_string()));

--- a/readyset-adapter/src/status_reporter.rs
+++ b/readyset-adapter/src/status_reporter.rs
@@ -7,13 +7,13 @@ use readyset_client::consensus::{Authority, AuthorityControl};
 use readyset_client::debug::stats::PersistentStats;
 use readyset_client::status::ReadySetControllerStatus;
 use readyset_client::ReadySetHandle;
-use readyset_data::TimestampTz;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::warn;
 
 use crate::backend::noria_connector::{MetaVariable, QueryResult};
 use crate::upstream_database::LazyUpstream;
+use crate::utils::time_or_null;
 use crate::UpstreamDatabase;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -174,17 +174,5 @@ where
                 None
             }
         }
-    }
-}
-
-// Helper function for formatting
-fn time_or_null(time_ms: Option<u64>) -> String {
-    if let Some(t) = time_ms {
-        // TimestampTz treats unix ms as not having a timezone, but since we lose the knowledge
-        // that this timestamp came from a unix epoch, adding it back in explicitly helps provide
-        // the timezone context.
-        format!("{} UTC", TimestampTz::from_unix_ms(t))
-    } else {
-        "NULL".to_string()
     }
 }

--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
 use database_utils::{DatabaseURL, ReplicationServerId};
@@ -277,6 +277,8 @@ impl TestBuilder {
             });
         }
 
+        let adapter_start_time = SystemTime::now();
+
         let mut backend_shutdown_rx = shutdown_tx.subscribe();
         let fallback_url = fallback_url_and_db_name.as_ref().map(|(f, _)| f.clone());
         tokio::spawn(async move {
@@ -332,6 +334,7 @@ impl TestBuilder {
                             query_status_cache,
                             authority.clone(),
                             status_reporter,
+                            adapter_start_time,
                         );
 
                     let mut backend_shutdown_rx_clone = backend_shutdown_rx_connection.clone();

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -28,35 +28,17 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay miss is recorded in |
-    /// | shard | The shard the replay miss is recorded in |
-    /// | miss_in | The LocalNodeIndex of the data flow node where the miss occurred |
-    /// | needed_for | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_MISSES: &str = "readyset_domain.replay_misses";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling and forwarding a Message or Input packet. Recorded at
     /// the domain following handling each Message and Input packet.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | from_node | The src node of the packet. |
-    /// | to_node |The dst node of the packet. |
-    /// | domain | The index of the domain handling the packet. |
-    /// | shard | The shard the domain handling the packet. |
     pub const DOMAIN_FORWARD_TIME: &str = "readyset_forward_time_us";
 
     /// Counter: The total time the domain spends handling and forwarding
     /// a Message or Input packet. Recorded at the domain following handling
     /// each Message and Input packet.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | from_node | The src node of the packet. |
-    /// | to_node |The dst node of the packet. |
-    /// | domain | The index of the domain handling the packet. |
-    /// | shard | The shard the domain handling the packet. |
     pub const DOMAIN_TOTAL_FORWARD_TIME: &str = "readyset_total_forward_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
@@ -65,9 +47,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay miss is recorded in. |
-    /// | shard | The shard the replay miss is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_TIME: &str = "readyset_domain.handle_replay_time";
 
@@ -77,9 +56,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay miss is recorded in. |
-    /// | shard | The shard the replay miss is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_REPLAY_TIME: &str = "readyset_domain.total_handle_replay_time";
 
@@ -90,9 +66,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the reader replay request is recorded in. |
-    /// | shard | The shard the reader replay request is recorded in. |
-    /// | node | The LocalNodeIndex of the reader node handling the packet. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_READER_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_replay_request_time_us";
@@ -104,9 +77,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the reader replay request is recorded in. |
-    /// | shard | The shard the reader replay request is recorded in. |
-    /// | node | The LocalNodeIndex of the reader node handling the packet. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_total_replay_request_time_us";
@@ -117,9 +87,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard |The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_SEED_REPLAY_TIME: &str = "readyset_domain.seed_replay_time_us";
 
@@ -129,9 +96,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard |The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_SEED_REPLAY_TIME: &str = "readyset_domain.total_seed_replay_time_us";
 
@@ -139,48 +103,24 @@ pub mod recorded {
     /// chunker at a node during the processing of a StartReplay packet.
     /// Recorded at the domain when the state chunker thread is finished
     /// executing.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the start replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | from_node | The first node on the replay path. |
     pub const DOMAIN_CHUNKED_REPLAY_TIME: &str = "readyset_domain.chunked_replay_time_us";
 
     /// Counter: The total time in microseconds that a domain spawning a state
     /// chunker at a node during the processing of a StartReplay packet.
     /// Recorded at the domain when the state chunker thread is finished
     /// executing.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the start replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | from_node | The first node on the replay path. |
     pub const DOMAIN_TOTAL_CHUNKED_REPLAY_TIME: &str =
         "readyset_domain.total_chunked_replay_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling a StartReplay packet. Recorded at the domain
     /// following StartReplay packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     pub const DOMAIN_CHUNKED_REPLAY_START_TIME: &str =
         "readyset_domain.chunked_replay_start_time_us";
 
     /// Counter: The total time in microseconds that a domain spends
     /// handling a StartReplay packet. Recorded at the domain
     /// following StartReplay packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the replay is required for. |
     pub const DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME: &str =
         "readyset_domain.total_chunked_replay_start_time_us";
 
@@ -190,9 +130,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the Finish packet is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_FINISH_REPLAY_TIME: &str = "readyset_domain.finish_replay_time_us";
 
@@ -202,9 +139,6 @@ pub mod recorded {
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain the replay request is recorded in. |
-    /// | shard | The shard the replay request is recorded in. |
-    /// | tag | The client tag of the request that the Finish packet is required for. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_FINISH_REPLAY_TIME: &str = "readyset_domain.total_finish_replay_time_us";
 
@@ -223,10 +157,6 @@ pub mod recorded {
 
     /// Counter: The number of evicitons performed at a worker. Incremented each
     /// time `do_eviction` is called at the worker.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The domain that the eviction is performed in. |
     pub const EVICTION_WORKER_EVICTIONS_REQUESTED: &str =
         "readyset_eviction_worker.evictions_requested";
 
@@ -266,29 +196,16 @@ pub mod recorded {
 
     /// Counter: The number of lookup requests to a base table nodes state.
     ///
-    ///
     /// | Tag | Description |
     /// | --- | ----------- |
     /// | table_name | The name of the base table. |
-    /// | shard | The shard of the base table the lookup is requested in. |
-    /// | node | The LocalNodeIndex of the base table node handling the packet. |
     /// | cache_name | The name of the cache associated with this replay.
     pub const BASE_TABLE_LOOKUP_REQUESTS: &str = "readyset_base_table.lookup_requests";
 
     /// Counter: The number of packets dropped by an egress node.
-    ///
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | node | The NodeIndex of the ingress node that was supposed to receive the packet. |
     pub const EGRESS_NODE_DROPPED_PACKETS: &str = "readyset_egress.dropped_packets";
 
     /// Counter: The number of packets sent by an egress node.
-    ///
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | node | The NodeIndex of the ingress node were the packet was sent. |
     pub const EGRESS_NODE_SENT_PACKETS: &str = "readyset_egress.sent_packets";
 
     /// Counter: The number of eviction packets received.
@@ -313,23 +230,20 @@ pub mod recorded {
     /// | Tag | Description |
     /// | --- | ----------- |
     /// | ntype | The dataflow node type. |
-    /// | node  | The index of the dataflow node. |
     pub const NODE_ADDED: &str = "readyset_node_added";
 
     /// Counter: The number of times a dataflow packet has been propagated
     /// for each domain.
     ///
     /// | Tag | Description |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard of the base table the lookup is requested in. |
+    /// | --- | ----------- |
     /// | packet_type | The type of packet |
     pub const DOMAIN_PACKET_SENT: &str = "readyset_domain.packet_sent";
 
     /// Gauge: The number of dataflow packets queued for each domain.
     ///
     /// | Tag | Description |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard of the base table the lookup is requested in. |
+    /// | --- | ----------- |
     /// | packet_type | The type of packet |
     pub const DOMAIN_PACKETS_QUEUED: &str = "readyset_domain.packets_queued";
 
@@ -360,12 +274,14 @@ pub mod recorded {
     /// snapshot begins.
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | status | SnapshotStatusTag |
     pub const REPLICATOR_SNAPSHOT_STATUS: &str = "readyset_replicator.snapshot_status";
 
     /// Gauge: Progress (in percent, 0-100) in snapshotting the given table
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | schema | Schema the relevant table exists in |
     /// | name | Name of the table being snapshot |
     pub const REPLICATOR_SNAPSHOT_PERCENT: &str = "readyset_replicator.snapshot.percent";
@@ -387,6 +303,7 @@ pub mod recorded {
     /// Counter: The total amount of time spent servicing controller RPCs.
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | path | The http path associated with the rpc request. |
     pub const CONTROLLER_RPC_OVERALL_TIME: &str = "readyset_controller.rpc_overall_time";
 
@@ -394,6 +311,7 @@ pub mod recorded {
     /// for each request.
     ///
     /// | Tag | Description |
+    /// | --- | ----------- |
     /// | path | The http path associated with the rpc request. |
     pub const CONTROLLER_RPC_REQUEST_TIME: &str = "readyset_controller.rpc_request_time";
 

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -14,12 +14,13 @@ pub mod client;
 /// Documents the set of metrics that are currently being recorded within
 /// a ReadySet instance.
 pub mod recorded {
-    /// Counter: Set at startup of a ReadySet service to the current unix
-    /// timestamp in milliseconds, this metric can be used to detect service
-    /// restarts. When available, prefer the metrics scraped by whatever
-    /// manages orchestration (such as kube-state-metrics's
-    /// kube_pod_container_status_restarts metric)
-    pub const NORIA_STARTUP_TIMESTAMP: &str = "readyset_startup_timestamp";
+    /// Counter: The number of times the adapter has started up. In standalone mode, this metric
+    /// can be used to count the number of system startups.
+    pub const READYSET_ADAPTER_STARTUPS: &str = "readyset_adapter_startups";
+
+    /// Counter: The number of times the server has started up. In standalone mode, this metric
+    /// should track [`READYSET_ADAPTER_STARTUPS`] exactly.
+    pub const READYSET_SERVER_STARTUPS: &str = "readyset_server_startups";
 
     /// Counter: The number of lookup misses that occurred during replay
     /// requests. Recorded at the domain on every lookup miss during a

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -32,6 +32,7 @@ pub mod recorded {
     /// | shard | The shard the replay miss is recorded in |
     /// | miss_in | The LocalNodeIndex of the data flow node where the miss occurred |
     /// | needed_for | The client tag of the request that the replay is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_MISSES: &str = "readyset_domain.replay_misses";
 
     /// Histogram: The time in microseconds that a domain spends
@@ -67,6 +68,7 @@ pub mod recorded {
     /// | domain | The index of the domain the replay miss is recorded in. |
     /// | shard | The shard the replay miss is recorded in. |
     /// | tag | The client tag of the request that the replay is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_TIME: &str = "readyset_domain.handle_replay_time";
 
     /// Counter: The total time in microseconds that a domain spends
@@ -78,6 +80,7 @@ pub mod recorded {
     /// | domain | The index of the domain the replay miss is recorded in. |
     /// | shard | The shard the replay miss is recorded in. |
     /// | tag | The client tag of the request that the replay is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_REPLAY_TIME: &str = "readyset_domain.total_handle_replay_time";
 
     /// Histogram: The time in microseconds spent handling a reader replay
@@ -90,6 +93,7 @@ pub mod recorded {
     /// | domain | The index of the domain the reader replay request is recorded in. |
     /// | shard | The shard the reader replay request is recorded in. |
     /// | node | The LocalNodeIndex of the reader node handling the packet. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_READER_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_replay_request_time_us";
 
@@ -103,6 +107,7 @@ pub mod recorded {
     /// | domain | The index of the domain the reader replay request is recorded in. |
     /// | shard | The shard the reader replay request is recorded in. |
     /// | node | The LocalNodeIndex of the reader node handling the packet. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_total_replay_request_time_us";
 
@@ -115,6 +120,7 @@ pub mod recorded {
     /// | domain | The index of the domain the replay request is recorded in. |
     /// | shard |The shard the replay request is recorded in. |
     /// | tag | The client tag of the request that the replay is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_SEED_REPLAY_TIME: &str = "readyset_domain.seed_replay_time_us";
 
     /// Counter: The total time in microseconds that a domain spends
@@ -126,6 +132,7 @@ pub mod recorded {
     /// | domain | The index of the domain the replay request is recorded in. |
     /// | shard |The shard the replay request is recorded in. |
     /// | tag | The client tag of the request that the replay is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_SEED_REPLAY_TIME: &str = "readyset_domain.total_seed_replay_time_us";
 
     /// Histogram: The time in microseconds that a domain spawning a state
@@ -186,6 +193,7 @@ pub mod recorded {
     /// | domain | The index of the domain the replay request is recorded in. |
     /// | shard | The shard the replay request is recorded in. |
     /// | tag | The client tag of the request that the Finish packet is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_FINISH_REPLAY_TIME: &str = "readyset_domain.finish_replay_time_us";
 
     /// Counter: The total time in microseconds that a domain spends
@@ -197,6 +205,7 @@ pub mod recorded {
     /// | domain | The index of the domain the replay request is recorded in. |
     /// | shard | The shard the replay request is recorded in. |
     /// | tag | The client tag of the request that the Finish packet is required for. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_TOTAL_FINISH_REPLAY_TIME: &str = "readyset_domain.total_finish_replay_time_us";
 
     /// Histogram: The amount of time spent handling an eviction
@@ -280,6 +289,7 @@ pub mod recorded {
     /// | table_name | The name of the base table. |
     /// | shard | The shard of the base table the lookup is requested in. |
     /// | node | The LocalNodeIndex of the base table node handling the packet. |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const BASE_TABLE_LOOKUP_REQUESTS: &str = "readyset_base_table.lookup_requests";
 
     /// Counter: The number of packets dropped by an egress node.

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -238,38 +238,21 @@ pub mod recorded {
     /// decision and sending packets.
     pub const EVICTION_WORKER_EVICTION_TIME: &str = "readyset_eviction_worker.eviction_time_us";
 
-    /// Gauge: The amount of bytes required to store a dataflow node's state./
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | node | The LocalNodeIndex of the dataflow node. |
-    pub const NODE_STATE_SIZE_BYTES: &str = "readyset_node_state_size_bytes";
-
-    /// Gauge: The sum of the amount of bytes used to store the dataflow node's
-    /// partial state within a domain.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard identifier of the domain. |
-    pub const DOMAIN_PARTIAL_STATE_SIZE_BYTES: &str = "readyset_domain.partial_state_size_bytes";
-
     /// Gauge: The sum of the amount of bytes used to store a node's reader state
     /// within a domain.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | name | The name of the reader node |
     pub const READER_STATE_SIZE_BYTES: &str = "readyset_reader_state_size_bytes";
 
     /// Gauge: The sum of the amount of bytes used to store a node's base tables
     /// on disk.
-    pub const ESTIMATED_BASE_TABLE_SIZE_BYTES: &str = "readyset_base_tables_estimated_size_bytes";
-
-    /// Gauge: The sum of a domain's total node state and reader state bytes.
     ///
     /// | Tag | Description |
     /// | --- | ----------- |
-    /// | domain | The index of the domain. |
-    /// | shard | The shard identifier of the domain. |
-    pub const DOMAIN_TOTAL_NODE_STATE_SIZE_BYTES: &str =
-        "readyset_domain.total_node_state_size_bytes";
+    /// | table_name | The name of the base table. |
+    pub const ESTIMATED_BASE_TABLE_SIZE_BYTES: &str = "readyset_base_tables_estimated_size_bytes";
 
     /// Counter: The number of HTTP requests received at the readyset-server, for either the
     /// controller or worker.

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -3,340 +3,120 @@
 //! To make the metrics performant, it holds handles to all the required metrics for
 //! fast operations, wherever possible.
 
-use std::collections::BTreeMap;
-use std::convert::TryInto;
 use std::time::Duration;
 
-use metrics::{gauge, register_counter, register_histogram, Counter, Histogram, SharedString};
+use metrics::{counter, gauge, histogram};
 use nom_sql::Relation;
 use readyset_client::metrics::recorded;
-use strum::{EnumCount, IntoEnumIterator};
 
-use crate::domain::{LocalNodeIndex, ReplicaAddress, Tag};
-use crate::{NodeMap, Packet, PacketDiscriminants};
+use crate::{Packet, PacketDiscriminants};
 
 /// Contains handles to the various metrics collected for a domain.
 /// Whenever possible the handles are generated at init time, others
 /// that require dynamic labels are created on demand and stored in
 /// a BTreeMap or a NodeMap.
-pub(super) struct DomainMetrics {
-    index: SharedString,
-    shard: SharedString,
-    eviction_requests: Counter,
-    eviction_time: Histogram,
-    eviction_size: Histogram,
-
-    packets_sent: [Counter; PacketDiscriminants::COUNT],
-
-    // using a BTree to look up metrics by tag/node, BTree is faster than HashMap for u32/u64 keys
-    chunked_replay_start_time: BTreeMap<Tag, (Counter, Histogram)>,
-    total_replay_time: BTreeMap<Tag, (Counter, Histogram)>,
-    seed_replay_time: BTreeMap<Tag, (Counter, Histogram)>,
-    finish_replay_time: BTreeMap<Tag, (Counter, Histogram)>,
-    total_forward_time: BTreeMap<(LocalNodeIndex, LocalNodeIndex), (Counter, Histogram)>,
-    replay_misses: BTreeMap<(LocalNodeIndex, Tag), Counter>,
-
-    reader_replay_request_time: NodeMap<(Counter, Histogram)>,
-    chunked_replay_time: NodeMap<(Counter, Histogram)>,
-    base_table_lookups: NodeMap<Counter>,
-}
+pub(super) struct DomainMetrics;
 
 impl DomainMetrics {
-    pub(super) fn new(replica_address: ReplicaAddress) -> Self {
-        let index: SharedString = replica_address.domain_index.index().to_string().into();
-        let shard: SharedString = replica_address.shard.to_string().into();
-
-        let packets_sent: Vec<Counter> = PacketDiscriminants::iter()
-            .map(|d| {
-                let name: &'static str = d.into();
-                register_counter!(recorded::DOMAIN_PACKET_SENT,
-                                  "domain" => index.clone(),
-                                  "shard" => shard.clone(),
-                                  "packet_type" => name,
-                )
-            })
-            .collect();
-
-        DomainMetrics {
-            eviction_requests: register_counter!(recorded::EVICTION_REQUESTS, vec![],),
-            eviction_time: register_histogram!(recorded::EVICTION_TIME, vec![]),
-            eviction_size: register_histogram!(recorded::EVICTION_FREED_MEMORY, vec![],),
-            chunked_replay_start_time: Default::default(),
-            chunked_replay_time: Default::default(),
-            total_replay_time: Default::default(),
-            seed_replay_time: Default::default(),
-            finish_replay_time: Default::default(),
-            total_forward_time: Default::default(),
-            replay_misses: Default::default(),
-            packets_sent: packets_sent.try_into().ok().unwrap(),
-            reader_replay_request_time: Default::default(),
-            base_table_lookups: Default::default(),
-            shard,
-            index,
-        }
+    pub(super) fn new() -> Self {
+        DomainMetrics
     }
 
     pub(super) fn inc_eviction_requests(&self) {
-        self.eviction_requests.increment(1);
+        counter!(recorded::EVICTION_REQUESTS, 1)
     }
 
     pub(super) fn rec_eviction_time(&self, time: Duration, total_freed: u64) {
-        self.eviction_time.record(time.as_micros() as f64);
-        self.eviction_size.record(total_freed as f64);
+        histogram!(recorded::EVICTION_TIME, time.as_micros() as f64);
+        histogram!(recorded::EVICTION_FREED_MEMORY, total_freed as f64);
     }
 
-    pub(super) fn rec_chunked_replay_start_time(&mut self, tag: Tag, time: Duration) {
-        if let Some((ctr, histo)) = self.chunked_replay_start_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string()
-            );
+    pub(super) fn rec_chunked_replay_start_time(&mut self, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
+            time.as_micros() as u64,
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_CHUNKED_REPLAY_START_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string()
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.chunked_replay_start_time.insert(tag, (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_CHUNKED_REPLAY_START_TIME,
+            time.as_micros() as f64,
+        );
     }
 
-    pub(super) fn recorders_for_chunked_replay(
-        &mut self,
-        from_node: LocalNodeIndex,
-    ) -> (Counter, Histogram) {
-        if let Some(recorders) = self.chunked_replay_time.get(from_node) {
-            recorders.clone()
-        } else {
-            let recorders = (
-                register_counter!(
-                    recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_TIME,
-                    "domain" => self.index.clone(),
-                    "shard" => self.shard.clone(),
-                    "from_node" => from_node.to_string()
-                ),
-                register_histogram!(
-                    recorded::DOMAIN_CHUNKED_REPLAY_TIME,
-                    "domain" => self.index.clone(),
-                    "shard" => self.shard.clone(),
-                    "from_node" => from_node.to_string()
-                ),
-            );
+    pub(super) fn rec_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_REPLAY_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            self.chunked_replay_time
-                .insert(from_node, recorders.clone());
-            recorders
-        }
+        histogram!(
+            recorded::DOMAIN_REPLAY_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_replay_time(&mut self, tag: Tag, cache_name: &Relation, time: Duration) {
-        if let Some((ctr, histo)) = self.total_replay_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
+    pub(super) fn rec_seed_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.total_replay_time.insert(tag, (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_SEED_REPLAY_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_seed_replay_time(&mut self, tag: Tag, cache_name: &Relation, time: Duration) {
-        if let Some((ctr, histo)) = self.seed_replay_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
+    pub(super) fn rec_finish_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_SEED_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.seed_replay_time.insert(tag, (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_FINISH_REPLAY_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_finish_replay_time(
-        &mut self,
-        tag: Tag,
-        cache_name: &Relation,
-        time: Duration,
-    ) {
-        if let Some((ctr, histo)) = self.finish_replay_time.get(&tag) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            let histo = register_histogram!(
-                recorded::DOMAIN_FINISH_REPLAY_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "tag" => tag.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.finish_replay_time.insert(tag, (ctr, histo));
-        }
+    pub(super) fn rec_forward_time(&mut self, time: Duration) {
+        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64);
+        histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64);
     }
 
-    pub(super) fn rec_forward_time(
-        &mut self,
-        src: LocalNodeIndex,
-        dst: LocalNodeIndex,
-        time: Duration,
-    ) {
-        if let Some((ctr, histo)) = self.total_forward_time.get(&(src, dst)) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_TOTAL_FORWARD_TIME,
-                "from_node" => src.to_string(),
-                "to_node" => dst.to_string(),
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-            );
+    pub(super) fn rec_reader_replay_time(&mut self, cache_name: &Relation, time: Duration) {
+        counter!(
+            recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
+            time.as_micros() as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
 
-            let histo = register_histogram!(
-                recorded::DOMAIN_FORWARD_TIME,
-                "from_node" => src.to_string(),
-                "to_node" => dst.to_string(),
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.total_forward_time.insert((src, dst), (ctr, histo));
-        }
+        histogram!(
+            recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
+            time.as_micros() as f64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
-    pub(super) fn rec_reader_replay_time(
-        &mut self,
-        node: LocalNodeIndex,
-        cache_name: &Relation,
-        time: Duration,
-    ) {
-        if let Some((ctr, histo)) = self.reader_replay_request_time.get(node) {
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "node" => node.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            let histo = register_histogram!(
-                recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "node" => node.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(time.as_micros() as u64);
-            histo.record(time.as_micros() as f64);
-
-            self.reader_replay_request_time.insert(node, (ctr, histo));
-        }
-    }
-
-    pub(super) fn inc_replay_misses(
-        &mut self,
-        miss_in: LocalNodeIndex,
-        needed_for: Tag,
-        cache_name: &Relation,
-        n: usize,
-    ) {
-        if let Some(ctr) = self.replay_misses.get(&(miss_in, needed_for)) {
-            ctr.increment(n as u64);
-        } else {
-            let ctr = register_counter!(
-                recorded::DOMAIN_REPLAY_MISSES,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "miss_in" => miss_in.id().to_string(),
-                "needed_for" => needed_for.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
-            ctr.increment(n as u64);
-            self.replay_misses.insert((miss_in, needed_for), ctr);
-        }
+    pub(super) fn inc_replay_misses(&mut self, cache_name: &Relation, n: usize) {
+        counter!(
+            recorded::DOMAIN_REPLAY_MISSES,
+            n as u64,
+            "cache_name" => cache_name_to_string(cache_name)
+        );
     }
 
     pub(super) fn inc_packets_sent(&mut self, packet: &Packet) {
         let discriminant: PacketDiscriminants = packet.into();
-        self.packets_sent[discriminant as usize].increment(1);
-    }
+        let packet_type: &'static str = discriminant.into();
 
-    pub(super) fn inc_base_table_lookups(&mut self, node: LocalNodeIndex, cache_name: &Relation) {
-        if let Some(ctr) = self.base_table_lookups.get(node) {
-            ctr.increment(1);
-        } else {
-            let ctr = register_counter!(
-                recorded::BASE_TABLE_LOOKUP_REQUESTS,
-                "domain" => self.index.clone(),
-                "shard" => self.shard.clone(),
-                "node" => node.to_string(),
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-            ctr.increment(1);
-            self.base_table_lookups.insert(node, ctr);
-        }
+        counter!(recorded::DOMAIN_PACKET_SENT, 1, "packet_type" => packet_type);
     }
 
     pub(super) fn set_reader_state_size(&self, name: &Relation, size: u64) {
@@ -352,6 +132,15 @@ impl DomainMetrics {
             recorded::ESTIMATED_BASE_TABLE_SIZE_BYTES,
             size as f64,
             "table_name" => cache_name_to_string(name),
+        );
+    }
+
+    pub(super) fn inc_base_table_lookups(&mut self, cache_name: &Relation, table_name: &Relation) {
+        counter!(
+            recorded::BASE_TABLE_LOOKUP_REQUESTS,
+            1,
+            "cache_name" => cache_name_to_string(cache_name),
+            "table_name" => cache_name_to_string(table_name)
         );
     }
 }

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -85,9 +85,14 @@ impl DomainMetrics {
         );
     }
 
-    pub(super) fn rec_forward_time(&mut self, time: Duration) {
-        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64);
-        histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64);
+    pub(super) fn rec_forward_time_input(&mut self, time: Duration) {
+        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64, "packet_type" => "input");
+        histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64, "packet_type" => "input");
+    }
+
+    pub(super) fn rec_forward_time_message(&mut self, time: Duration) {
+        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64, "packet_type" => "message");
+        histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64, "packet_type" => "message");
     }
 
     pub(super) fn rec_reader_replay_time(&mut self, cache_name: &Relation, time: Duration) {

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -24,6 +24,7 @@ use futures_util::stream::StreamExt;
 use futures_util::TryFutureExt;
 pub use internal::{DomainIndex, ReplicaAddress};
 use merging_interval_tree::IntervalTreeSet;
+use nom_sql::Relation;
 use petgraph::graph::NodeIndex;
 use readyset_alloc::StdThreadBuildWrapper;
 use readyset_client::debug::info::KeyCount;
@@ -54,6 +55,9 @@ use crate::payload::{
 use crate::prelude::*;
 use crate::processing::ColumnMiss;
 use crate::{backlog, DomainRequest, Readers};
+
+/// A stub for the cache name used for domain metrics that are emitted during a migration.
+const MIGRATION_CACHE_NAME_STUB: &str = "migration";
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Config {
@@ -791,6 +795,7 @@ impl Domain {
         miss_columns: &[usize],
         dst: Destination,
         target: Target,
+        cache_name: Relation,
     ) -> Result<(), ReadySetError> {
         let miss_index = Index::new(IndexType::best_for_keys(&miss_keys), miss_columns.to_vec());
         // the cloned is a bit sad; self.request_partial_replay doesn't use
@@ -847,11 +852,12 @@ impl Domain {
                         unishard: true, // local replays are necessarily single-shard
                         requesting_shard: self.shard(),
                         requesting_replica: self.replica(),
+                        cache_name: cache_name.clone(),
                     });
                 continue;
             }
 
-            self.send_partial_replay_request(tag, miss_keys.clone())?;
+            self.send_partial_replay_request(tag, miss_keys.clone(), cache_name.clone())?;
         }
 
         Ok(())
@@ -867,6 +873,7 @@ impl Domain {
         requesting_shard: usize,
         requesting_replica: usize,
         needed_for: Tag,
+        cache_name: Relation,
     ) -> ReadySetResult<()> {
         use std::collections::hash_map::Entry;
         use std::ops::AddAssign;
@@ -875,7 +882,7 @@ impl Domain {
         let mut w = self.waiting.remove(miss_in).unwrap_or_default();
 
         self.metrics
-            .inc_replay_misses(miss_in, needed_for, missed_keys.len());
+            .inc_replay_misses(miss_in, needed_for, &cache_name, missed_keys.len());
 
         let is_generated = self
             .replay_paths
@@ -978,7 +985,13 @@ impl Domain {
         self.waiting.insert(miss_in, w);
 
         for ((target, columns), keys) in needed_replays {
-            self.find_tags_and_replay(keys, &columns, Destination(miss_in), target)?
+            self.find_tags_and_replay(
+                keys,
+                &columns,
+                Destination(miss_in),
+                target,
+                cache_name.clone(),
+            )?
         }
 
         Ok(())
@@ -993,6 +1006,7 @@ impl Domain {
         &mut self,
         tag: Tag,
         keys: Vec<KeyComparison>,
+        cache_name: Relation,
     ) -> ReadySetResult<()> {
         let requesting_shard = self.shard();
         let requesting_replica = self.replica();
@@ -1027,6 +1041,7 @@ impl Domain {
                             keys: keys.clone(), // sad to clone here
                             requesting_shard,
                             requesting_replica,
+                            cache_name: cache_name.clone(),
                         })
                         .is_err()
                     {
@@ -1051,6 +1066,7 @@ impl Domain {
                         unishard: true, // only one option, so only one path
                         requesting_shard,
                         requesting_replica,
+                        cache_name,
                     })
                     .is_err()
                 {
@@ -1075,6 +1091,7 @@ impl Domain {
                             unishard: true, // !ask_all, so only one path
                             requesting_shard,
                             requesting_replica,
+                            cache_name: cache_name.clone(),
                         })
                         .is_err()
                     {
@@ -1645,9 +1662,15 @@ impl Domain {
                         }
 
                         let replica = self.replica();
+
+                        struct Misses {
+                            misses: Vec<KeyComparison>,
+                            cache_name: Relation,
+                        }
+
                         let txs = (0..num_shards)
                             .map(|shard| -> ReadySetResult<_> {
-                                let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+                                let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Misses>();
                                 let sender = self
                                     .channel_coordinator
                                     .builder_for(&ReplicaAddress {
@@ -1661,9 +1684,10 @@ impl Domain {
                                 tokio::spawn(
                                     UnboundedReceiverStream::new(rx)
                                         .map(move |misses| Packet::RequestReaderReplay {
-                                            keys: misses,
+                                            keys: misses.misses,
                                             cols: cols.clone(),
                                             node,
+                                            cache_name: misses.cache_name,
                                         })
                                         .map(Ok)
                                         .forward(sender)
@@ -1687,14 +1711,14 @@ impl Domain {
                         let (r_part, w_part) = backlog::new_partial(
                             num_columns,
                             index,
-                            move |misses: &mut dyn Iterator<Item = KeyComparison>| {
+                            move |misses: &mut dyn Iterator<Item = KeyComparison>, cache_name| {
                                 if num_shards == 1 {
                                     let misses = misses.collect::<Vec<_>>();
                                     if misses.is_empty() {
                                         return true;
                                     }
                                     #[allow(clippy::indexing_slicing)] // just checked len is 1
-                                    txs[0].send(misses).is_ok()
+                                    txs[0].send(Misses { misses, cache_name }).is_ok()
                                 } else {
                                     let mut per_shard = HashMap::new();
                                     for miss in misses {
@@ -1712,7 +1736,12 @@ impl Domain {
                                     per_shard.into_iter().all(|(shard, keys)| {
                                         #[allow(clippy::indexing_slicing)]
                                         // we know txs.len() is equal to num_shards
-                                        txs[shard].send(keys).is_ok()
+                                        txs[shard]
+                                            .send(Misses {
+                                                misses: keys,
+                                                cache_name: cache_name.clone(),
+                                            })
+                                            .is_ok()
                                     })
                                 }
                             },
@@ -1965,6 +1994,7 @@ impl Domain {
                         replicas: replicas.clone(),
                     },
                     data: Vec::<Record>::new().into(),
+                    cache_name: MIGRATION_CACHE_NAME_STUB.into(),
                 });
 
                 let added_cols = self.ingress_inject.get(from).cloned();
@@ -2042,6 +2072,7 @@ impl Domain {
                                     replicas: replicas.clone(),
                                 },
                                 data: chunk,
+                                cache_name: MIGRATION_CACHE_NAME_STUB.into(),
                             };
 
                             trace!(num = i, len, "sending batch");
@@ -2066,6 +2097,7 @@ impl Domain {
                                     replicas: replicas.clone(),
                                 },
                                 data: Default::default(),
+                                cache_name: MIGRATION_CACHE_NAME_STUB.into(),
                             }) {
                                 warn!(%error, "replayer noticed domain shutdown");
                             }
@@ -2378,12 +2410,19 @@ impl Domain {
                 self.total_forward_time.stop();
                 self.metrics.rec_forward_time(src, dst, start.elapsed());
             }
-            Packet::ReplayPiece { tag, .. } => {
+            Packet::ReplayPiece {
+                ref tag,
+                ref cache_name,
+                ..
+            } => {
                 let start = time::Instant::now();
+                let cache_name = cache_name.clone();
+                let tag = *tag;
                 self.total_replay_time.start();
                 self.handle_replay(m, executor)?;
                 self.total_replay_time.stop();
-                self.metrics.rec_replay_time(tag, start.elapsed());
+                self.metrics
+                    .rec_replay_time(tag, &cache_name, start.elapsed());
             }
             Packet::Evict(req) => {
                 self.handle_eviction(req, executor)?;
@@ -2400,6 +2439,7 @@ impl Domain {
                 mut keys,
                 cols,
                 node,
+                cache_name,
             } => {
                 let start = time::Instant::now();
                 self.total_replay_time.start();
@@ -2458,39 +2498,40 @@ impl Domain {
                         // Destination and target are the same since readers can't generate columns
                         Destination(node),
                         Target(node),
+                        cache_name.clone(),
                     )?;
                 }
 
                 self.total_replay_time.stop();
-                self.metrics.rec_reader_replay_time(node, start.elapsed());
+                self.metrics
+                    .rec_reader_replay_time(node, &cache_name, start.elapsed());
             }
             Packet::RequestPartialReplay {
                 tag,
-                keys,
-                unishard,
-                requesting_shard,
-                requesting_replica,
+                ref keys,
+                ref cache_name,
+                ..
             } => {
                 trace!(%tag, ?keys, "got replay request");
                 let start = time::Instant::now();
+                let cache_name = cache_name.clone();
                 self.total_replay_time.start();
-                self.seed_all(
-                    tag,
-                    requesting_shard,
-                    requesting_replica,
-                    keys.into_iter().collect(),
-                    unishard,
-                    executor,
-                )?;
+                self.seed_all(m, executor)?;
                 self.total_replay_time.stop();
-                self.metrics.rec_seed_replay_time(tag, start.elapsed());
+                self.metrics
+                    .rec_seed_replay_time(tag, &cache_name, start.elapsed());
             }
-            Packet::Finish(tag, ni) => {
+            Packet::Finish {
+                tag,
+                node,
+                cache_name,
+            } => {
                 let start = time::Instant::now();
                 self.total_replay_time.start();
-                self.finish_replay(tag, ni, executor)?;
+                self.finish_replay(tag, node, &cache_name, executor)?;
                 self.total_replay_time.stop();
-                self.metrics.rec_finish_replay_time(tag, start.elapsed());
+                self.metrics
+                    .rec_finish_replay_time(tag, &cache_name, start.elapsed());
             }
             Packet::Spin => {
                 // spinning as instructed
@@ -2663,15 +2704,31 @@ impl Domain {
         }
     }
 
-    fn seed_all(
-        &mut self,
-        tag: Tag,
-        requesting_shard: usize,
-        requesting_replica: usize,
-        keys: HashSet<KeyComparison>,
-        single_shard: bool,
-        ex: &mut dyn Executor,
-    ) -> Result<(), ReadySetError> {
+    fn seed_all(&mut self, packet: Packet, ex: &mut dyn Executor) -> Result<(), ReadySetError> {
+        let (tag, keys, unishard, requesting_shard, requesting_replica, cache_name) =
+            if let Packet::RequestPartialReplay {
+                tag,
+                keys,
+                unishard,
+                requesting_shard,
+                requesting_replica,
+                cache_name,
+            } = packet
+            {
+                (
+                    tag,
+                    keys,
+                    unishard,
+                    requesting_shard,
+                    requesting_replica,
+                    cache_name,
+                )
+            } else {
+                internal!()
+            };
+
+        let keys: HashSet<KeyComparison> = keys.into_iter().collect();
+
         #[allow(clippy::indexing_slicing)]
         // tag came from an internal data structure that guarantees it's present
         let (source, index, path) = match &self.replay_paths[tag] {
@@ -2709,7 +2766,8 @@ impl Domain {
 
         if let Some(node) = self.nodes.get(*source) {
             if node.borrow().is_base() {
-                self.metrics.inc_base_table_lookups(*source);
+                self.metrics
+                    .inc_base_table_lookups(*source, &cache_name.clone());
             }
         }
 
@@ -2748,10 +2806,11 @@ impl Domain {
                 // same for range queries was a whole bug that eta had to spend like 2
                 // hours tracking down, only to find it was as simple as this.
                 replay_keys,
-                single_shard,
+                unishard,
                 requesting_shard,
                 requesting_replica,
                 tag,
+                cache_name.clone(),
             )?;
         }
 
@@ -2769,11 +2828,12 @@ impl Domain {
                     tag,
                     context: ReplayPieceContext::Partial {
                         for_keys: found_keys,
-                        unishard: single_shard, // if we are the only source, only one path
+                        unishard, // if we are the only source, only one path
                         requesting_shard,
                         requesting_replica,
                     },
                     data: records.into(),
+                    cache_name,
                 },
                 ex,
             )?;
@@ -2784,6 +2844,12 @@ impl Domain {
 
     #[allow(clippy::cognitive_complexity)]
     fn handle_replay(&mut self, m: Packet, ex: &mut dyn Executor) -> ReadySetResult<()> {
+        let cache_name = if let Packet::ReplayPiece { ref cache_name, .. } = m {
+            cache_name.clone()
+        } else {
+            internal!()
+        };
+
         let tag = m
             .tag()
             .ok_or_else(|| internal_err!("handle_replay called on an invalid message"))?;
@@ -2841,9 +2907,9 @@ impl Domain {
                 Packet::ReplayPiece {
                     tag,
                     link,
-
                     data,
                     context,
+                    ..
                 } => (tag, link, data, context),
                 _ => internal!(),
             };
@@ -2954,6 +3020,7 @@ impl Domain {
                 tag,
                 data,
                 context,
+                cache_name: cache_name.clone(),
             });
 
             macro_rules! replay_context {
@@ -3595,6 +3662,7 @@ impl Domain {
                 next_replay.requesting_shard,
                 next_replay.requesting_replica,
                 next_replay.tag,
+                cache_name.clone(),
             )?;
         }
 
@@ -3690,6 +3758,7 @@ impl Domain {
                             keys,
                             requesting_shard,
                             requesting_replica,
+                            cache_name: cache_name.clone(),
                         });
                 }
 
@@ -3717,7 +3786,11 @@ impl Domain {
                 // but this allows finish_replay to dispatch into the node by
                 // overriding replaying_to.
                 self.not_ready.remove(&dst);
-                self.delayed_for_self.push_back(Packet::Finish(tag, dst));
+                self.delayed_for_self.push_back(Packet::Finish {
+                    tag,
+                    node: dst,
+                    cache_name: cache_name.clone(),
+                });
             }
         }
         Ok(())
@@ -3727,6 +3800,7 @@ impl Domain {
         &mut self,
         tag: Tag,
         node: LocalNodeIndex,
+        cache_name: &Relation,
         ex: &mut dyn Executor,
     ) -> Result<(), ReadySetError> {
         let mut was = mem::replace(&mut self.mode, DomainMode::Forwarding);
@@ -3819,7 +3893,11 @@ impl Domain {
             }
         } else {
             // we're not done -- inject a request to continue handling buffered things
-            self.delayed_for_self.push_back(Packet::Finish(tag, node));
+            self.delayed_for_self.push_back(Packet::Finish {
+                tag,
+                node,
+                cache_name: cache_name.clone(),
+            });
             Ok(())
         }
     }

--- a/readyset-dataflow/src/node/special/egress.rs
+++ b/readyset-dataflow/src/node/special/egress.rs
@@ -23,11 +23,6 @@ pub struct EgressTx {
     domain_index: DomainIndex,
     shard: usize,
     replication: SenderReplication,
-
-    #[serde(skip)]
-    sent_ctr: Option<metrics::Counter>,
-    #[serde(skip)]
-    dropped_ctr: Option<metrics::Counter>,
 }
 
 impl EgressTx {
@@ -44,8 +39,6 @@ impl EgressTx {
             domain_index,
             shard,
             replication,
-            sent_ctr: None,
-            dropped_ctr: None,
         }
     }
 
@@ -59,27 +52,11 @@ impl EgressTx {
     }
 
     fn inc_sent(&mut self) {
-        if let Some(ctr) = &self.sent_ctr {
-            ctr.increment(1);
-        } else {
-            let node = self.node.index().to_string();
-            let ctr =
-                metrics::register_counter!(recorded::EGRESS_NODE_SENT_PACKETS, "node" => node);
-            ctr.increment(1);
-            self.sent_ctr.replace(ctr);
-        }
+        metrics::counter!(recorded::EGRESS_NODE_SENT_PACKETS, 1)
     }
 
     fn inc_dropped(&mut self) {
-        if let Some(ctr) = &self.dropped_ctr {
-            ctr.increment(1);
-        } else {
-            let node = self.node.index().to_string();
-            let ctr =
-                metrics::register_counter!(recorded::EGRESS_NODE_DROPPED_PACKETS, "node" => node);
-            ctr.increment(1);
-            self.dropped_ctr.replace(ctr);
-        }
+        metrics::counter!(recorded::EGRESS_NODE_DROPPED_PACKETS, 1);
     }
 }
 

--- a/readyset-dataflow/src/node/special/packet_filter.rs
+++ b/readyset-dataflow/src/node/special/packet_filter.rs
@@ -289,6 +289,7 @@ mod test {
                     requesting_replica: 0,
                     unishard: false,
                 },
+                cache_name: "test".into(),
             };
 
             let mut packet_filter = PacketFilter::default();
@@ -611,6 +612,7 @@ mod test {
                 tag: Tag::new(1),
                 data: Default::default(),
                 context,
+                cache_name: "test".into(),
             }
         }
     }

--- a/readyset-dataflow/src/payload.rs
+++ b/readyset-dataflow/src/payload.rs
@@ -346,9 +346,6 @@ pub enum DomainRequest {
         state: PrepareStateKind,
     },
 
-    /// Ask domain to log its state size
-    UpdateStateSize,
-
     /// Inform domain about a new replay path.
     SetupReplayPath {
         tag: Tag,

--- a/readyset-dataflow/src/payload.rs
+++ b/readyset-dataflow/src/payload.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display};
 
 use dataflow_state::MaterializedNodeState;
 use itertools::Itertools;
+use nom_sql::Relation;
 use readyset_client::{self, KeyComparison, PacketData, PacketTrace};
 use readyset_data::DfType;
 use serde::{Deserialize, Serialize};
@@ -465,13 +466,20 @@ pub enum Packet {
         tag: Tag,
         data: Records,
         context: ReplayPieceContext,
+        /// The cache name associated with the replay. Only used for metric labels.
+        cache_name: Relation,
     },
 
     // Trigger an eviction as specified by the to the [`EvictRequest`].
     Evict(EvictRequest),
 
     // Internal control
-    Finish(Tag, LocalNodeIndex),
+    Finish {
+        tag: Tag,
+        node: LocalNodeIndex,
+        /// The cache name associated with the replay. Only used for metric labels.
+        cache_name: Relation,
+    },
 
     // Control messages
     /// Ask domain (nicely) to replay a particular set of keys.
@@ -481,6 +489,8 @@ pub enum Packet {
         unishard: bool,
         requesting_shard: usize,
         requesting_replica: usize,
+        /// The cache name associated with the replay. Only used for metric labels.
+        cache_name: Relation,
     },
 
     /// Ask domain (nicely) to replay a particular set of keys into a Reader.
@@ -488,6 +498,8 @@ pub enum Packet {
         node: LocalNodeIndex,
         cols: Vec<usize>,
         keys: Vec<KeyComparison>,
+        /// The cache name associated with the replay. Only used for metric labels.
+        cache_name: Relation,
     },
 
     /// A packet used solely to drive the event loop forward.
@@ -626,11 +638,13 @@ impl Packet {
                 tag,
                 ref data,
                 ref context,
+                ref cache_name,
             } => Packet::ReplayPiece {
                 link,
                 tag,
                 data: data.clone(),
                 context: context.clone(),
+                cache_name: cache_name.clone(),
             },
             Packet::Timestamp {
                 ref timestamp,

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -6,7 +6,7 @@ use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 use std::{io, mem};
 
 use anyhow::{anyhow, bail, Context};
@@ -552,6 +552,7 @@ impl TestScript {
         let mut rh = ReadySetHandle::new(authority.clone()).await;
 
         let server_supports_pagination = rh.supports_pagination().await.unwrap();
+        let adapter_start_time = SystemTime::now();
 
         let task = tokio::spawn(async move {
             let (s, _) = listener.accept().await.unwrap();
@@ -608,6 +609,7 @@ impl TestScript {
                             query_status_cache,
                             authority,
                             status_reporter,
+                            adapter_start_time,
                         )
                 }};
             }

--- a/readyset-server/src/controller/migrate/mod.rs
+++ b/readyset-server/src/controller/migrate/mod.rs
@@ -1161,7 +1161,6 @@ fn plan_add_nodes(
                         recorded::NODE_ADDED,
                         1,
                         "ntype" => dataflow_state.ingredients[ni].node_type_string(),
-                        "node" => nnodes.to_string()
                     );
                 }
                 dataflow_state

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::process;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use clap::builder::NonEmptyStringValueParser;
 use clap::Parser;
@@ -211,13 +211,7 @@ fn main() -> anyhow::Result<()> {
             ("opt_level", READYSET_VERSION.opt_level),
         ]
     );
-    metrics::counter!(
-        recorded::NORIA_STARTUP_TIMESTAMP,
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u64
-    );
+    metrics::counter!(recorded::READYSET_SERVER_STARTUPS, 1);
 
     if let Some(volume_id) = &opts.worker_options.volume_id {
         info!(%volume_id);

--- a/readyset-server/src/worker/mod.rs
+++ b/readyset-server/src/worker/mod.rs
@@ -627,11 +627,7 @@ async fn do_eviction(
                         )
                     });
 
-                    counter!(
-                        recorded::EVICTION_WORKER_EVICTIONS_REQUESTED,
-                        1,
-                        "domain" => target.domain_index.index().to_string(),
-                    );
+                    counter!(recorded::EVICTION_WORKER_EVICTIONS_REQUESTED, 1);
 
                     let tx = match domain_senders.entry(target) {
                         Occupied(entry) => entry.into_mut(),

--- a/readyset-server/src/worker/readers.rs
+++ b/readyset-server/src/worker/readers.rs
@@ -241,7 +241,10 @@ impl ReadRequestHandler {
 
         // Trigger backfills for all the keys we missed on, regardless of a consistency hit/miss
         if !keys_to_replay.is_empty() {
-            reader.trigger(keys_to_replay.into_iter().map(|k| k.into_owned()));
+            reader.trigger(
+                keys_to_replay.into_iter().map(|k| k.into_owned()),
+                target.name.clone(),
+            );
         }
 
         let read = BlockingRead {
@@ -540,7 +543,10 @@ impl BlockingRead {
             self.eviction_epoch = cur_eviction_epoch;
             // Retrigger all un-read keys. Its possible they could have been filled and then
             // evicted again without us reading it.
-            if !reader.trigger(still_waiting.into_iter().map(|v| v.into_owned())) {
+            if !reader.trigger(
+                still_waiting.into_iter().map(|v| v.into_owned()),
+                self.target.name.clone(),
+            ) {
                 // server is shutting down and won't do the backfill
                 return Poll::Ready(Err(ReadySetError::ServerShuttingDown));
             }

--- a/readyset-server/src/worker/replica.rs
+++ b/readyset-server/src/worker/replica.rs
@@ -118,7 +118,9 @@ fn flatten_request_reader_replay(
     let mut i = 0;
     while i < packets.len() {
         match packets.get_mut(i) {
-            Some(Packet::RequestReaderReplay { node, cols, keys }) if *node == n && *cols == c => {
+            Some(Packet::RequestReaderReplay {
+                node, cols, keys, ..
+            }) if *node == n && *cols == c => {
                 unique_keys.extend(keys.drain(..));
                 packets.remove(i);
             }
@@ -435,7 +437,7 @@ impl Replica {
                                     // After processing we need to ack timestamp and input messages from base
                                     connections.iter_mut().find(|(t, _)| *t == *token).map(|(_, conn)| (*tag, conn))
                                 }
-                                Packet::RequestReaderReplay { node, cols, keys } => {
+                                Packet::RequestReaderReplay { node, cols, keys, .. } => {
                                     // We want to batch multiple reader replay requests into a single call while
                                     // deduplicating non unique keys
                                     let mut unique_keys: HashSet<_> = keys.drain(..).collect();

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime};
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
@@ -786,13 +786,8 @@ where
                 ("opt_level", READYSET_VERSION.opt_level),
             ]
         );
-        metrics::counter!(
-            recorded::NORIA_STARTUP_TIMESTAMP,
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64
-        );
+        metrics::counter!(recorded::READYSET_ADAPTER_STARTUPS, 1);
+        let adapter_start_time = SystemTime::now();
 
         let (shutdown_tx, shutdown_rx) = shutdown::channel();
 
@@ -1161,6 +1156,7 @@ where
                                     query_status_cache,
                                     adapter_authority.clone(),
                                     status_reporter_clone,
+                                    adapter_start_time,
                                 );
                                 connection_handler.process_connection(s, backend).await;
                             }


### PR DESCRIPTION
This commit adds a new "packet_type" label to the domain foward time
metrics to differentiate between input and message packets when plotting
metrics.

