### PR TITLE
adapter+server: Autoparameterize range queries

### DIFF
--- a/benchmarks/src/bin/write_propagation.rs
+++ b/benchmarks/src/bin/write_propagation.rs
@@ -106,7 +106,7 @@ impl Writer {
         let auto_increments: Arc<RwLock<HashMap<Relation, AtomicUsize>>> = Arc::default();
         let view_name_cache = SharedCache::new();
         let view_cache = SharedCache::new();
-        let server_supports_pagination = ch.supports_pagination().await?;
+        let adapter_rewrite_params = ch.adapter_rewrite_params().await?;
         let (dialect, nom_sql_dialect) = match DatabaseURL::from_str(&self.database_url)? {
             DatabaseURL::MySQL(_) => (Dialect::DEFAULT_MYSQL, nom_sql::Dialect::MySQL),
             DatabaseURL::PostgreSQL(_) => {
@@ -123,7 +123,7 @@ impl Writer {
             dialect,
             nom_sql_dialect,
             vec![],
-            server_supports_pagination,
+            adapter_rewrite_params,
         )
         .await;
 

--- a/logictests/ranges.test
+++ b/logictests/ranges.test
@@ -9,33 +9,64 @@ insert into t1 (x, y) values
 (3, 3),
 (4, 5);
 
-query I valuesort
-select x from t1 where y < ?;
-? = 5
-----
-1
-2
-3
+# query I valuesort
+# select x from t1 where y < ?;
+# ? = 5
+# ----
+# 1
+# 2
+# 3
+# 
+# query I valuesort
+# select x from t1 where x >= ? and y >= ?;
+# ? = 1
+# ? = 2
+# ----
+# 1
+# 1
+# 3
+# 4
+# 
+# query I valuesort
+# select x from t1 where x > ? and y > ?
+# ? = 2
+# ? = 4
+# ----
+# 4
+# 
+# query I valuesort
+# select x from t1 where x > ? and y > ?
+# ? = 4
+# ? = 4
+# ----
+# 
+# query I valuesort
+# select x from t1 where x >= 2 and x <= 4
+# ----
+# 2
+# 3
+# 4
+# 
+# query I valuesort
+# select x from t1 where x >= 2 and x < 4
+# ----
+# 2
+# 3
+# 
+# query I valuesort
+# select x from t1 where x > 2 and x <= 4
+# ----
+# 3
+# 4
+# 
+# query I valuesort
+# select x from t1 where x > 2 and x < 4
+# ----
+# 3
 
 query I valuesort
-select x from t1 where x >= ? and y >= ?;
-? = 1
+select x from t1 where x > ? and y < ?
 ? = 2
+? = 4
 ----
-1
-1
 3
-4
-
-query I valuesort
-select x from t1 where x > ? and y > ?
-? = 2
-? = 4
-----
-4
-
-query I valuesort
-select x from t1 where x > ? and y > ?
-? = 4
-? = 4
-----

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1094,7 +1094,7 @@ where
         stmt: &nom_sql::SelectStatement,
     ) -> ReadySetResult<(nom_sql::SelectStatement, bool)> {
         let mut rewritten = stmt.clone();
-        adapter_rewrites::process_query(&mut rewritten, self.noria.server_supports_pagination())?;
+        adapter_rewrites::process_query(&mut rewritten, self.noria.rewrite_params())?;
         // Attempt ReadySet unless the query is unsupported or dropped
         let should_do_readyset = !matches!(
             self.state
@@ -1814,7 +1814,7 @@ where
             }
         }
         // Now migrate the new query
-        adapter_rewrites::process_query(&mut stmt, self.noria.server_supports_pagination())?;
+        adapter_rewrites::process_query(&mut stmt, self.noria.rewrite_params())?;
         let migration_state = match self
             .noria
             .handle_create_cached_query(
@@ -2200,7 +2200,7 @@ where
                                 let mut stmt = *stmt.clone();
                                 adapter_rewrites::process_query(
                                     &mut stmt,
-                                    self.noria.server_supports_pagination(),
+                                    self.noria.rewrite_params(),
                                 )?;
 
                                 ViewCreateRequest::new(
@@ -2579,10 +2579,7 @@ where
         Option<QueryStatus>,
         ReadySetResult<ProcessedQueryParams>,
     ) {
-        match adapter_rewrites::process_query(
-            &mut q.statement,
-            self.noria.server_supports_pagination(),
-        ) {
+        match adapter_rewrites::process_query(&mut q.statement, self.noria.rewrite_params()) {
             Ok(processed_query_params) => {
                 let s = self.state.query_status_cache.query_status(q);
                 let should_try = if self.state.proxy_state.should_proxy() {

--- a/readyset-client-test-helpers/src/lib.rs
+++ b/readyset-client-test-helpers/src/lib.rs
@@ -89,6 +89,7 @@ pub struct TestBuilder {
     storage_dir_path: Option<PathBuf>,
     authority: Option<Arc<Authority>>,
     replication_server_id: Option<ReplicationServerId>,
+    allow_mixed_comparisons: bool,
 }
 
 impl Default for TestBuilder {
@@ -113,6 +114,7 @@ impl TestBuilder {
             storage_dir_path: None,
             authority: None,
             replication_server_id: None,
+            allow_mixed_comparisons: true,
         }
     }
 
@@ -185,6 +187,11 @@ impl TestBuilder {
         self
     }
 
+    pub fn allow_mixed_comparisons(mut self, allow_mixed_comparisons: bool) -> Self {
+        self.allow_mixed_comparisons = allow_mixed_comparisons;
+        self
+    }
+
     pub async fn build<A>(self) -> (A::ConnectionOpts, Handle, ShutdownSender)
     where
         A: Adapter + 'static,
@@ -232,7 +239,8 @@ impl TestBuilder {
         builder.set_persistence(persistence);
         builder.set_allow_topk(true);
         builder.set_allow_paginate(true);
-        builder.set_allow_mixed_comparisons(true);
+        builder.set_allow_mixed_comparisons(self.allow_mixed_comparisons);
+
         if !self.partial {
             builder.disable_partial();
         }
@@ -307,7 +315,7 @@ impl TestBuilder {
                     };
 
                     let mut rh = ReadySetHandle::new(authority.clone()).await;
-                    let server_supports_pagination = rh.supports_pagination().await.unwrap();
+                    let adapter_rewrite_params = rh.adapter_rewrite_params().await.unwrap();
                     let noria = NoriaConnector::new(
                         rh.clone(),
                         auto_increments,
@@ -317,7 +325,7 @@ impl TestBuilder {
                         A::EXPR_DIALECT,
                         A::DIALECT,
                         schema_search_path,
-                        server_supports_pagination,
+                        adapter_rewrite_params,
                     )
                     .await;
 

--- a/readyset-client/src/controller.rs
+++ b/readyset-client/src/controller.rs
@@ -14,6 +14,7 @@ use petgraph::graph::NodeIndex;
 use readyset_errors::{
     internal, internal_err, rpc_err, rpc_err_no_downcast, ReadySetError, ReadySetResult,
 };
+use readyset_sql_passes::adapter_rewrites::AdapterRewriteParams;
 use replication_offset::ReplicationOffsets;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -925,8 +926,8 @@ impl ReadySetHandle {
     );
 
     simple_request!(
-        /// Returns true if topk and pagination support are enabled on the server
-        supports_pagination() -> bool
+        /// Returns the params to use when performing adapter rewrites.
+        adapter_rewrite_params() -> AdapterRewriteParams
     );
 
     simple_request!(

--- a/readyset-client/src/recipe/changelist.rs
+++ b/readyset-client/src/recipe/changelist.rs
@@ -43,7 +43,7 @@ use nom_sql::{
 };
 use readyset_data::DfType;
 use readyset_errors::{internal, unsupported, ReadySetError, ReadySetResult};
-use readyset_sql_passes::adapter_rewrites;
+use readyset_sql_passes::adapter_rewrites::{self, AdapterRewriteParams};
 use serde::{Deserialize, Serialize};
 use test_strategy::Arbitrary;
 use tracing::error;
@@ -483,7 +483,7 @@ impl Change {
     /// rewrites on the parsed query string before passing it to the server via `/extend_recipe`.
     pub fn from_cache_ddl_request(
         ddl_req: &CacheDDLRequest,
-        server_supports_pagination: bool,
+        adapter_rewrite_params: AdapterRewriteParams,
     ) -> ReadySetResult<Self> {
         macro_rules! mk_error {
             ($str:expr) => {
@@ -531,7 +531,7 @@ impl Change {
 
                         adapter_rewrites::process_query(
                             &mut statement,
-                            server_supports_pagination,
+                            adapter_rewrite_params
                         )?;
 
                         Change::CreateCache(CreateCache {

--- a/readyset-logictest/src/runner.rs
+++ b/readyset-logictest/src/runner.rs
@@ -551,7 +551,7 @@ impl TestScript {
 
         let mut rh = ReadySetHandle::new(authority.clone()).await;
 
-        let server_supports_pagination = rh.supports_pagination().await.unwrap();
+        let adapter_rewrite_params = rh.adapter_rewrite_params().await.unwrap();
         let adapter_start_time = SystemTime::now();
 
         let task = tokio::spawn(async move {
@@ -572,7 +572,7 @@ impl TestScript {
                     DatabaseType::PostgreSQL => nom_sql::Dialect::PostgreSQL,
                 },
                 Default::default(),
-                server_supports_pagination,
+                adapter_rewrite_params,
             )
             .await;
             let query_status_cache: &'static _ = Box::leak(Box::new(QueryStatusCache::new()));

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2598,7 +2598,12 @@ async fn drop_and_recreate_demo_cache() {
     // There was an error returned at one point in doing this, so this test is an attempt to block
     // a breaking change to the demo script at CI time.
     readyset_tracing::init_test_logging();
-    let (opts, _handle, shutdown_tx) = setup().await;
+    let (opts, _handle, shutdown_tx) = TestBuilder::default()
+        .fallback(true)
+        .allow_mixed_comparisons(false)
+        .build::<PostgreSQLAdapter>()
+        .await;
+
     let conn = connect(opts).await;
 
     let queries = [

--- a/readyset-psql/tests/integration.rs
+++ b/readyset-psql/tests/integration.rs
@@ -2003,6 +2003,73 @@ async fn show_caches_contains_select_statement() {
     shutdown_tx.shutdown().await;
 }
 
+// Tests that mixed comparisons work end-to-end with autoparameterization
+#[tokio::test(flavor = "multi_thread")]
+async fn mixed_comparisons() {
+    let (opts, _handle, shutdown_tx) = setup().await;
+    let conn = connect(opts).await;
+
+    conn.simple_query("DROP TABLE IF EXISTS t").await.unwrap();
+    conn.simple_query("CREATE TABLE t (x int, y int)")
+        .await
+        .unwrap();
+
+    eventually!(conn
+        .simple_query("CREATE CACHE FROM SELECT * FROM t WHERE x = 1 AND y < 10")
+        .await
+        .is_ok());
+
+    let query_text = match conn
+        .simple_query("SHOW CACHES")
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap()
+    {
+        SimpleQueryMessage::Row(row) => row.get(2).unwrap().to_owned(),
+        _ => panic!(),
+    };
+
+    assert_eq!(
+        query_text,
+        r#"SELECT
+  "t"."x",
+  "t"."y"
+FROM
+  "t"
+WHERE
+  (
+    ("t"."x" = $1)
+    AND ("t"."y" < $2)
+  )"#
+    );
+
+    conn.simple_query("SELECT * FROM t WHERE x = 2 AND y < 20")
+        .await
+        .unwrap();
+
+    let (destination, status) = match conn
+        .simple_query("EXPLAIN LAST STATEMENT")
+        .await
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap()
+    {
+        SimpleQueryMessage::Row(row) => (
+            row.get(0).unwrap().to_owned(),
+            row.get(1).unwrap().to_owned(),
+        ),
+        _ => panic!(),
+    };
+
+    assert_eq!(destination, "readyset");
+    assert_eq!(status, "ok");
+
+    shutdown_tx.shutdown().await;
+}
+
 mod http_tests {
     use super::*;
     #[tokio::test(flavor = "multi_thread")]

--- a/readyset-server/src/controller/inner.rs
+++ b/readyset-server/src/controller/inner.rs
@@ -525,9 +525,9 @@ impl Leader {
                 state_copy.extend_recipe(body, true).await?;
                 return_serialized!(ExtendRecipeResult::Done);
             }
-            (&Method::GET | &Method::POST, "/supports_pagination") => {
+            (&Method::GET | &Method::POST, "/adapter_rewrite_params") => {
                 let ds = self.dataflow_state_handle.read().await;
-                let supports = ds.recipe.supports_pagination();
+                let supports = ds.recipe.adapter_rewrite_params();
                 return_serialized!(supports)
             }
             (&Method::POST, "/evict_single") => {

--- a/readyset-server/src/controller/sql/query_graph.rs
+++ b/readyset-server/src/controller/sql/query_graph.rs
@@ -370,7 +370,7 @@ impl QueryGraph {
             fn combine_comparisons(
                 current_view_placeholder: &ViewPlaceholder,
                 new_param: &Parameter,
-            ) -> ReadySetResult<ViewPlaceholder> {
+            ) -> Option<ViewPlaceholder> {
                 match (current_view_placeholder, new_param) {
                     (
                         ViewPlaceholder::OneToOne(idx, BinaryOperator::GreaterOrEqual),
@@ -379,7 +379,7 @@ impl QueryGraph {
                             placeholder_idx: Some(ref placeholder_idx),
                             ..
                         },
-                    ) => Ok(ViewPlaceholder::Between(*idx, *placeholder_idx)),
+                    ) => Some(ViewPlaceholder::Between(*idx, *placeholder_idx)),
                     (
                         ViewPlaceholder::OneToOne(idx, BinaryOperator::LessOrEqual),
                         Parameter {
@@ -387,8 +387,8 @@ impl QueryGraph {
                             placeholder_idx: Some(ref placeholder_idx),
                             ..
                         },
-                    ) => Ok(ViewPlaceholder::Between(*placeholder_idx, *idx)),
-                    _ => unsupported!("Conflicting binary operators in query"),
+                    ) => Some(ViewPlaceholder::Between(*placeholder_idx, *idx)),
+                    _ => None,
                 }
             }
 
@@ -402,8 +402,21 @@ impl QueryGraph {
                             if *col == param.col
                                 && matches!(placeholder, ViewPlaceholder::OneToOne(_, ref op) if *op != param.op) =>
                         {
-                            *placeholder = combine_comparisons(placeholder, param)?;
-                            Ok((index_type, columns))
+                            // Try to combine the one-to-one placeholder with the given param into
+                            // a between placeholder
+                            if let Some(p) = combine_comparisons(placeholder, param) {
+                                *placeholder = p;
+                            } else {
+                                // If the param and placeholder aren't a <= and >= pair, just tack
+                                // on the param as another one-to-one placeholder
+                                columns.push((
+                                    mir::Column::from(param.col.clone()),
+                                    param
+                                        .placeholder_idx
+                                        .map(|idx| ViewPlaceholder::OneToOne(idx, param.op))
+                                        .unwrap_or(ViewPlaceholder::Generated),
+                                ));
+                            }
                         }
                         // Otherwise, add a new ViewPlaceholder and continue
                         _ => {
@@ -414,9 +427,9 @@ impl QueryGraph {
                                     .map(|idx| ViewPlaceholder::OneToOne(idx, param.op))
                                     .unwrap_or(ViewPlaceholder::Generated),
                             ));
-                            Ok((index_type, columns))
                         }
                     }
+                    Ok((index_type, columns))
                 },
             )?;
 

--- a/readyset-server/src/controller/sql/recipe/mod.rs
+++ b/readyset-server/src/controller/sql/recipe/mod.rs
@@ -6,6 +6,7 @@ use readyset_client::recipe::changelist::ChangeList;
 use readyset_client::ViewCreateRequest;
 use readyset_data::Dialect;
 use readyset_errors::ReadySetResult;
+use readyset_sql_passes::adapter_rewrites::AdapterRewriteParams;
 use readyset_util::hash::hash;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
@@ -219,7 +220,21 @@ impl Recipe {
     }
 
     /// Returns true only if this recipe supports pagination.
-    pub(crate) fn supports_pagination(&self) -> bool {
-        self.mir_config().allow_paginate && self.mir_config().allow_topk
+    pub(crate) fn adapter_rewrite_params(&self) -> AdapterRewriteParams {
+        AdapterRewriteParams {
+            server_supports_mixed_comparisons: self.mir_config().allow_mixed_comparisons,
+            server_supports_pagination: self.mir_config().allow_paginate
+                && self.mir_config().allow_topk,
+        }
     }
+    //
+    // /// Returns true only if this recipe supports pagination.
+    // pub(crate) fn supports_pagination(&self) -> bool {
+    //     self.mir_config().allow_paginate && self.mir_config().allow_topk
+    // }
+    //
+    // /// Returns true only if this recipe supports mixed comparisons
+    // pub(crate) fn supports_mixed_comparisons(&self) -> bool {
+    //     self.mir_config().allow_mixed_comparisons
+    // }
 }

--- a/readyset-sql-passes/benches/adapter_rewrites.rs
+++ b/readyset-sql-passes/benches/adapter_rewrites.rs
@@ -8,7 +8,7 @@ fn auto_parametrize_query(c: &mut Criterion) {
         b.iter_batched(
             || q.clone(),
             |mut q| {
-                adapter_rewrites::auto_parametrize_query(&mut q);
+                adapter_rewrites::auto_parametrize_query(&mut q, false);
                 black_box(q)
             },
             BatchSize::SmallInput,

--- a/readyset-sql-passes/src/adapter_rewrites/autoparametrize.rs
+++ b/readyset-sql-passes/src/adapter_rewrites/autoparametrize.rs
@@ -5,6 +5,8 @@ use nom_sql::{BinaryOperator, Expr, InValue, ItemPlaceholder, Literal, SelectSta
 
 #[derive(Default)]
 struct AutoParametrizeVisitor {
+    autoparametrize_equals: bool,
+    autoparametrize_ranges: bool,
     out: Vec<(usize, Literal)>,
     has_aggregates: bool,
     in_supported_position: bool,
@@ -60,10 +62,29 @@ impl<'ast> VisitorMut<'ast> for AutoParametrizeVisitor {
                 } => {}
                 Expr::BinaryOp {
                     lhs: box Expr::Column(_),
+                    op,
+                    rhs: box Expr::Literal(Literal::Placeholder(_)),
+                } if op.is_ordering_comparison() => {}
+                Expr::BinaryOp {
+                    lhs: box Expr::Column(_),
                     op: BinaryOperator::Equal,
                     rhs: box Expr::Literal(lit),
                 } => {
-                    self.replace_literal(lit);
+                    if self.autoparametrize_equals {
+                        self.replace_literal(lit);
+                    }
+
+                    return Ok(());
+                }
+                Expr::BinaryOp {
+                    lhs: box Expr::Column(_),
+                    op,
+                    rhs: box Expr::Literal(lit),
+                } if op.is_ordering_comparison() => {
+                    if self.autoparametrize_ranges {
+                        self.replace_literal(lit);
+                    }
+
                     return Ok(());
                 }
                 Expr::BinaryOp {
@@ -71,6 +92,178 @@ impl<'ast> VisitorMut<'ast> for AutoParametrizeVisitor {
                     op: BinaryOperator::Equal,
                     rhs: rhs @ box Expr::Column(_),
                 } => {
+                    // for lit = col, swap the equality first then revisit
+                    mem::swap(lhs, rhs);
+                    return self.visit_expr(expression);
+                }
+                Expr::BinaryOp {
+                    lhs: lhs @ box Expr::Literal(_),
+                    op,
+                    rhs: rhs @ box Expr::Column(_),
+                } if op.is_ordering_comparison() => {
+                    // for lit = col, swap the inequality first then revisit
+                    mem::swap(lhs, rhs);
+                    return self.visit_expr(expression);
+                }
+                Expr::In {
+                    lhs: box Expr::Column(_),
+                    rhs: InValue::List(exprs),
+                    negated: false,
+                } if exprs.iter().all(|e| {
+                    matches!(
+                        e,
+                        Expr::Literal(lit) if !matches!(lit, Literal::Placeholder(_))
+                    )
+                }) && !self.has_aggregates =>
+                {
+                    if self.autoparametrize_equals {
+                        let exprs = mem::replace(
+                            exprs,
+                            iter::repeat(Expr::Literal(Literal::Placeholder(
+                                ItemPlaceholder::QuestionMark,
+                            )))
+                            .take(exprs.len())
+                            .collect(),
+                        );
+                        let num_exprs = exprs.len();
+                        let start_index = self.param_index;
+                        self.out.extend(exprs.into_iter().enumerate().filter_map(
+                            move |(i, expr)| match expr {
+                                Expr::Literal(lit) => Some((i + start_index, lit)),
+                                // unreachable since we checked everything in the list is a literal
+                                // above, but best not to panic regardless
+                                _ => None,
+                            },
+                        ));
+                        self.param_index += num_exprs;
+                    }
+                    return Ok(());
+                }
+                Expr::BinaryOp {
+                    lhs,
+                    op: BinaryOperator::And,
+                    rhs,
+                } => {
+                    self.visit_expr(lhs.as_mut())?;
+                    self.in_supported_position = true;
+                    self.visit_expr(rhs.as_mut())?;
+                    self.in_supported_position = true;
+                    return Ok(());
+                }
+                _ => self.in_supported_position = false,
+            }
+        }
+
+        visit_mut::walk_expr(self, expression)?;
+        self.in_supported_position = was_supported;
+        Ok(())
+    }
+
+    fn visit_offset(&mut self, offset: &'ast mut Literal) -> Result<(), Self::Error> {
+        if !matches!(offset, Literal::Placeholder(_)) && self.autoparametrize_equals {
+            self.replace_literal(offset);
+        }
+
+        visit_mut::walk_offset(self, offset)
+    }
+}
+
+/// Walks through the query to determine whether the query has equals comparisons, range
+/// comparisons, equals placeholders, and range placeholders in positions that support
+/// autoparameterization.
+#[derive(Default)]
+struct AnalyzeLiteralsVisitor {
+    contains_equal: bool,
+    contains_range: bool,
+    contains_equal_placeholder: bool,
+    contains_range_placeholder: bool,
+    query_depth: u8,
+    in_supported_position: bool,
+    has_aggregates: bool,
+}
+
+impl<'ast> VisitorMut<'ast> for AnalyzeLiteralsVisitor {
+    type Error = !;
+
+    fn visit_select_statement(
+        &mut self,
+        select_statement: &'ast mut SelectStatement,
+    ) -> Result<(), Self::Error> {
+        self.query_depth = self.query_depth.saturating_add(1);
+        visit_mut::walk_select_statement(self, select_statement)?;
+        self.query_depth = self.query_depth.saturating_sub(1);
+        Ok(())
+    }
+
+    fn visit_where_clause(&mut self, expression: &'ast mut Expr) -> Result<(), Self::Error> {
+        // We can only support parameters in the WHERE clause of the top-level query, not any
+        // subqueries it contains.
+        self.in_supported_position = self.query_depth <= 1;
+        self.visit_expr(expression)?;
+        self.in_supported_position = false;
+        Ok(())
+    }
+
+    fn visit_expr(&mut self, expression: &'ast mut Expr) -> Result<(), Self::Error> {
+        let was_supported = self.in_supported_position;
+        if was_supported {
+            match expression {
+                Expr::BinaryOp {
+                    lhs: box Expr::Column(_),
+                    op: BinaryOperator::Equal,
+                    rhs: box Expr::Literal(lit),
+                } => {
+                    self.contains_equal = true;
+
+                    if let Literal::Placeholder(_) = lit {
+                        self.contains_equal_placeholder = true;
+                    }
+
+                    return Ok(());
+                }
+                Expr::BinaryOp {
+                    lhs: box Expr::Column(_),
+                    op,
+                    rhs: box Expr::Literal(lit),
+                } if op.is_ordering_comparison() => {
+                    self.contains_range = true;
+
+                    if let Literal::Placeholder(_) = lit {
+                        self.contains_range_placeholder = true;
+                    }
+
+                    return Ok(());
+                }
+                Expr::Between {
+                    min: box Expr::Literal(lit),
+                    ..
+                }
+                | Expr::Between {
+                    max: box Expr::Literal(lit),
+                    ..
+                } => {
+                    self.contains_range = true;
+
+                    if let Literal::Placeholder(_) = lit {
+                        self.contains_range_placeholder = true;
+                    }
+
+                    return Ok(());
+                }
+                Expr::BinaryOp {
+                    lhs: lhs @ box Expr::Literal(_),
+                    op: BinaryOperator::Equal,
+                    rhs: rhs @ box Expr::Column(_),
+                } => {
+                    // for lit = col, swap the equality first then revisit
+                    mem::swap(lhs, rhs);
+                    return self.visit_expr(expression);
+                }
+                Expr::BinaryOp {
+                    lhs: lhs @ box Expr::Literal(_),
+                    op,
+                    rhs: rhs @ box Expr::Column(_),
+                } if op.is_ordering_comparison() => {
                     // for lit = col, swap the equality first then revisit
                     mem::swap(lhs, rhs);
                     return self.visit_expr(expression);
@@ -86,26 +279,7 @@ impl<'ast> VisitorMut<'ast> for AutoParametrizeVisitor {
                     )
                 }) && !self.has_aggregates =>
                 {
-                    let exprs = mem::replace(
-                        exprs,
-                        iter::repeat(Expr::Literal(Literal::Placeholder(
-                            ItemPlaceholder::QuestionMark,
-                        )))
-                        .take(exprs.len())
-                        .collect(),
-                    );
-                    let num_exprs = exprs.len();
-                    let start_index = self.param_index;
-                    self.out
-                        .extend(exprs.into_iter().enumerate().filter_map(
-                            move |(i, expr)| match expr {
-                                Expr::Literal(lit) => Some((i + start_index, lit)),
-                                // unreachable since we checked everything in the list is a literal
-                                // above, but best not to panic regardless
-                                _ => None,
-                            },
-                        ));
-                    self.param_index += num_exprs;
+                    self.contains_equal = true;
                     return Ok(());
                 }
                 Expr::BinaryOp {
@@ -130,7 +304,7 @@ impl<'ast> VisitorMut<'ast> for AutoParametrizeVisitor {
 
     fn visit_offset(&mut self, offset: &'ast mut Literal) -> Result<(), Self::Error> {
         if !matches!(offset, Literal::Placeholder(_)) {
-            self.replace_literal(offset);
+            self.contains_equal = true;
         }
 
         visit_mut::walk_offset(self, offset)
@@ -140,36 +314,53 @@ impl<'ast> VisitorMut<'ast> for AutoParametrizeVisitor {
 /// Replace all literals that are in positions we support parameters in the given query with
 /// parameters, and return the values for those parameters alongside the index in the parameter list
 /// where they appear as a tuple of (placeholder position, value).
-pub fn auto_parametrize_query(query: &mut SelectStatement) -> Vec<(usize, Literal)> {
+pub fn auto_parametrize_query(
+    query: &mut SelectStatement,
+    server_supports_mixed_comparisons: bool,
+) -> Vec<(usize, Literal)> {
     // Don't try to auto-parametrize equal-queries that already contain range params for now, since
     // we don't yet allow mixing range and equal parameters in the same query
-    if query.where_clause.iter().any(|expr| {
-        iter::once(expr)
-            .chain(expr.recursive_subexpressions())
-            .any(|subexpr| {
-                matches!(
-                    subexpr,
-                    Expr::BinaryOp {
-                        op: BinaryOperator::Less
-                            | BinaryOperator::Greater
-                            | BinaryOperator::LessOrEqual
-                            | BinaryOperator::GreaterOrEqual,
-                        rhs: box Expr::Literal(Literal::Placeholder(..)),
-                        ..
-                    } | Expr::Between {
-                        min: box Expr::Literal(Literal::Placeholder(..)),
-                        ..
-                    } | Expr::Between {
-                        max: box Expr::Literal(Literal::Placeholder(..)),
-                        ..
-                    }
-                )
-            })
-    }) {
-        return vec![];
-    }
+    let mut visitor = AnalyzeLiteralsVisitor::default();
+    visitor.visit_select_statement(query).unwrap();
+
+    let (autoparametrize_equals, autoparametrize_ranges) = if server_supports_mixed_comparisons {
+        (true, true)
+    } else if !visitor.contains_range {
+        // If a query contains no range comparisons in positions that support
+        // autoparameterization, we can just proceed with autoparameterizing equals
+        // comparisons
+        (true, false)
+    } else if !visitor.contains_equal {
+        // If a query contains no equals comparisons in positions that support
+        // autoparameterization, we can just proceed with autoparameterizing range
+        // comparisons
+        (false, true)
+    } else {
+        // If we're here, it means the query has both range and equals comparisons in
+        // positions that support autoparameterization
+
+        match (
+            visitor.contains_equal_placeholder,
+            visitor.contains_range_placeholder,
+        ) {
+            // If the query contains only equals placeholders, we try to autoparameterize the rest
+            // of the equals comparisons in the query
+            (true, false) => (true, false),
+            // If the query contains only range placeholders, we try to autoparameterize the rest
+            // of the range comparisons in the query
+            (false, true) => (false, true),
+            // If the query contains no placeholderse, we try to autoparameterize the equals
+            // comparisons only, since we don't support mixed comparisons yet
+            (false, false) => (true, false),
+            // If the query contains equal and range placeholders, we bail, since we don't support
+            // mixed comparisons yet
+            (true, true) => return vec![],
+        }
+    };
 
     let mut visitor = AutoParametrizeVisitor {
+        autoparametrize_equals,
+        autoparametrize_ranges,
         has_aggregates: query.contains_aggregate_select(),
         ..Default::default()
     };
@@ -177,6 +368,7 @@ pub fn auto_parametrize_query(query: &mut SelectStatement) -> Vec<(usize, Litera
     visitor.visit_select_statement(query).unwrap();
     visitor.out
 }
+
 #[cfg(test)]
 mod tests {
     use nom_sql::{Dialect, DialectDisplay};
@@ -190,16 +382,18 @@ mod tests {
     fn parse_select_statement(q: &str, dialect: Dialect) -> SelectStatement {
         try_parse_select_statement(q, dialect).unwrap()
     }
-
     fn test_auto_parametrize(
         query: &str,
         expected_query: &str,
-        expected_parameters: Vec<(usize, Literal)>,
+        // These are parameters that are expected to have been added by the autoparameterization
+        // rewrite pass
+        expected_added_parameters: Vec<(usize, Literal)>,
         dialect: nom_sql::Dialect,
+        server_supports_mixed_comparisons: bool,
     ) {
         let mut query = parse_select_statement(query, dialect);
         let expected = parse_select_statement(expected_query, dialect);
-        let res = auto_parametrize_query(&mut query);
+        let res = auto_parametrize_query(&mut query, server_supports_mixed_comparisons);
         assert_eq!(
             query,
             expected,
@@ -207,32 +401,38 @@ mod tests {
             query.display(dialect),
             expected.display(dialect),
         );
-        assert_eq!(res, expected_parameters);
+        assert_eq!(res, expected_added_parameters);
     }
 
     fn test_auto_parametrize_mysql(
         query: &str,
         expected_query: &str,
-        expected_parameters: Vec<(usize, Literal)>,
+        // These are parameters that are expected to have been added by the autoparameterization
+        // rewrite pass
+        expected_added_parameters: Vec<(usize, Literal)>,
     ) {
         test_auto_parametrize(
             query,
             expected_query,
-            expected_parameters,
+            expected_added_parameters,
             nom_sql::Dialect::MySQL,
+            false,
         )
     }
 
     fn test_auto_parametrize_postgres(
         query: &str,
         expected_query: &str,
-        expected_parameters: Vec<(usize, Literal)>,
+        // These are parameters that are expected to have been added by the autoparameterization
+        // rewrite pass
+        expected_added_parameters: Vec<(usize, Literal)>,
     ) {
         test_auto_parametrize(
             query,
             expected_query,
-            expected_parameters,
+            expected_added_parameters,
             nom_sql::Dialect::PostgreSQL,
+            false,
         )
     }
 
@@ -389,5 +589,277 @@ mod tests {
             "SELECT * FROM posts WHERE id = 1 AND created_at BETWEEN ? and ?",
             vec![],
         );
+    }
+
+    #[test]
+    fn range_query_literals() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE score > 0 AND score < 10",
+            "SELECT * FROM posts WHERE score > ? AND score < ?",
+            vec![(0, 0.into()), (1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn range_query_literals_inclusive() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE score >= 0 AND score <= 10",
+            "SELECT * FROM posts WHERE score >= ? AND score <= ?",
+            vec![(0, 0.into()), (1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn range_query_literals_inclusive_exclusive() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE score >= 0 AND score < 10",
+            "SELECT * FROM posts WHERE score >= ? AND score < ?",
+            vec![(0, 0.into()), (1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn range_query_literals_exclusive_inclusive() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE score > 0 AND score <= 10",
+            "SELECT * FROM posts WHERE score > ? AND score <= ?",
+            vec![(0, 0.into()), (1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn equals_then_range() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id = 1 AND score > 0 AND score < 10",
+            "SELECT * FROM posts WHERE id = ? AND score > 0 AND score < 10",
+            vec![(0, 1.into())],
+        );
+    }
+
+    #[test]
+    fn range_then_equals() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE score > 0 AND score < 10 AND id = 1",
+            "SELECT * FROM posts WHERE score > 0 AND score < 10 AND id = ?",
+            vec![(0, 1.into())],
+        );
+    }
+
+    #[test]
+    fn range_with_or() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE score > 0 OR score < 10",
+            "SELECT * FROM posts WHERE score > 0 OR score < 10",
+            vec![],
+        );
+    }
+
+    #[test]
+    fn nested_range() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id in (SELECT id FROM posts WHERE score > 0 AND score < 10)",
+            "SELECT * FROM posts WHERE id in (SELECT id FROM posts WHERE score > 0 AND score < 10)",
+            vec![],
+        );
+    }
+
+    #[test]
+    fn less_than() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id < 10",
+            "SELECT * FROM posts WHERE id < ?",
+            vec![(0, 10.into())],
+        );
+    }
+
+    #[test]
+    fn less_than_equal() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id <= 10",
+            "SELECT * FROM posts WHERE id <= ?",
+            vec![(0, 10.into())],
+        );
+    }
+
+    #[test]
+    fn greater_than() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id > 10",
+            "SELECT * FROM posts WHERE id > ?",
+            vec![(0, 10.into())],
+        );
+    }
+
+    #[test]
+    fn greater_than_equal() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id >= 10",
+            "SELECT * FROM posts WHERE id >= ?",
+            vec![(0, 10.into())],
+        );
+    }
+
+    #[test]
+    fn range_with_pre_existing_equals_param() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id = ? AND views > 10",
+            "SELECT * FROM posts WHERE id = ? AND views > 10",
+            vec![],
+        );
+    }
+
+    #[test]
+    fn equals_with_pre_existing_range_param() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id = 10 AND views > ? AND date > 10",
+            "SELECT * FROM posts WHERE id = 10 AND views > ? AND date > ?",
+            vec![(1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn ranges_only() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id > 10 AND views > 2",
+            "SELECT * FROM posts WHERE id > ? AND views > ?",
+            vec![(0, 10.into()), (1, 2.into())],
+        );
+    }
+
+    #[test]
+    fn some_equals() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id = ? AND views = 10",
+            "SELECT * FROM posts WHERE id = ? AND views = ?",
+            vec![(1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn some_equals_with_ranges() {
+        test_auto_parametrize_mysql(
+            "SELECT * FROM posts WHERE id = ? AND date = 10 AND views > 10",
+            "SELECT * FROM posts WHERE id = ? AND date = ? AND views > 10",
+            vec![(1, 10.into())],
+        );
+    }
+
+    #[test]
+    fn supported_equals_with_unsupported_ranges() {
+        test_auto_parametrize_mysql(
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE id < 1) s ON users.id = s.id WHERE id = 1",
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE id < 1) s ON users.id = s.id WHERE id = ?",
+            vec![(0, 1.into())],
+        )
+    }
+
+    #[test]
+    fn supported_ranges_with_unsupported_equals() {
+        test_auto_parametrize_mysql(
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id < 1",
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id < ?",
+            vec![(0, 1.into())],
+        )
+    }
+
+    #[test]
+    fn supported_ranges_and_equals_with_unsupported_equals() {
+        test_auto_parametrize_mysql(
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id = 1 AND age > 21",
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id = ? AND age > 21",
+            vec![(0, 1.into())],
+        )
+    }
+
+    #[test]
+    fn supported_ranges_and_equals_with_unsupported_ranges() {
+        test_auto_parametrize_mysql(
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE age > 50) s ON users.id = s.id WHERE id = 1 AND age > 21",
+            "SELECT id FROM users JOIN (SELECT id FROM users WHERE age > 50) s ON users.id = s.id WHERE id = ? AND age > 21",
+            vec![(0, 1.into())],
+        )
+    }
+
+    mod mixed_comparisons {
+        use super::*;
+
+        fn test_auto_parametrize_mysql(
+            query: &str,
+            expected_query: &str,
+            // These are parameters that are expected to have been added by the
+            // autoparameterization rewrite pass
+            expected_added_parameters: Vec<(usize, Literal)>,
+        ) {
+            test_auto_parametrize(
+                query,
+                expected_query,
+                expected_added_parameters,
+                nom_sql::Dialect::MySQL,
+                true,
+            )
+        }
+
+        #[test]
+        fn some_equals_with_ranges() {
+            test_auto_parametrize_mysql(
+                "SELECT * FROM posts WHERE id = ? AND date = 10 AND views > 9",
+                "SELECT * FROM posts WHERE id = ? AND date = ? AND views > ?",
+                vec![(1, 10.into()), (2, 9.into())],
+            );
+        }
+
+        #[test]
+        fn range_with_pre_existing_equals_param() {
+            test_auto_parametrize_mysql(
+                "SELECT * FROM posts WHERE id = ? AND views > 10",
+                "SELECT * FROM posts WHERE id = ? AND views > ?",
+                vec![(1, 10.into())],
+            );
+        }
+
+        #[test]
+        fn equals_with_pre_existing_range_param() {
+            test_auto_parametrize_mysql(
+                "SELECT * FROM posts WHERE id = 10 AND views > ? AND date > 9",
+                "SELECT * FROM posts WHERE id = ? AND views > ? AND date > ?",
+                vec![(0, 10.into()), (2, 9.into())],
+            );
+        }
+
+        #[test]
+        fn supported_equals_with_unsupported_ranges() {
+            test_auto_parametrize_mysql(
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE id < 1) s ON users.id = s.id WHERE id = 1",
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE id < 1) s ON users.id = s.id WHERE id = ?",
+                vec![(0, 1.into())],
+            )
+        }
+
+        #[test]
+        fn supported_ranges_with_unsupported_equals() {
+            test_auto_parametrize_mysql(
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id < 1",
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id < ?",
+                vec![(0, 1.into())],
+            )
+        }
+
+        #[test]
+        fn supported_ranges_and_equals_with_unsupported_equals() {
+            test_auto_parametrize_mysql(
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id = 1 AND age > 21",
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE id = 1) s ON users.id = s.id WHERE id = ? AND age > ?",
+                vec![(0, 1.into()), (1, 21.into())],
+            )
+        }
+
+        #[test]
+        fn supported_ranges_and_equals_with_unsupported_ranges() {
+            test_auto_parametrize_mysql(
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE age > 50) s ON users.id = s.id WHERE id = 1 AND age > 21",
+                "SELECT id FROM users JOIN (SELECT id FROM users WHERE age > 50) s ON users.id = s.id WHERE id = ? AND age > ?",
+                vec![(0, 1.into()), (1, 21.into())],
+            )
+        }
     }
 }

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -10,7 +10,7 @@ use readyset_client_metrics::{
     recorded, DatabaseType, EventType, QueryExecutionEvent, QueryLogMode, ReadysetExecutionEvent,
     SqlQueryType,
 };
-use readyset_sql_passes::adapter_rewrites;
+use readyset_sql_passes::adapter_rewrites::{self, AdapterRewriteParams};
 use readyset_sql_passes::anonymize::anonymize_literals;
 use readyset_util::shutdown::ShutdownReceiver;
 use tokio::select;
@@ -63,10 +63,15 @@ impl QueryMetrics {
 
 impl QueryLogger {
     fn query_string(query: &SqlQuery) -> SharedString {
+        const ADAPTER_REWRITE_PARAMS: AdapterRewriteParams = AdapterRewriteParams {
+            server_supports_pagination: true,
+            server_supports_mixed_comparisons: true,
+        };
+
         SharedString::from(match query {
             SqlQuery::Select(stmt) => {
                 let mut stmt = stmt.clone();
-                if adapter_rewrites::process_query(&mut stmt, true).is_ok() {
+                if adapter_rewrites::process_query(&mut stmt, ADAPTER_REWRITE_PARAMS).is_ok() {
                     anonymize_literals(&mut stmt);
                     // FIXME(REA-2168): Use correct dialect.
                     stmt.display(nom_sql::Dialect::MySQL).to_string()


### PR DESCRIPTION
This commit:
1. Adds support to the adapter autoparameterization pass to
   autoparameterize range queries (queries that include inequality
   comparisons); and
2. Updates the view key construction logic to support multiple
   inequality comparisons that can't be transformed into a
   `ViewPlaceholder::Between`

In the case of queries with mixed comparisons (those with equality
comparisons and inequality comparisons), autoparameterization will
succeed, but the `detect_unsupported_placeholders` pass will fail during
the server's AST rewrites.

I considered augmenting `ViewPlaceholder::Between` to include
inclusivity bounds (i.e. an enum to specify whether a bound was
inclusive or exclusive), but ultimately, I decided it made sense to keep
it as close to Postgres's `BETWEEN` semantics as possible, which always
assumes inclusive bounds.

There is further work here to deduplicate range queries that all rely on
the same index (e.g. `SELECT * FROM t WHERE x > $1 AND x < $10` and
`SELECT * FROM t WHERE x >= $1 AND x <= $10` can both use the same
reader node, since the only difference between them is the inclusivity
of the bounds). I started on this work but it seemed a bit more
challenging and figured it made sense to tackle it in a separate commit
anyway.

Fixes: REA-809
Release-Note-Core: Added support for the autoparameterization of range
  queries
