### PR TITLE
metrics: Add caches misses and keys read to verbose metrics

### DIFF
--- a/readyset-adapter/src/metrics_handle.rs
+++ b/readyset-adapter/src/metrics_handle.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use metrics::SharedString;
 use metrics_exporter_prometheus::formatting::{sanitize_label_key, sanitize_label_value};
 use metrics_exporter_prometheus::{Distribution, PrometheusHandle};
-use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_COUNT;
+use readyset_client_metrics::recorded::QUERY_LOG_EXECUTION_TIME;
 use readyset_client_metrics::DatabaseType;
 
 #[derive(Debug, Default, Clone)]
@@ -54,15 +54,14 @@ impl MetricsHandle {
 
     /// Clone a snapshot of all QUERY_LOG_EXECUTION_COUNT counters.
     pub fn snapshot_counters(&mut self, database_type: DatabaseType) {
-        fn filter(key: &str) -> bool {
-            key == QUERY_LOG_EXECUTION_COUNT
-        }
+        let count_key = format!("{QUERY_LOG_EXECUTION_TIME}_count");
+        let filter = |key: &str| -> bool { key == count_key };
 
         let db_type = SharedString::from(database_type).to_string();
 
         let counters = self
             .counters(Some(filter))
-            .get(QUERY_LOG_EXECUTION_COUNT)
+            .get(&count_key)
             .cloned()
             .map(|h| {
                 h.into_iter()

--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -37,13 +37,6 @@ pub const QUERY_LOG_TOTAL_KEYS_READ: &str = "readyset_query_log_total_keys_read"
 /// | query | The query text being executed. |
 pub const QUERY_LOG_TOTAL_CACHE_MISSES: &str = "readyset_query_log_total_cache_misses";
 
-/// Counter: The number of queries which encountered at least one cache miss.
-///
-/// | Tag | Description |
-/// | --- | ----------- |
-/// | query | The query text being executed. |
-pub const QUERY_LOG_QUERY_CACHE_MISSED: &str = "readyset_query_log_query_cache_missed";
-
 /// Counter: The number of successful queries (dry runs/real) processed by the migration handler.
 pub const MIGRATION_HANDLER_SUCCESSES: &str = "readyset_migration_handler_successes";
 

--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -10,7 +10,6 @@
 ///
 /// [`DatabaseType`]: crate::DatabaseType
 pub const QUERY_LOG_EXECUTION_TIME: &str = "readyset_query_log_execution_time";
-pub const QUERY_LOG_EXECUTION_COUNT: &str = "readyset_query_log_execution_count";
 
 /// Histogram: The time in seconds that the database spent executing a
 /// query.

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -36,11 +36,6 @@ pub mod recorded {
     /// the domain following handling each Message and Input packet.
     pub const DOMAIN_FORWARD_TIME: &str = "readyset_forward_time_us";
 
-    /// Counter: The total time the domain spends handling and forwarding
-    /// a Message or Input packet. Recorded at the domain following handling
-    /// each Message and Input packet.
-    pub const DOMAIN_TOTAL_FORWARD_TIME: &str = "readyset_total_forward_time_us";
-
     /// Histogram: The time in microseconds that a domain spends
     /// handling a ReplayPiece packet. Recorded at the domain following
     /// ReplayPiece packet handling.
@@ -49,15 +44,6 @@ pub mod recorded {
     /// | --- | ----------- |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_REPLAY_TIME: &str = "readyset_domain.handle_replay_time";
-
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a ReplayPiece packet. Recorded at the domain following
-    /// ReplayPiece packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_TOTAL_REPLAY_TIME: &str = "readyset_domain.total_handle_replay_time";
 
     /// Histogram: The time in microseconds spent handling a reader replay
     /// request. Recorded at the domain following RequestReaderReplay
@@ -70,17 +56,6 @@ pub mod recorded {
     pub const DOMAIN_READER_REPLAY_REQUEST_TIME: &str =
         "readyset_domain.reader_replay_request_time_us";
 
-    /// Counter: The total time in microseconds spent handling a reader replay
-    /// request. Recorded at the domain following RequestReaderReplay
-    /// packet handling.
-    ///
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME: &str =
-        "readyset_domain.reader_total_replay_request_time_us";
-
     /// Histogram: The time in microseconds that a domain spends
     /// handling a RequestPartialReplay packet. Recorded at the domain
     /// following RequestPartialReplay packet handling.
@@ -90,39 +65,17 @@ pub mod recorded {
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_SEED_REPLAY_TIME: &str = "readyset_domain.seed_replay_time_us";
 
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a RequestPartialReplay packet. Recorded at the domain
-    /// following RequestPartialReplay packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_TOTAL_SEED_REPLAY_TIME: &str = "readyset_domain.total_seed_replay_time_us";
-
     /// Histogram: The time in microseconds that a domain spawning a state
     /// chunker at a node during the processing of a StartReplay packet.
     /// Recorded at the domain when the state chunker thread is finished
     /// executing.
     pub const DOMAIN_CHUNKED_REPLAY_TIME: &str = "readyset_domain.chunked_replay_time_us";
 
-    /// Counter: The total time in microseconds that a domain spawning a state
-    /// chunker at a node during the processing of a StartReplay packet.
-    /// Recorded at the domain when the state chunker thread is finished
-    /// executing.
-    pub const DOMAIN_TOTAL_CHUNKED_REPLAY_TIME: &str =
-        "readyset_domain.total_chunked_replay_time_us";
-
     /// Histogram: The time in microseconds that a domain spends
     /// handling a StartReplay packet. Recorded at the domain
     /// following StartReplay packet handling.
     pub const DOMAIN_CHUNKED_REPLAY_START_TIME: &str =
         "readyset_domain.chunked_replay_start_time_us";
-
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a StartReplay packet. Recorded at the domain
-    /// following StartReplay packet handling.
-    pub const DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME: &str =
-        "readyset_domain.total_chunked_replay_start_time_us";
 
     /// Histogram: The time in microseconds that a domain spends
     /// handling a Finish packet for a replay. Recorded at the domain
@@ -132,15 +85,6 @@ pub mod recorded {
     /// | --- | ----------- |
     /// | cache_name | The name of the cache associated with this replay.
     pub const DOMAIN_FINISH_REPLAY_TIME: &str = "readyset_domain.finish_replay_time_us";
-
-    /// Counter: The total time in microseconds that a domain spends
-    /// handling a Finish packet for a replay. Recorded at the domain
-    /// following Finish packet handling.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | cache_name | The name of the cache associated with this replay.
-    pub const DOMAIN_TOTAL_FINISH_REPLAY_TIME: &str = "readyset_domain.total_finish_replay_time_us";
 
     /// Histogram: The amount of time spent handling an eviction
     /// request.
@@ -317,13 +261,6 @@ pub mod recorded {
     /// Gauge: Indicates whether a server is the leader. Set to 1 when the
     /// server is leader, 0 for follower.
     pub const CONTROLLER_IS_LEADER: &str = "readyset_controller.is_leader";
-
-    /// Counter: The total amount of time spent servicing controller RPCs.
-    ///
-    /// | Tag | Description |
-    /// | --- | ----------- |
-    /// | path | The http path associated with the rpc request. |
-    pub const CONTROLLER_RPC_OVERALL_TIME: &str = "readyset_controller.rpc_overall_time";
 
     /// Histogram: The distribution of time spent servicing controller RPCs
     /// for each request.

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -215,9 +215,17 @@ pub mod recorded {
     pub const EVICTION_FREED_MEMORY: &str = "readyset_eviction_freed_memory";
 
     /// Counter: The number of times a query was served entirely from reader cache.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const SERVER_VIEW_QUERY_HIT: &str = "readyset_server.view_query_result_hit";
 
     /// Counter: The number of times a query required at least a partial replay.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | cache_name | The name of the cache associated with this replay.
     pub const SERVER_VIEW_QUERY_MISS: &str = "readyset_server.view_query_result_miss";
 
     /// Histogram: The amount of time in microseconds spent waiting for an upquery during a read

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -36,11 +36,6 @@ impl DomainMetrics {
     }
 
     pub(super) fn rec_chunked_replay_start_time(&mut self, time: Duration) {
-        counter!(
-            recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_START_TIME,
-            time.as_micros() as u64,
-        );
-
         histogram!(
             recorded::DOMAIN_CHUNKED_REPLAY_START_TIME,
             time.as_micros() as f64,
@@ -49,12 +44,6 @@ impl DomainMetrics {
 
     pub(super) fn rec_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_TOTAL_REPLAY_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_REPLAY_TIME,
                 time.as_micros() as f64,
@@ -65,12 +54,6 @@ impl DomainMetrics {
 
     pub(super) fn rec_seed_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_TOTAL_SEED_REPLAY_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_SEED_REPLAY_TIME,
                 time.as_micros() as f64,
@@ -81,12 +64,6 @@ impl DomainMetrics {
 
     pub(super) fn rec_finish_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_TOTAL_FINISH_REPLAY_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_FINISH_REPLAY_TIME,
                 time.as_micros() as f64,
@@ -96,23 +73,15 @@ impl DomainMetrics {
     }
 
     pub(super) fn rec_forward_time_input(&mut self, time: Duration) {
-        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64, "packet_type" => "input");
         histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64, "packet_type" => "input");
     }
 
     pub(super) fn rec_forward_time_message(&mut self, time: Duration) {
-        counter!(recorded::DOMAIN_TOTAL_FORWARD_TIME, time.as_micros() as u64, "packet_type" => "message");
         histogram!(recorded::DOMAIN_FORWARD_TIME, time.as_micros() as f64, "packet_type" => "message");
     }
 
     pub(super) fn rec_reader_replay_time(&mut self, cache_name: &Relation, time: Duration) {
         if self.verbose {
-            counter!(
-                recorded::DOMAIN_READER_TOTAL_REPLAY_REQUEST_TIME,
-                time.as_micros() as u64,
-                "cache_name" => cache_name_to_string(cache_name)
-            );
-
             histogram!(
                 recorded::DOMAIN_READER_REPLAY_REQUEST_TIME,
                 time.as_micros() as f64,

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -122,11 +122,13 @@ impl DomainMetrics {
     }
 
     pub(super) fn inc_replay_misses(&mut self, cache_name: &Relation, n: usize) {
-        counter!(
-            recorded::DOMAIN_REPLAY_MISSES,
-            n as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_REPLAY_MISSES,
+                n as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn inc_packets_sent(&mut self, packet: &Packet) {

--- a/readyset-dataflow/src/domain/mod.rs
+++ b/readyset-dataflow/src/domain/mod.rs
@@ -24,7 +24,7 @@ use futures_util::stream::StreamExt;
 use futures_util::TryFutureExt;
 pub use internal::{DomainIndex, ReplicaAddress};
 use merging_interval_tree::IntervalTreeSet;
-use metrics::{counter, histogram};
+use metrics::histogram;
 use nom_sql::Relation;
 use petgraph::graph::NodeIndex;
 use readyset_alloc::StdThreadBuildWrapper;
@@ -2110,10 +2110,6 @@ impl Domain {
                         );
 
                         let time = start.elapsed();
-                        counter!(
-                            recorded::DOMAIN_TOTAL_CHUNKED_REPLAY_TIME,
-                            time.as_micros() as u64
-                        );
                         histogram!(
                             recorded::DOMAIN_CHUNKED_REPLAY_TIME,
                             time.as_micros() as f64

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -1366,11 +1366,26 @@ async fn handle_controller_request(
     histogram!(
         recorded::CONTROLLER_RPC_REQUEST_TIME,
         request_start.elapsed().as_micros() as f64,
-        "path" => path
+        "path" => coalesce_path(path),
     );
 
     if reply_tx.send(ret).is_err() {
         warn!("client hung up");
+    }
+}
+
+fn coalesce_path(path: String) -> String {
+    match path.as_str() {
+        "/extend_recipe"
+        | "/views"
+        | "/verbose_views"
+        | "/view_statuses"
+        | "/view_builder"
+        | "/min_persisted_replication_offset"
+        | "/replication_offsets"
+        | "/set_schema_replication_offset"
+        | "/dry_run" => path,
+        _ => "other".into(),
     }
 }
 

--- a/readyset-server/src/controller/mod.rs
+++ b/readyset-server/src/controller/mod.rs
@@ -11,7 +11,7 @@ use dataflow::prelude::ChannelCoordinator;
 use failpoint_macros::set_failpoint;
 use futures::future::Either;
 use hyper::http::{Method, StatusCode};
-use metrics::{counter, gauge, histogram};
+use metrics::{gauge, histogram};
 use nom_sql::Relation;
 use readyset_client::consensus::{
     Authority, AuthorityControl, AuthorityWorkerHeartbeatResponse, CacheDDLRequest,
@@ -1362,12 +1362,6 @@ async fn handle_controller_request(
                 .expect("Bincode serialization of ReadySetError should not fail"))),
         }
     };
-
-    counter!(
-        recorded::CONTROLLER_RPC_OVERALL_TIME,
-        request_start.elapsed().as_micros() as u64,
-        "path" => path.clone()
-    );
 
     histogram!(
         recorded::CONTROLLER_RPC_REQUEST_TIME,

--- a/readyset-server/src/main.rs
+++ b/readyset-server/src/main.rs
@@ -193,6 +193,7 @@ fn main() -> anyhow::Result<()> {
         recs.push(MetricsRecorder::Prometheus(
             PrometheusBuilder::new()
                 .add_global_label("deployment", &opts.deployment)
+                .set_quantiles(&[0.5, 0.9, 0.99])?
                 .build_recorder(),
         ));
     }

--- a/readyset-server/src/worker/readers.rs
+++ b/readyset-server/src/worker/readers.rs
@@ -16,6 +16,7 @@ use dataflow::{
 use failpoint_macros::set_failpoint;
 use futures::pin_mut;
 use futures_util::future::TryFutureExt;
+use metrics::{counter, histogram};
 use pin_project::pin_project;
 use readyset_client::consistency::Timestamp;
 #[cfg(feature = "failure_injection")]
@@ -133,8 +134,6 @@ pub struct ReadRequestHandler {
     global_readers: Readers,
     readers_cache: ReaderMap,
     wait: tokio::sync::mpsc::UnboundedSender<(BlockingRead, Ack)>,
-    miss_ctr: metrics::Counter,
-    hit_ctr: metrics::Counter,
     upquery_timeout: Duration,
 }
 
@@ -157,8 +156,6 @@ impl ReadRequestHandler {
             global_readers: readers,
             readers_cache: Default::default(),
             wait,
-            miss_ctr: metrics::register_counter!(recorded::SERVER_VIEW_QUERY_MISS),
-            hit_ctr: metrics::register_counter!(recorded::SERVER_VIEW_QUERY_HIT),
             upquery_timeout,
         }
     }
@@ -220,7 +217,7 @@ impl ReadRequestHandler {
             Ok(hit) => {
                 // We hit on all keys, and there is no consistency miss, can return results
                 // immediately
-                self.hit_ctr.increment(1);
+                counter!(recorded::SERVER_VIEW_QUERY_HIT, 1, "cache_name" => target.name.display_unquoted().to_string());
 
                 let results = ResultIterator::new(hit, &reader.post_lookup, limit, offset, filter);
 
@@ -237,7 +234,7 @@ impl ReadRequestHandler {
             }
         };
 
-        self.miss_ctr.increment(1);
+        counter!(recorded::SERVER_VIEW_QUERY_MISS, 1, "cache_name" => target.name.display_unquoted().to_string());
 
         // Trigger backfills for all the keys we missed on, regardless of a consistency hit/miss
         if !keys_to_replay.is_empty() {
@@ -343,7 +340,6 @@ impl Service<Tagged<ReadQuery>> for ReadRequestHandler {
 /// A spawned task responsible for repeating reads that could not be immediately served from cache,
 /// until they succeed.
 pub async fn retry_misses(mut rx: UnboundedReceiver<(BlockingRead, Ack)>) {
-    let upquery_hist = metrics::register_histogram!(recorded::SERVER_VIEW_UPQUERY_DURATION);
     let mut reader_cache: ReaderMap = Default::default();
 
     while let Some((mut pending, ack)) = rx.recv().await {
@@ -363,7 +359,12 @@ pub async fn retry_misses(mut rx: UnboundedReceiver<(BlockingRead, Ack)>) {
             }
 
             if let Poll::Ready(res) = pending.check(&mut reader_cache) {
-                upquery_hist.record(pending.first.elapsed().as_micros() as f64);
+                histogram!(
+                    recorded::SERVER_VIEW_UPQUERY_DURATION,
+                    pending.first.elapsed().as_micros() as f64,
+                    "cache_name" => pending.target.name.display_unquoted().to_string()
+                );
+
                 if let Some(a) = ack {
                     let _ = a.send(res);
                 };

--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -750,6 +750,7 @@ where
             let recorder = PrometheusBuilder::new()
                 .add_global_label("upstream_db_type", database_label)
                 .add_global_label("deployment", &options.deployment)
+                .set_quantiles(&[0.5, 0.9, 0.99])?
                 .build_recorder();
 
             let handle = recorder.handle();

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -194,7 +194,6 @@ impl QueryLogger {
                             }
 
                             histogram!(recorded::QUERY_LOG_EXECUTION_TIME, duration.as_micros() as f64, &labels);
-                            counter!(recorded::QUERY_LOG_EXECUTION_COUNT, 1, &labels);
                         }
                         Some(ReadysetExecutionEvent::Other { duration }) => {
                             let mut labels =
@@ -209,7 +208,6 @@ impl QueryLogger {
                             }
 
                             histogram!(recorded::QUERY_LOG_EXECUTION_TIME, duration.as_micros() as f64, &labels);
-                            counter!(recorded::QUERY_LOG_EXECUTION_COUNT, 1, &labels);
                         }
                         None => (),
                     }
@@ -227,7 +225,6 @@ impl QueryLogger {
                         }
 
                         histogram!(recorded::QUERY_LOG_EXECUTION_TIME, duration.as_micros() as f64, &labels);
-                        counter!(recorded::QUERY_LOG_EXECUTION_COUNT, 1, &labels);
                     }
                 }
             }

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -180,8 +180,10 @@ impl QueryLogger {
                         Some(ReadysetExecutionEvent::CacheRead { cache_misses, num_keys, duration, cache_name }) => {
                             let mut labels = vec![("cache_name", SharedString::from(cache_name.display_unquoted().to_string()))];
 
-                            counter!(recorded::QUERY_LOG_TOTAL_KEYS_READ, num_keys, &labels);
-                            counter!(recorded::QUERY_LOG_TOTAL_CACHE_MISSES, cache_misses, &labels);
+                            if mode.is_verbose() {
+                                counter!(recorded::QUERY_LOG_TOTAL_KEYS_READ, num_keys, &labels);
+                                counter!(recorded::QUERY_LOG_TOTAL_CACHE_MISSES, cache_misses, &labels);
+                            }
 
                             labels.push(("database_type", SharedString::from(DatabaseType::ReadySet)));
 

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -183,10 +183,6 @@ impl QueryLogger {
                             counter!(recorded::QUERY_LOG_TOTAL_KEYS_READ, num_keys, &labels);
                             counter!(recorded::QUERY_LOG_TOTAL_CACHE_MISSES, cache_misses, &labels);
 
-                            if cache_misses != 0 {
-                                counter!(recorded::QUERY_LOG_QUERY_CACHE_MISSED, cache_misses, &labels);
-                            }
-
                             labels.push(("database_type", SharedString::from(DatabaseType::ReadySet)));
 
                             if mode.is_verbose() {


### PR DESCRIPTION
This commit changes the adapter's query logger so that the metrics we
use to measure the number of keys read and missed per cache read are
only emitted when the query log mode is set to verbose.

