### PR TITLE
metrics: Replace snapshot progress metric

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -278,13 +278,8 @@ pub mod recorded {
     /// | status | SnapshotStatusTag |
     pub const REPLICATOR_SNAPSHOT_STATUS: &str = "readyset_replicator.snapshot_status";
 
-    /// Gauge: Progress (in percent, 0-100) in snapshotting the given table
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | schema | Schema the relevant table exists in |
-    /// | name | Name of the table being snapshot |
-    pub const REPLICATOR_SNAPSHOT_PERCENT: &str = "readyset_replicator.snapshot.percent";
+    /// Gauge: The number of tables currently snapshotting
+    pub const REPLICATOR_TABLES_SNAPSHOTTING: &str = "readyset_replicator.tables_snapshotting";
 
     /// Counter: Number of failures encountered when following the replication
     /// log.

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -8,12 +8,10 @@ use futures::future::TryFutureExt;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use itertools::Itertools;
-use metrics::register_gauge;
 use mysql::prelude::Queryable;
 use mysql::{Transaction, TxOpts};
 use mysql_async as mysql;
 use nom_sql::{DialectDisplay, NonReplicatedRelation, NotReplicatedReason, Relation};
-use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::{Change, ChangeList};
 use readyset_data::Dialect;
 use readyset_errors::{internal_err, ReadySetResult};
@@ -25,6 +23,7 @@ use tracing_futures::Instrument;
 
 use crate::db_util::DatabaseSchemas;
 use crate::table_filter::TableFilter;
+use crate::TablesSnapshottingGaugeGuard;
 
 const BATCH_SIZE: usize = 1000; // How many queries to buffer before pushing to ReadySet
 
@@ -400,10 +399,7 @@ impl MySqlReplicator {
         info!(rows = %nrows, "Snapshotting started");
 
         table_mutator.set_snapshot_mode(true).await?;
-        let progress_percentage_metric: metrics::Gauge = register_gauge!(
-            recorded::REPLICATOR_SNAPSHOT_PERCENT,
-            "name" => table_mutator.table_name().display(nom_sql::Dialect::MySQL).to_string(),
-        );
+        let _tables_snapshotting_metric_handle = TablesSnapshottingGaugeGuard::new();
 
         let start_time = Instant::now();
         let mut last_report_time = start_time;
@@ -418,7 +414,6 @@ impl MySqlReplicator {
                     break;
                 }
                 Err(err) => {
-                    progress_percentage_metric.set(0.0);
                     return Err(log_err(err));
                 }
             };
@@ -429,34 +424,25 @@ impl MySqlReplicator {
             if rows.len() == BATCH_SIZE {
                 // We aggregate rows into batches and then send them all to noria
                 let send_rows = std::mem::replace(&mut rows, Vec::with_capacity(BATCH_SIZE));
-                table_mutator.insert_many(send_rows).await.map_err(|err| {
-                    progress_percentage_metric.set(0.0);
-                    log_err(err)
-                })?;
+                table_mutator
+                    .insert_many(send_rows)
+                    .await
+                    .map_err(log_err)?;
             }
 
             if snapshot_report_interval_secs != 0
                 && last_report_time.elapsed().as_secs() > snapshot_report_interval_secs
             {
                 last_report_time = Instant::now();
-                crate::log_snapshot_progress(
-                    start_time.elapsed(),
-                    cnt as i64,
-                    nrows as i64,
-                    &progress_percentage_metric,
-                );
+                crate::log_snapshot_progress(start_time.elapsed(), cnt as i64, nrows as i64);
             }
         }
 
         if !rows.is_empty() {
-            table_mutator.insert_many(rows).await.map_err(|err| {
-                progress_percentage_metric.set(0.0);
-                log_err(err)
-            })?;
+            table_mutator.insert_many(rows).await.map_err(log_err)?;
         }
 
         info!(rows_replicated = %cnt, "Snapshotting finished");
-        progress_percentage_metric.set(100.0);
 
         Ok(())
     }

