### PR TITLE
metrics: Make domain replay misses a verbose metric

### DIFF
--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -122,11 +122,13 @@ impl DomainMetrics {
     }
 
     pub(super) fn inc_replay_misses(&mut self, cache_name: &Relation, n: usize) {
-        counter!(
-            recorded::DOMAIN_REPLAY_MISSES,
-            n as u64,
-            "cache_name" => cache_name_to_string(cache_name)
-        );
+        if self.verbose {
+            counter!(
+                recorded::DOMAIN_REPLAY_MISSES,
+                n as u64,
+                "cache_name" => cache_name_to_string(cache_name)
+            );
+        }
     }
 
     pub(super) fn inc_packets_sent(&mut self, packet: &Packet) {


### PR DESCRIPTION
This commit makes the metric that tracks the number of replay misses for
a particular domain a verbose metric, since it is not required for the
everyday operation of Readyset.

