### PR TITLE
metrics: Add cache name to upquery duration metric

### DIFF
--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -216,6 +216,10 @@ pub mod recorded {
 
     /// Histogram: The amount of time in microseconds spent waiting for an upquery during a read
     /// request.
+    ///
+    /// | Tag | Description |
+    /// | --- | ----------- |
+    /// | cache_name | The name of the cache associated with this upquery.
     pub const SERVER_VIEW_UPQUERY_DURATION: &str = "readyset_server.view_query_upquery_duration_us";
 
     /// Counter: The number of times a dataflow node type is added to the


### PR DESCRIPTION
This commit adds the cache name as a label to the histogram we use to
measure upquery duration. This will allow us to see exactly which caches
have problematic upqueries in a given deployment, which in turn will help
us determine which caches are contributing to overall system
instability.