--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -9,7 +9,6 @@ use failpoint_macros::set_failpoint;
 use futures::stream::FuturesUnordered;
 use futures::{pin_mut, StreamExt, TryFutureExt};
 use itertools::Itertools;
-use metrics::register_gauge;
 use nom_sql::{
     parse_key_specification_string, parse_sql_type, Column, ColumnConstraint, ColumnSpecification,
     CreateTableBody, CreateTableStatement, Dialect, DialectDisplay, NonReplicatedRelation,
@@ -18,7 +17,6 @@ use nom_sql::{
 use postgres_types::{accepts, FromSql, Kind, Type};
 #[cfg(feature = "failure_injection")]
 use readyset_client::failpoints;
-use readyset_client::metrics::recorded;
 use readyset_client::recipe::changelist::{Change, ChangeList, PostgresTableMetadata};
 use readyset_client::TableOperation;
 use readyset_data::{DfType, DfValue, Dialect as DataDialect, PgEnumMetadata};
@@ -31,6 +29,7 @@ use tracing::{debug, info, info_span, trace, warn, Instrument};
 use super::connector::CreatedSlot;
 use crate::db_util::CreateSchema;
 use crate::table_filter::TableFilter;
+use crate::TablesSnapshottingGaugeGuard;
 
 const BATCH_SIZE: usize = 1024; // How many queries to buffer before pushing to ReadySet
 
@@ -520,11 +519,7 @@ impl TableDescription {
         pin_mut!(binary_row_batches);
 
         info!(%approximate_rows, "Snapshotting started");
-        let progress_percentage_metric: metrics::Gauge = register_gauge!(
-            recorded::REPLICATOR_SNAPSHOT_PERCENT,
-            "schema" => self.schema()?.to_string(),
-            "name" => self.name.name.to_string()
-        );
+        let _tables_snapshotting_metric_handle = TablesSnapshottingGaugeGuard::new();
         let start_time = Instant::now();
         let mut last_report_time = start_time;
         let snapshot_report_interval_secs = snapshot_report_interval_secs as u64;
@@ -542,7 +537,6 @@ impl TableDescription {
                             .map(|i| row.try_get::<DfValue>(i))
                             .collect::<Result<Vec<_>, _>>()
                             .map_err(|err| {
-                                progress_percentage_metric.set(0.0);
                                 ReadySetError::ReplicationFailed(format!(
                                     "Failed converting to DfValue, table: {}, row: {}, err: {}",
                                     noria_table.table_name().display(Dialect::PostgreSQL),
@@ -581,23 +575,14 @@ impl TableDescription {
             } else {
                 noria_table
                     .insert_many(noria_rows_iter.collect::<Result<Vec<_>, _>>()?)
-                    .await
-                    .map_err(|err| {
-                        progress_percentage_metric.set(0.0);
-                        err
-                    })?;
+                    .await?
             }
 
             if snapshot_report_interval_secs != 0
                 && last_report_time.elapsed().as_secs() > snapshot_report_interval_secs
             {
                 last_report_time = Instant::now();
-                crate::log_snapshot_progress(
-                    start_time.elapsed(),
-                    cnt as i64,
-                    approximate_rows,
-                    &progress_percentage_metric,
-                );
+                crate::log_snapshot_progress(start_time.elapsed(), cnt as i64, approximate_rows);
             }
         }
 
@@ -613,7 +598,6 @@ impl TableDescription {
         }
 
         info!(rows_replicated = %cnt, "Snapshotting finished");
-        progress_percentage_metric.set(100.0);
 
         Ok(())
     }


### PR DESCRIPTION
This commit replaces the metric used to track the snapshot progress
percentage of each table (which is already being logged) with a new
gauge that just tracks the number of tables currently being snapshotted.
This is part of an effort to reduce the cardinality of our metrics.

