### PR TITLE
expr: Fix operator precedence

### DIFF
--- a/dataflow-expression/tests/mysql_oracle.rs
+++ b/dataflow-expression/tests/mysql_oracle.rs
@@ -93,10 +93,9 @@ async fn example_exprs_eval_same_as_mysql() {
     for expr in [
         "1 != 2",
         "1 != 1",
-        // TODO(ethan) These currently fail
-        // "-1 = -1",
-        // "-1.0 = -1.0",
-        // "-1 = -1.0",
+        "-1 = -1",
+        "-1.0 = -1.0",
+        "-1 = -1.0",
         "1 = --1",
         "1 != -1",
         "1.0 = --1.0",

--- a/dataflow-expression/tests/postgres_oracle.rs
+++ b/dataflow-expression/tests/postgres_oracle.rs
@@ -70,10 +70,9 @@ async fn example_exprs_eval_same_as_postgres() {
         "1 != 1",
         "4 + 5",
         "5 > 4",
-        // TODO(ethan) These currently fail
-        // "-1 = -1",
-        // "-1.0 = -1.0",
-        // "-1 = -1.0",
+        "-1 = -1",
+        "-1.0 = -1.0",
+        "-1 = -1.0",
         "1 != -1",
         "1.0 != -1.0",
         "'a' like 'A'",

--- a/nom-sql/src/expression.rs
+++ b/nom-sql/src/expression.rs
@@ -1092,32 +1092,11 @@ where
         // separate precedence/associativity table) per SQL dialect that we support but for now
         // this seems to be good enough.
         Ok(match input {
-            Infix(And) => Affix::Infix(Precedence(4), Associativity::Right),
-            Infix(Or) => Affix::Infix(Precedence(2), Associativity::Right),
-            Infix(Like) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(NotLike) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(ILike) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(NotILike) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(Equal) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(NotEqual) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(Greater) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(GreaterOrEqual) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(Less) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(LessOrEqual) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(Is) => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(IsNot) => Affix::Infix(Precedence(7), Associativity::Right),
-            In | NotIn => Affix::Infix(Precedence(7), Associativity::Right),
-            Infix(Add) => Affix::Infix(Precedence(11), Associativity::Right),
-            Infix(Subtract) => Affix::Infix(Precedence(11), Associativity::Right),
+            Prefix(Neg) => Affix::Prefix(Precedence(14)),
             Infix(Multiply) => Affix::Infix(Precedence(12), Associativity::Right),
             Infix(Divide) => Affix::Infix(Precedence(12), Associativity::Right),
-            Prefix(Not) => Affix::Prefix(Precedence(6)),
-            Prefix(Neg) => Affix::Prefix(Precedence(5)),
-            Primary(_) => Affix::Nilfix,
-            Group(_) => Affix::Nilfix,
-            PgsqlCast(..) => Affix::Nilfix,
-            OpSuffix(..) => Affix::Nilfix,
-
+            Infix(Add) => Affix::Infix(Precedence(11), Associativity::Right),
+            Infix(Subtract) => Affix::Infix(Precedence(11), Associativity::Right),
             // All JSON operators have the same precedence.
             //
             // Not positive whether this 8 puts all other operators at the correct relative
@@ -1134,6 +1113,27 @@ where
             Infix(AtArrowRight) => Affix::Infix(Precedence(8), Associativity::Left),
             Infix(AtArrowLeft) => Affix::Infix(Precedence(8), Associativity::Left),
             Infix(HashSubtract) => Affix::Infix(Precedence(8), Associativity::Left),
+
+            Infix(Like) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(NotLike) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(ILike) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(NotILike) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(Equal) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(NotEqual) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(Greater) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(GreaterOrEqual) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(Less) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(LessOrEqual) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(Is) => Affix::Infix(Precedence(7), Associativity::Right),
+            Infix(IsNot) => Affix::Infix(Precedence(7), Associativity::Right),
+            In | NotIn => Affix::Infix(Precedence(7), Associativity::Right),
+            Prefix(Not) => Affix::Prefix(Precedence(5)),
+            Infix(And) => Affix::Infix(Precedence(4), Associativity::Right),
+            Infix(Or) => Affix::Infix(Precedence(2), Associativity::Right),
+            Primary(_) => Affix::Nilfix,
+            Group(_) => Affix::Nilfix,
+            PgsqlCast(..) => Affix::Nilfix,
+            OpSuffix(..) => Affix::Nilfix,
         })
     }
 


### PR DESCRIPTION
Our operator precedence designations in our expression pratt parser were
incorrect, leading to the incorrect evaluation of certain expressions.
(For example, the expression `-1 = -1` was being interpreted as
`-(1 = -1)`.) This commit updates the operator precedence to match the
operator precedence as documented for MySQL[0] and adds some more oracle
tests to exercise the updated operator precedence rules.

Release-Note-Core: Fixed an issue where Readyset evaluated certain
  expressions incorrectly
