### PR TITLE
replicators: Skip snapshotting tables in readyset schema

### DIFF
--- a/replicators/src/postgres_connector/snapshot.rs
+++ b/replicators/src/postgres_connector/snapshot.rs
@@ -1015,6 +1015,7 @@ impl<'a> PostgresReplicator<'a> {
         ON n.oid = c.relnamespace
         WHERE c.relkind IN ($1) AND n.nspname <> 'pg_catalog'
                                 AND n.nspname <> 'information_schema'
+                                AND n.nspname <> 'readyset'
                                 AND n.nspname !~ '^pg_toast'
                                 AND c.oid NOT IN(
         SELECT c.oid


### PR DESCRIPTION
Our DDL triggers create a table in the readyset schema for versions of
postgres before 14, and this table was being snapshotted, which doesn't
make sense as this is an internal catalog table that is used to allow
for ddl replication to readyset.

This commit ignores tables in the `readyset` schema while determining
the set of tables to snapshot.

Fixes: REA-4077
