### PR TITLE
build: Install clippy and rustfmt

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /tmp
 
 COPY rust-toolchain .
 
-RUN rustup default "$(cat public/rust-toolchain)"; rm rust-toolchain
+RUN rustup default "$(cat rust-toolchain)"; rm rust-toolchain
+RUN rustup component add clippy
+RUN rustup component add rustfmt
 
 RUN set -eux; \
     apt-get update; \


### PR DESCRIPTION
For some reason, rustup was previously installing clippy and rustfmt
automatically and then suddenly stopped, breaking our build pipeline
steps that run these commands. To remediate this, this commit adds steps
in public/build/Dockerfile to manually install clippy and rustfmt, which
is what the documentation for each of these tools suggests we do.

