### PR TITLE
metrics: Add on_input metrics

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -247,6 +247,21 @@ pub mod recorded {
     /// | packet_type | The type of packet |
     pub const DOMAIN_PACKETS_QUEUED: &str = "readyset_domain.packets_queued";
 
+    /// Histogram: The amount of time in microseconds an operator node spends handling a call to
+    /// `Ingredient::on_input`.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | ntype | The operator node type. |
+    pub const NODE_ON_INPUT_DURATION: &str = "readyset_domain.node_on_input_duration_us";
+
+    /// Counter: The number of times `Ingredient::on_input` has been invoked for a node.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | ntype | The operator node type. |
+    pub const NODE_ON_INPUT_INVOCATIONS: &str = "readyset_domain.node_on_input_invocations";
+
     /// Histogram: The time a snapshot takes to be performed.
     pub const REPLICATOR_SNAPSHOT_DURATION: &str = "readyset_replicator.snapshot_duration_us";
 


### PR DESCRIPTION
This commit adds metrics to track the duration and count of invocations
to `Ingredient::on_input`, labeled by the node operator type. This will
give us insight into what nodes are the most expensive nodes in the
graph and will help us spot anomalies (e.g. if a project node is taking
a very long time, something is probably wrong).

