### PR TITLE
metrics: Remove unnecessary counters

### DIFF
--- a/build/docker/grafana/dashboards/query_specific.json
+++ b/build/docker/grafana/dashboards/query_specific.json
@@ -93,7 +93,7 @@
             "targets": [
                 {
                     "exemplar": true,
-                    "expr": "readyset_query_log_execution_count{deployment=\"$deployment\",query_id=\"${queryfilter:raw}\"}",
+                    "expr": "readyset_query_log_execution_time_count{deployment=\"$deployment\",query_id=\"${queryfilter:raw}\"}",
                     "interval": "",
                     "legendFormat": "{{query}}",
                     "queryType": "randomWalk",

--- a/readyset-adapter/src/metrics_handle.rs
+++ b/readyset-adapter/src/metrics_handle.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use metrics::SharedString;
 use metrics_exporter_prometheus::formatting::{sanitize_label_key, sanitize_label_value};
 use metrics_exporter_prometheus::{Distribution, PrometheusHandle};
-use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_COUNT;
+use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_TIME;
 use readyset_client_metrics::DatabaseType;
 
 #[derive(Debug, Default, Clone)]
@@ -54,15 +54,14 @@ impl MetricsHandle {
 
     /// Clone a snapshot of all QUERY_LOG_EXECUTION_COUNT counters.
     pub fn snapshot_counters(&mut self, database_type: DatabaseType) {
-        fn filter(key: &str) -> bool {
-            key == QUERY_LOG_EXECUTION_COUNT
-        }
+        let count_key = format!("{QUERY_LOG_EXECUTION_TIME}_count");
+        let filter = |key: &str| -> bool { key == count_key };
 
         let db_type = SharedString::from(database_type).to_string();
 
         let counters = self
             .counters(Some(filter))
-            .get(QUERY_LOG_EXECUTION_COUNT)
+            .get(&count_key)
             .cloned()
             .map(|h| {
                 h.into_iter()

--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -11,7 +11,6 @@
 ///
 /// [`DatabaseType`]: crate::DatabaseType
 pub const QUERY_LOG_EXECUTION_TIME: &str = "readyset_query_log_execution_time";
-pub const QUERY_LOG_EXECUTION_COUNT: &str = "readyset_query_log_execution_count";
 
 /// Histogram: The time in seconds that the database spent executing a
 /// query.

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -45,11 +45,6 @@ pub mod recorded {
     /// the domain following handling each Message and Input packet.
     pub const DOMAIN_FORWARD_TIME: &str = "readyset_forward_time_us";
 
-    /// Counter: The total time the domain spends handling and forwarding
-    /// a Message or Input packet. Recorded at the domain following handling
-    /// each Message and Input packet.
-    pub const DOMAIN_TOTAL_FORWARD_TIME: &str = "readyset_total_forward_time_us";
-
     /// Histogram: The time in microseconds that a domain spends
     /// handling a ReplayPiece packet. Recorded at the domain following
     /// ReplayPiece packet handling.
@@ -58,15 +53,6 @@ pub mod recorded {
     /// | --- | ----------- |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_TIME: &str = "readyset_domain.handle_replay_time";
-
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a ReplayPiece packet. Recorded at the domain following
-    /// ReplayPiece packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_TOTAL_REPLAY_TIME: &str = "readyset_domain.total_handle_replay_time";
 
     /// Histogram: The time in microseconds spent handling a reader replay
     /// request. Recorded at the domain following RequestReaderReplay
@@ -79,17 +65,6 @@ pub mod recorded {
     pub const DOMAIN_READER_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_replay_request_time_us";
 
-    /// Counter: The total time in microseconds spent handling a reader replay
-    /// request. Recorded at the domain following RequestReaderReplay
-    /// packet handling.
-    ///
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME: &str =
-        "readyset_domain.reader_total_replay_request_time_us";
-
     /// Histogram: The time in microseconds that a domain spends
     /// handling a RequestPartialReplay packet. Recorded at the domain
     /// following RequestPartialReplay packet handling.
@@ -99,39 +74,17 @@ pub mod recorded {
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_SEED_REPLAY_TIME: &str = "readyset_domain.seed_replay_time_us";
 
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a RequestPartialReplay packet. Recorded at the domain
-    /// following RequestPartialReplay packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_TOTAL_SEED_REPLAY_TIME: &str = "readyset_domain.total_seed_replay_time_us";
-
     /// Histogram: The time in microseconds that a domain spawning a state
     /// chunker at a node during the processing of a StartReplay packet.
     /// Recorded at the domain when the state chunker thread is finished
     /// executing.
     pub const DOMAIN_CHUNKED_REPLAY_TIME: &str = "readyset_domain.chunked_replay_time_us";
 
-    /// Counter: The total time in microseconds that a domain spawning a state
-    /// chunker at a node during the processing of a StartReplay packet.
-    /// Recorded at the domain when the state chunker thread is finished
-    /// executing.
-    pub const DOMAIN_TOTAL_CHUNKED_REPLAY_TIME: &str =
-        "readyset_domain.total_chunked_replay_time_us";
-
     /// Histogram: The time in microseconds that a domain spends
     /// handling a StartReplay packet. Recorded at the domain
     /// following StartReplay packet handling.
     pub const DOMAIN_CHUNKED_REPLAY_START_TIME: &str =
         "readyset_domain.chunked_replay_start_time_us";
-
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a StartReplay packet. Recorded at the domain
-    /// following StartReplay packet handling.
-    pub const DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME: &str =
-        "readyset_domain.total_chunked_replay_start_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling a Finish packet for a replay. Recorded at the domain
@@ -141,15 +94,6 @@ pub mod recorded {
     /// | --- | ----------- |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_FINISH_REPLAY_TIME: &str = "readyset_domain.finish_replay_time_us";
-
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a Finish packet for a replay. Recorded at the domain
-    /// following Finish packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_TOTAL_FINISH_REPLAY_TIME: &str = "readyset_domain.total_finish_replay_time_us";
 
     /// Histogram: The amount of time spent handling an eviction
     /// request.
@@ -316,13 +260,6 @@ pub mod recorded {
     /// Gauge: Indicates whether a server is the leader. Set to 1 when the
     /// server is leader, 0 for follower.
     pub const CONTROLLER_IS_LEADER: &str = "readyset_controller.is_leader";
-
-    /// Counter: The total amount of time spent servicing controller RPCs.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | path | The http path associated with the rpc request. |
-    pub const CONTROLLER_RPC_OVERALL_TIME: &str = "readyset_controller.rpc_overall_time";
 
     /// Histogram: The distribution of time spent servicing controller RPCs
     /// for each request.

--- a/readyset-clustertest/src/utils.rs
+++ b/readyset-clustertest/src/utils.rs
@@ -237,11 +237,13 @@ where
 }
 
 async fn get_num_view_queries(metrics: &mut MetricsClient) -> u32 {
+    let query_log_execution_count = format!("{}_count", recorded::QUERY_LOG_EXECUTION_TIME);
+
     match metrics.get_metrics().await {
         Ok(metrics) => metrics
             .iter()
             .map(
-                |d| match get_metric!(d.metrics, recorded::QUERY_LOG_EXECUTION_COUNT) {
+                |d| match get_metric!(d.metrics, &query_log_execution_count) {
                     Some(DumpedMetricValue::Counter(n)) => n as u32,
                     _ => 0,
                 },

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -36,11 +36,6 @@ impl DomainMetrics {
     }
 
     pub(super) fn rec_chunked_replay_start_time(&mut self, time: Duration) {
-        counter!(
-            recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
-            time.as_micros() as u64,
-        );
-
         histogram!(
             recorded::DOMAIN_CHUNKED_REPLAY_START_TIME,
             time.as_micros() as f64,
@@ -49,12 +44,6 @@ impl DomainMetrics {
 
     pub(super) fn rec_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_TOTAL_REPLAY_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_REPLAY_TIME,
                 time.as_micros() as f64,
@@ -65,12 +54,6 @@ impl DomainMetrics {
 
     pub(super) fn rec_seed_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_SEED_REPLAY_TIME,
                 time.as_micros() as f64,
@@ -81,12 +64,6 @@ impl DomainMetrics {
 
     pub(super) fn rec_finish_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_FINISH_REPLAY_TIME,
                 time.as_micros() as f64,
@@ -96,23 +73,15 @@ impl DomainMetrics {
     }
 
     pub(super) fn rec_forward_time_input(&mut self, time: Duration) {
-        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64, "packet_type" => "input");
         histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64, "packet_type" => "input");
     }
 
     pub(super) fn rec_forward_time_message(&mut self, time: Duration) {
-        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64, "packet_type" => "message");
         histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64, "packet_type" => "message");
     }
 
     pub(super) fn rec_reader_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
                 time.as_micros() as f64,

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -24,7 +24,7 @@ use futures_util::stream::StreamExt;
 use futures_util::TryFutureExt;
 pub use internal::{DomainIndex, ReplicaAddress};
 use merging_interval_tree::IntervalTreeSet;
-use metrics::{counter, histogram};
+use metrics::histogram;
 use nom_sql::Relation;
 use petgraph::graph::NodeIndex;
 use readyset_alloc::StdThreadBuildWrapper;
@@ -2110,10 +2110,6 @@ impl Domain {
                         );
 
                         let time = start.elapsed();
-                        counter!(
-                            recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_TIME,
-                            time.as_micros() as u64
-                        );
                         histogram!(
                             recorded::DOMAIN_CHUNKED_REPLAY_TIME,
                             time.as_micros() as f64

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -11,7 +11,7 @@ use dataflow::prelude::ChannelCoordinator;
 use failpoint_macros::set_failpoint;
 use futures::future::Either;
 use hyper::http::{Method, StatusCode};
-use metrics::{counter, gauge, histogram};
+use metrics::{gauge, histogram};
 use nom_sql::Relation;
 use readyset_client::consensus::{
     Authority, AuthorityControl, AuthorityWorkerHeartbeatResponse, CacheDDLRequest,
@@ -1362,12 +1362,6 @@ async fn handle_controller_request(
                 .expect("Bincode serialization of ReadySetError should not fail"))),
         }
     };
-
-    counter!(
-        recorded::CONTROLLER_RPC_OVERALL_TIME,
-        request_start.elapsed().as_micros() as u64,
-        "path" => path.clone()
-    );
 
     histogram!(
         recorded::CONTROLLER_RPC_REQUEST_TIME,

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -200,7 +200,6 @@ impl QueryLogger {
                             }
 
                             histogram!(recorded::QUERY_LOG_EXECUTION_TIME, duration.as_micros() as f64, &labels);
-                            counter!(recorded::QUERY_LOG_EXECUTION_COUNT, 1, &labels);
                         }
                         Some(ReadysetExecutionEvent::Other { duration }) => {
                             let mut labels =
@@ -215,7 +214,6 @@ impl QueryLogger {
                             }
 
                             histogram!(recorded::QUERY_LOG_EXECUTION_TIME, duration.as_micros() as f64, &labels);
-                            counter!(recorded::QUERY_LOG_EXECUTION_COUNT, 1, &labels);
                         }
                         None => (),
                     }
@@ -233,7 +231,6 @@ impl QueryLogger {
                         }
 
                         histogram!(recorded::QUERY_LOG_EXECUTION_TIME, duration.as_micros() as f64, &labels);
-                        counter!(recorded::QUERY_LOG_EXECUTION_COUNT, 1, &labels);
                     }
                 }
             }


### PR DESCRIPTION
Each Prometheus "summary" metric (i.e. the metric type we use for
quantiles) includes time series for the sum and count of observed
values. In many cases, we were using separate counters to count the
number or sum of observations for a histogram metric. This commit
removes these unnecessary counters to reduce the number of overall time
series being emitted by Readyset.

