### PR TITLE
build: Add git hash suffix to cloud binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4347,7 +4347,7 @@ dependencies = [
 
 [[package]]
 name = "readyset"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readyset"
-version = "1.0.0"
+version = "1.1.0"
 publish = false
 authors = ["ReadySet Technology, Inc. <info@readyset.io>"]
 edition = "2021"


### PR DESCRIPTION
The cloud binary will be named:
    readyset-[nightly|stable]-YYMMDD-<commit>

This allows identifying the type, date, and commit of a particular
release binary.

Also, sneaking in the increment to the deb package number for the next
release, because this still isn't automated yet...

Fixes: REA-4101
