### PR TITLE
nom-sql: Rework negative number parsing

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /tmp
 
 COPY rust-toolchain .
 
-RUN rustup default "$(cat public/rust-toolchain)"; rm rust-toolchain
+RUN rustup default "$(cat rust-toolchain)"; rm rust-toolchain
+RUN rustup component add clippy
+RUN rustup component add rustfmt
 
 RUN set -eux; \
     apt-get update; \

--- a/dataflow-expression/tests/mysql_oracle.rs
+++ b/dataflow-expression/tests/mysql_oracle.rs
@@ -93,6 +93,14 @@ async fn example_exprs_eval_same_as_mysql() {
     for expr in [
         "1 != 2",
         "1 != 1",
+        // TODO(ethan) These currently fail
+        // "-1 = -1",
+        // "-1.0 = -1.0",
+        // "-1 = -1.0",
+        "1 = --1",
+        "1 != -1",
+        "1.0 = --1.0",
+        "1.0 != -1.0",
         "4 + 5",
         "4 + '5'",
         "5 > 4",

--- a/dataflow-expression/tests/postgres_oracle.rs
+++ b/dataflow-expression/tests/postgres_oracle.rs
@@ -70,6 +70,12 @@ async fn example_exprs_eval_same_as_postgres() {
         "1 != 1",
         "4 + 5",
         "5 > 4",
+        // TODO(ethan) These currently fail
+        // "-1 = -1",
+        // "-1.0 = -1.0",
+        // "-1 = -1.0",
+        "1 != -1",
+        "1.0 != -1.0",
         "'a' like 'A'",
         "'a' ilike 'A'",
         "'a' not like 'a'",

--- a/nom-sql/src/update.rs
+++ b/nom-sql/src/update.rs
@@ -162,8 +162,7 @@ mod tests {
         use super::*;
         use crate::column::Column;
         use crate::table::Relation;
-        use crate::Expr::UnaryOp;
-        use crate::{BinaryOperator, Double, FunctionExpr, ItemPlaceholder, UnaryOperator};
+        use crate::{BinaryOperator, Double, FunctionExpr, ItemPlaceholder};
 
         #[test]
         fn updated_with_neg_float() {
@@ -185,13 +184,10 @@ mod tests {
                     table: Relation::from("stories"),
                     fields: vec![(
                         Column::from("hotness"),
-                        UnaryOp {
-                            op: UnaryOperator::Neg,
-                            rhs: Box::new(Expr::Literal(Literal::Double(Double {
-                                value: 19216.5479744,
-                                precision: 7,
-                            })))
-                        },
+                        Expr::Literal(Literal::Double(Double {
+                            value: -19216.5479744,
+                            precision: 7,
+                        }))
                     )],
                     where_clause: expected_where_cond,
                 }
@@ -261,8 +257,7 @@ mod tests {
         use super::*;
         use crate::column::Column;
         use crate::table::Relation;
-        use crate::Expr::UnaryOp;
-        use crate::{BinaryOperator, Double, UnaryOperator};
+        use crate::{BinaryOperator, Double};
 
         #[test]
         fn updated_with_neg_float() {
@@ -284,13 +279,10 @@ mod tests {
                     table: Relation::from("stories"),
                     fields: vec![(
                         Column::from("hotness"),
-                        UnaryOp {
-                            op: UnaryOperator::Neg,
-                            rhs: Box::new(Expr::Literal(Literal::Double(Double {
-                                value: 19216.5479744,
-                                precision: 7,
-                            })))
-                        },
+                        Expr::Literal(Literal::Double(Double {
+                            value: -19216.5479744,
+                            precision: 7,
+                        }))
                     ),],
                     where_clause: expected_where_cond,
                 }


### PR DESCRIPTION
Previously, we parsed negative numbers to be a UnaryOperator::Neg
applied to a Literal. This was incompatible with our
autoparameterization AST rewrite pass, which only replaced *Literals*
with placeholders. To add support for the autoparameterization of
negative literals, this commit updates the way we parse prefix negation
in our expression pratt parser such that a negative sign applied to an
integer, a float, or a double always produces a literal instead of a
UnaryOperator.

I considered just updating the autoparameterization rewrite pass to
look for and replace `UnaryOperators::Neg`s applied to literals, but
this would have meant having to evaluate the negative sign in our
rewrite pass, which felt less correct than simplifying our
representation of negative numbers in the AST.

While doing this work, I discovered that we do not correctly evaluate
`-1 = -1` for both MySQL and Postgres. This will be addressed in a
follow-up commit.

Release-Note-Core: Added support for the autoparamterization of negative
  numbers
