### PR TITLE
metrics: Removed query log cached missed metric

### DIFF
--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -37,13 +37,6 @@ pub const QUERY_LOG_TOTAL_KEYS_READ: &str = "readyset_query_log_total_keys_read"
 /// | query | The query text being executed. |
 pub const QUERY_LOG_TOTAL_CACHE_MISSES: &str = "readyset_query_log_total_cache_misses";
 
-/// Counter: The number of queries which encountered at least one cache miss.
-///
-/// | Tag | Description |
-/// | --- | ----------- |
-/// | query | The query text being executed. |
-pub const QUERY_LOG_QUERY_CACHE_MISSED: &str = "readyset_query_log_query_cache_missed";
-
 /// Counter: The number of successful queries (dry runs/real) processed by the migration handler.
 pub const MIGRATION_HANDLER_SUCCESSES: &str = "readyset_migration_handler_successes";
 

--- a/readyset/src/query_logger.rs
+++ b/readyset/src/query_logger.rs
@@ -183,10 +183,6 @@ impl QueryLogger {
                             counter!(recorded::QUERY_LOG_TOTAL_KEYS_READ, num_keys, &labels);
                             counter!(recorded::QUERY_LOG_TOTAL_CACHE_MISSES, cache_misses, &labels);
 
-                            if cache_misses != 0 {
-                                counter!(recorded::QUERY_LOG_QUERY_CACHE_MISSED, cache_misses, &labels);
-                            }
-
                             labels.push(("database_type", SharedString::from(DatabaseType::ReadySet)));
 
                             if mode.is_verbose() {


### PR DESCRIPTION
This commit removes the adapter's query log cached missed metric, which
counted the number of queries against caches that missed on at least one
key. This metric duplicates the SERVER_VIEW_QUERY_MISS metric, so it is
not needed.

