### PR TITLE
metrics: Configure Prometheus summary quantiles

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -8,6 +8,15 @@ pub use metrics::Key;
 use metrics_util::Histogram;
 use serde::{Deserialize, Serialize};
 
+/// The quantiles that will be included in all of the histograms we output.
+///
+/// The default quantiles included by the Prometheus recorded are 0.0, 0.5, 0.9, 0.95, 0.99, and
+/// 0.999. Realistically, we won't need such granualar information, and including 7 quantiles with
+/// every histogram means that each histogram outputs 7x the number of time series that would
+/// otherwise be output given the other labels on the metric. Limiting the number of quantiles to 3
+/// helps limit the number of time series produced by Readyset deployments.
+pub const HISTOGRAM_QUANTILES: [f64; 3] = [0.5, 0.9, 0.99];
+
 /// A client for accessing readyset metrics for a deployment.
 pub mod client;
 

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -193,6 +193,7 @@ fn main() -> anyhow::Result<()> {
         recs.push(MetricsRecorder::Prometheus(
             PrometheusBuilder::new()
                 .add_global_label("deployment", &opts.deployment)
+                .set_quantiles(&readyset_client::metrics::HISTOGRAM_QUANTILES)?
                 .build_recorder(),
         ));
     }

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -750,6 +750,7 @@ where
             let recorder = PrometheusBuilder::new()
                 .add_global_label("upstream_db_type", database_label)
                 .add_global_label("deployment", &options.deployment)
+                .set_quantiles(&readyset_client::metrics::HISTOGRAM_QUANTILES)?
                 .build_recorder();
 
             let handle = recorder.handle();


### PR DESCRIPTION
By default, metrics-rs records and emits time series for histogram with
the following quantiles: 0.0, 0.5, 0.9, 0.95, 0.99, 0.999, 1. This
produces at minimuim 7 time series for every histogram metric we emit.
This gets extremely expensive if a histogram has other labels too. This
commit limits the quantiles recorded by metrics-rs to only 0.5, 0.9,
and 0.99 to reduce the number of time series being produced by
Readyset.

Release-Note-Core: Reduced the cardinality of our histogram metrics by
  choosing only a few quantiles to track
