### PR TITLE
clustertest: Run with query log mode set to verbose

### DIFF
--- a/readyset-clustertest/src/server.rs
+++ b/readyset-clustertest/src/server.rs
@@ -218,6 +218,8 @@ impl AdapterBuilder {
                 "--allow-unauthenticated-connections".to_string(),
                 "--migration-request-timeout-ms".to_string(),
                 "1000".to_string(),
+                "--query-log-mode".to_string(),
+                "verbose".to_string(),
             ],
             auto_restart: false,
         }


### PR DESCRIPTION
This commit updates the clustertests to run with `--query-log-mode` set
to verbose, since some of the tests rely upon the extended labels we
include in the query log metrics when running in verbose mode.

