### PR TITLE
metrics: Add cache name to server view hit/miss metrics

### DIFF
--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -37,13 +37,6 @@ pub const QUERY_LOG_TOTAL_KEYS_READ: &str = "readyset_query_log_total_keys_read"
 /// | query | The query text being executed. |
 pub const QUERY_LOG_TOTAL_CACHE_MISSES: &str = "readyset_query_log_total_cache_misses";
 
-/// Counter: The number of queries which encountered at least one cache miss.
-///
-/// | Tag | Description |
-/// | --- | ----------- |
-/// | query | The query text being executed. |
-pub const QUERY_LOG_QUERY_CACHE_MISSED: &str = "readyset_query_log_query_cache_missed";
-
 /// Counter: The number of successful queries (dry runs/real) processed by the migration handler.
 pub const MIGRATION_HANDLER_SUCCESSES: &str = "readyset_migration_handler_successes";
 

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -215,9 +215,17 @@ pub mod recorded {
     pub const EVICTION_FREED_MEMORY: &str = "readyset_eviction_freed_memory";
 
     /// Counter: The number of times a query was served entirely from reader cache.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const SERVER_VIEW_QUERY_HIT: &str = "readyset_server.view_query_result_hit";
 
     /// Counter: The number of times a query required at least a partial replay.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const SERVER_VIEW_QUERY_MISS: &str = "readyset_server.view_query_result_miss";
 
     /// Histogram: The amount of time in microseconds spent waiting for an upquery during a read

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -122,11 +122,13 @@ impl DomainMetrics {
     }
 
     pub(super) fn inc_replay_misses(&mut self, cache_name: &Relation, n: usize) {
-        counter!(
-            recorded::DOMAIN_REPLAY_MISSES,
-            n as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_REPLAY_MISSES,
+                n as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn inc_packets_sent(&mut self, packet: &Packet) {

--- a/readyset-server/src/integration_serial.rs
+++ b/readyset-server/src/integration_serial.rs
@@ -139,7 +139,7 @@ async fn it_works_basic_impl() {
     );
     assert_eq!(
         get_metric!(metrics_dump, recorded::SERVER_VIEW_QUERY_HIT),
-        Some(DumpedMetricValue::Counter(0.0))
+        None,
     );
 
     // update value again

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -183,10 +183,6 @@ impl QueryLogger {
                             counter!(recorded::QUERY_LOG_TOTAL_KEYS_READ, num_keys, &labels);
                             counter!(recorded::QUERY_LOG_TOTAL_CACHE_MISSES, cache_misses, &labels);
 
-                            if cache_misses != 0 {
-                                counter!(recorded::QUERY_LOG_QUERY_CACHE_MISSED, cache_misses, &labels);
-                            }
-
                             labels.push(("database_type", SharedString::from(DatabaseType::ReadySet)));
 
                             if mode.is_verbose() {


### PR DESCRIPTION
This commit adds the cache name as a label to the counters we use to
track whether a query against a cache was a hit or a miss. Though we are
looking to keep label cardinality low, these metrics currently have no
other labels, and since they are counters, they don't have a "quantile"
label.

Release-Note-Core: Improved the metrics we use to track cache hits and
  misses
