### PR TITLE
readyset-psql: Fix named_cache_queryable_after_being_cleared

### DIFF
--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2102,6 +2102,8 @@ async fn recreate_replication_slot() {
 // Tests that a cache with a name can still be queried after it is cleared from the query status
 // cache
 #[tokio::test(flavor = "multi_thread")]
+#[serial]
+#[slow]
 async fn named_cache_queryable_after_being_cleared() {
     readyset_tracing::init_test_logging();
     let prefix = "named_cache_queryable_after_being_cleared";


### PR DESCRIPTION
This commit adds the `#[serial]` and `#[slow]` tags to the
`named_cache_queryable_after_being_cleared` test to prevent it from
running at the same time as the other tests in readyset_psql::fallback.
This fixes an issue where a table was being created by this test while
another test was running, causing the other test to fail.

