### PR TITLE
demo: Update compose file name for Postgres

### DIFF
--- a/quickstart/readyset_demo.sh
+++ b/quickstart/readyset_demo.sh
@@ -64,7 +64,13 @@ check_dependencies() {
 
 download_demo_compose_file() {
   echo -e "${BLUE}${WHALE}Downloading the ReadySet Docker Compose file... ${NOCOLOR}"
-  curl -Ls -o readyset.compose.yml "https://raw.githubusercontent.com/readysettech/readyset/main/quickstart/compose.postgres.yml"
+  curl -Ls "https://raw.githubusercontent.com/readysettech/readyset/main/quickstart/compose.postgres.yml" > /tmp/readyset.compose.yml
+  sed "s|readyset-postgres|readyset|" /tmp/readyset.compose.yml > readyset.compose.yml
+  ls
+  echo "cwd:"
+  pwd
+  echo 'compose:'
+  cat readyset.compose.yml
 }
 
 download_byo_compose_file() {


### PR DESCRIPTION
The compose.postgres.yml file has the name `readyset-postgres`, whereas
the BYO compose file has the name `readyset`. This causes discrepancies
when running certain commands, since the Readyset container name differs
based on the name of the compose file. This commit fixes the issue by
updating the name of the `compose.postgres.yml` file to `readyset` after
it's downloaded.

