### PR TITLE
metrics: Remove table name from base lookup

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -278,13 +278,8 @@ pub mod recorded {
     /// | status | SnapshotStatusTag |
     pub const REPLICATOR_SNAPSHOT_STATUS: &str = "readyset_replicator.snapshot_status";
 
-    /// Gauge: Progress (in percent, 0-100) in snapshotting the given table
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | schema | Schema the relevant table exists in |
-    /// | name | Name of the table being snapshot |
-    pub const REPLICATOR_SNAPSHOT_PERCENT: &str = "readyset_replicator.snapshot.percent";
+    /// Gauge: The number of tables currently snapshotting
+    pub const REPLICATOR_TABLES_SNAPSHOTTING: &str = "readyset_replicator.snapshot.percent";
 
     /// Counter: Number of failures encountered when following the replication
     /// log.

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -15,11 +15,15 @@ use crate::{Packet, PacketDiscriminants};
 /// Whenever possible the handles are generated at init time, others
 /// that require dynamic labels are created on demand and stored in
 /// a BTreeMap or a NodeMap.
-pub(super) struct DomainMetrics;
+pub(super) struct DomainMetrics {
+    /// Whether to record metrics that include metric labels with high cardinality. This flag
+    /// should be used very sparingly, as the cost of emitting these metrics could be quite high!
+    verbose: bool,
+}
 
 impl DomainMetrics {
-    pub(super) fn new() -> Self {
-        DomainMetrics
+    pub(super) fn new(verbose: bool) -> Self {
+        DomainMetrics { verbose }
     }
 
     pub(super) fn inc_eviction_requests(&self) {
@@ -44,45 +48,51 @@ impl DomainMetrics {
     }
 
     pub(super) fn rec_replay_time(&mut self, cache_name: &Relation, time: Duration) {
-        counter!(
-            recorded::DOMAIN_TOTAL_REPLAY_TIME,
-            time.as_micros() as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_TOTAL_REPLAY_TIME,
+                time.as_micros() as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
 
-        histogram!(
-            recorded::DOMAIN_REPLAY_TIME,
-            time.as_micros() as f64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+            histogram!(
+                recorded::DOMAIN_REPLAY_TIME,
+                time.as_micros() as f64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn rec_seed_replay_time(&mut self, cache_name: &Relation, time: Duration) {
-        counter!(
-            recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
-            time.as_micros() as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
+                time.as_micros() as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
 
-        histogram!(
-            recorded::DOMAIN_SEED_REPLAY_TIME,
-            time.as_micros() as f64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+            histogram!(
+                recorded::DOMAIN_SEED_REPLAY_TIME,
+                time.as_micros() as f64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn rec_finish_replay_time(&mut self, cache_name: &Relation, time: Duration) {
-        counter!(
-            recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
-            time.as_micros() as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
+                time.as_micros() as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
 
-        histogram!(
-            recorded::DOMAIN_FINISH_REPLAY_TIME,
-            time.as_micros() as f64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+            histogram!(
+                recorded::DOMAIN_FINISH_REPLAY_TIME,
+                time.as_micros() as f64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn rec_forward_time_input(&mut self, time: Duration) {
@@ -96,17 +106,19 @@ impl DomainMetrics {
     }
 
     pub(super) fn rec_reader_replay_time(&mut self, cache_name: &Relation, time: Duration) {
-        counter!(
-            recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
-            time.as_micros() as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
+                time.as_micros() as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
 
-        histogram!(
-            recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
-            time.as_micros() as f64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+            histogram!(
+                recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
+                time.as_micros() as f64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn inc_replay_misses(&mut self, cache_name: &Relation, n: usize) {
@@ -133,20 +145,24 @@ impl DomainMetrics {
     }
 
     pub(super) fn set_base_table_size(&self, name: &Relation, size: u64) {
-        gauge!(
-            recorded::ESTIMATED_BASE_TABLE_SIZE_BYTES,
-            size as f64,
-            "table_name" => cache_name_to_string(name),
-        );
+        if self.verbose {
+            gauge!(
+                recorded::ESTIMATED_BASE_TABLE_SIZE_BYTES,
+                size as f64,
+                "table_name" => cache_name_to_string(name),
+            );
+        }
     }
 
     pub(super) fn inc_base_table_lookups(&mut self, cache_name: &Relation, table_name: &Relation) {
-        counter!(
-            recorded::BASE_TABLE_LOOKUP_REQUESTS,
-            1,
-            "cache_name" => cache_name_to_string(cache_name),
-            "table_name" => cache_name_to_string(table_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::BASE_TABLE_LOOKUP_REQUESTS,
+                1,
+                "cache_name" => cache_name_to_string(cache_name),
+                "table_name" => cache_name_to_string(table_name)
+            );
+        }
     }
 }
 

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -154,13 +154,12 @@ impl DomainMetrics {
         }
     }
 
-    pub(super) fn inc_base_table_lookups(&mut self, cache_name: &Relation, table_name: &Relation) {
+    pub(super) fn inc_base_table_lookups(&mut self, cache_name: &Relation) {
         if self.verbose {
             counter!(
                 recorded::BASE_TABLE_LOOKUP_REQUESTS,
                 1,
                 "cache_name" => cache_name_to_string(cache_name),
-                "table_name" => cache_name_to_string(table_name)
             );
         }
     }

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -2765,8 +2765,7 @@ impl Domain {
 
         if let Some(node) = self.nodes.get(*source) {
             if node.borrow().is_base() {
-                self.metrics
-                    .inc_base_table_lookups(&cache_name, node.borrow().name());
+                self.metrics.inc_base_table_lookups(&cache_name);
             }
         }
 

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -77,6 +77,9 @@ pub struct Config {
 
     #[serde(default)]
     pub eviction_kind: crate::EvictionKind,
+
+    /// Whether to emit verbose metrics for the domain.
+    pub verbose_metrics: bool,
 }
 
 const BATCH_SIZE: usize = 256;
@@ -459,7 +462,7 @@ impl DomainBuilder {
 
             aggressively_update_state_sizes: self.config.aggressively_update_state_sizes,
 
-            metrics: domain_metrics::DomainMetrics::new(),
+            metrics: domain_metrics::DomainMetrics::new(self.config.verbose_metrics),
 
             eviction_kind: self.config.eviction_kind,
             remapped_keys: Default::default(),

--- a/readyset-server/src/builder.rs
+++ b/readyset-server/src/builder.rs
@@ -95,6 +95,7 @@ impl Builder {
         ));
 
         builder.set_replication_strategy(opts.domain_replication_options.into());
+        builder.set_verbose_domain_metrics(opts.verbose_domain_metrics);
 
         if let Some(volume_id) = opts.volume_id {
             builder.set_volume_id(volume_id);
@@ -315,6 +316,12 @@ impl Builder {
     /// that field for more information.
     pub fn set_view_request_timeout(&mut self, value: std::time::Duration) {
         self.config.domain_config.view_request_timeout = value;
+    }
+
+    /// Sets the value of [`Config::domain_config::verbose_metrics`]. See documentation of
+    /// that field for more information.
+    pub fn set_verbose_domain_metrics(&mut self, value: bool) {
+        self.config.domain_config.verbose_metrics = value;
     }
 
     /// Sets the value of [`Config::domain_config::table_request_timeout`]. See documentation of

--- a/readyset-server/src/lib.rs
+++ b/readyset-server/src/lib.rs
@@ -518,6 +518,7 @@ impl Default for Config {
                 // now.
                 table_request_timeout: Duration::from_millis(1800000),
                 eviction_kind: dataflow::EvictionKind::Random,
+                verbose_metrics: false,
             },
             persistence: Default::default(),
             min_workers: 1,
@@ -668,6 +669,17 @@ pub struct WorkerOptions {
         hide = true
     )]
     pub background_recovery_interval_seconds: u64,
+
+    /// Whether to emit verbose metrics for the domains on this worker. This should be used very
+    /// sparingly, as the metrics emitted will have high label cardinality and can be quite
+    /// expensive!
+    #[arg(
+        long,
+        env = "VERBOSE_DOMAIN_METRICS",
+        default_value = "false",
+        hide = true
+    )]
+    pub verbose_domain_metrics: bool,
 }
 
 impl WorkerOptions {

--- a/replicators/src/lib.rs
+++ b/replicators/src/lib.rs
@@ -14,9 +14,10 @@ pub(crate) mod table_filter;
 
 use std::time::Duration;
 
-use metrics::Gauge;
+use metrics::{register_gauge, Gauge};
 use nom_sql::Relation;
 pub use noria_adapter::{cleanup, NoriaAdapter};
+use readyset_client::metrics::recorded;
 use readyset_errors::ReadySetError;
 pub use replication_offset::mysql::MySqlPosition;
 pub use replication_offset::postgres::PostgresPosition;
@@ -39,6 +40,28 @@ pub enum ReplicatorMessage {
 pub enum ControllerMessage {
     /// Drop the specified table and require a new partial snapshot
     ResnapshotTable { table: Relation },
+}
+
+/// A handle to the metric we use to track the number of tables currently snapshotting. To use this
+/// handle, just keep it in scope while the table is snapshotting; once the handle is dropped, the
+/// gauge will be decremented. The type is designed to ensure that we *always* 1) increment the
+/// gauge when the handle is created and 2) decrement the gauge when the handle is dropped.
+struct TablesSnapshottingGaugeHandle(Gauge);
+
+impl TablesSnapshottingGaugeHandle {
+    /// Creates a new handle and increments the gauge by 1. The gauge is automatically decremented
+    /// when the handle is dropped.
+    fn new() -> Self {
+        let gauge = register_gauge!(recorded::REPLICATOR_TABLES_SNAPSHOTTING);
+        gauge.increment(1.0);
+        Self(gauge)
+    }
+}
+
+impl Drop for TablesSnapshottingGaugeHandle {
+    fn drop(&mut self) {
+        self.0.decrement(1.0);
+    }
 }
 
 /// Provide a simplistic human-readable estimate for how much time remains to complete an operation
@@ -64,7 +87,7 @@ pub(crate) fn estimate_remaining_time(elapsed: Duration, progress: i64, total: i
 /// unknown (equals to 0 or 1), then estimated time and progress will be set to 'n/a'
 /// To provide feedback to a user, number of replicated rows and estimated total rows are logged
 /// If total number of rows is unknown progress %% is set to 0.0 (in metric).
-pub(crate) fn log_snapshot_progress(elapsed: Duration, cnt: i64, total: i64, metric: &Gauge) {
+pub(crate) fn log_snapshot_progress(elapsed: Duration, cnt: i64, total: i64) {
     let estimate = estimate_remaining_time(elapsed, cnt, total);
     let mut progress_percent: f64;
     progress_percent = if total > 1 {
@@ -84,5 +107,4 @@ pub(crate) fn log_snapshot_progress(elapsed: Duration, cnt: i64, total: i64, met
     };
     let rows_total_est = if total > cnt { total } else { cnt };
     info!(rows_replicated = %cnt, rows_total_est = %rows_total_est, %progress, %estimate, "Snapshotting progress");
-    metric.set(progress_percent);
 }


### PR DESCRIPTION
This commit removes the table name from the base table lookup counter
metric to reduce the number of time series the metric generates.

