### PR TITLE
readers: Fix cache miss statistics

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -89,7 +89,6 @@ use readyset_adapter_types::{DeallocateId, ParsedCommand};
 use readyset_client::consensus::{Authority, AuthorityControl, CacheDDLRequest};
 use readyset_client::consistency::Timestamp;
 use readyset_client::query::*;
-use readyset_client::results::Results;
 use readyset_client::utils::retry_with_exponential_backoff;
 use readyset_client::{ColumnSchema, PlaceholderIdx, ViewCreateRequest};
 pub use readyset_client_metrics::QueryDestination;
@@ -2085,7 +2084,7 @@ where
 
         Ok(noria_connector::QueryResult::from_owned(
             select_schema,
-            vec![Results::new(data)],
+            data,
         ))
     }
 
@@ -2143,7 +2142,7 @@ where
 
         Ok(noria_connector::QueryResult::from_owned(
             select_schema,
-            vec![Results::new(results)],
+            results,
         ))
     }
 
@@ -3064,7 +3063,7 @@ where
 
         Ok(noria_connector::QueryResult::from_owned(
             select_schema,
-            vec![Results::new(results)],
+            results,
         ))
     }
 
@@ -3098,10 +3097,7 @@ where
             .map(|conn| vec![conn.to_string().into()])
             .collect::<Vec<_>>();
 
-        Ok(noria_connector::QueryResult::from_owned(
-            schema,
-            vec![Results::new(data)],
-        ))
+        Ok(noria_connector::QueryResult::from_owned(schema, data))
     }
 
     pub fn in_transaction(&self) -> bool {

--- a/readyset-client/src/lib.rs
+++ b/readyset-client/src/lib.rs
@@ -366,8 +366,8 @@ pub use crate::table::{
     TableOperation, TableReplicationStatus, TableRequest, TableStatus,
 };
 pub use crate::view::{
-    KeyComparison, LookupResult, ReadQuery, ReadReply, ReadReplyBatch, ReadReplyStats, SchemaType,
-    View, ViewCreateRequest, ViewQuery,
+    KeyComparison, LookupResult, ReadQuery, ReadReply, ReadReplyBatch, SchemaType, View,
+    ViewCreateRequest, ViewQuery,
 };
 
 pub mod builders {

--- a/readyset-mysql/src/query_handler.rs
+++ b/readyset-mysql/src/query_handler.rs
@@ -7,7 +7,6 @@ use nom_sql::{Column, Expr, FieldDefinitionExpr, Literal, SqlIdentifier, SqlQuer
 use readyset_adapter::backend::noria_connector::QueryResult;
 use readyset_adapter::backend::SelectSchema;
 use readyset_adapter::{QueryHandler, SetBehavior};
-use readyset_client::results::Results;
 use readyset_client::ColumnSchema;
 use readyset_data::{DfType, DfValue};
 use readyset_errors::{ReadySetError, ReadySetResult};
@@ -860,7 +859,7 @@ impl QueryHandler for MySqlQueryHandler {
                         }]),
                         columns: Cow::Owned(vec![field_name]),
                     },
-                    vec![Results::new(vec![vec![MAX_ALLOWED_PACKET_DEFAULT]])],
+                    vec![vec![MAX_ALLOWED_PACKET_DEFAULT]],
                 ))
             }
             _ => Ok(QueryResult::empty(SelectSchema {

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -8,7 +8,7 @@ use readyset_adapter::backend::{
 };
 use readyset_adapter::upstream_database::LazyUpstream;
 use readyset_adapter_types::ParsedCommand;
-use readyset_client::results::{ResultIterator, Results};
+use readyset_client::results::ResultIterator;
 use readyset_client::ColumnSchema;
 use readyset_data::DfType;
 use upstream::StatementMeta;
@@ -115,10 +115,10 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                 });
 
                 let resultset = Resultset::from_readyset(
-                    ResultIterator::owned(vec![Results::new(vec![vars
+                    ResultIterator::owned(vec![vec![vars
                         .into_iter()
                         .map(|v| readyset_data::DfValue::from(v.value))
-                        .collect()])]),
+                        .collect()]]),
                     &select_schema,
                 )?;
                 Ok(Select {
@@ -153,10 +153,8 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                     rows.push(vec![v.name.as_str().into(), v.value.into()]);
                 }
 
-                let resultset = Resultset::from_readyset(
-                    ResultIterator::owned(vec![Results::new(rows)]),
-                    &select_schema,
-                )?;
+                let resultset =
+                    Resultset::from_readyset(ResultIterator::owned(vec![rows]), &select_schema)?;
                 Ok(Select {
                     schema: select_schema.try_into()?,
                     resultset,
@@ -191,10 +189,8 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                     rows.push(vec![v.name.as_str().into(), v.value.into()]);
                 }
 
-                let resultset = Resultset::from_readyset(
-                    ResultIterator::owned(vec![Results::new(rows)]),
-                    &select_schema,
-                )?;
+                let resultset =
+                    Resultset::from_readyset(ResultIterator::owned(vec![rows]), &select_schema)?;
                 Ok(Select {
                     schema: select_schema.try_into()?,
                     resultset,

--- a/readyset-psql/src/resultset.rs
+++ b/readyset-psql/src/resultset.rs
@@ -117,7 +117,6 @@ mod tests {
     use futures::{StreamExt, TryStreamExt};
     use psql_srv::PsqlValue;
     use readyset_adapter::backend as cl;
-    use readyset_client::results::Results;
     use readyset_client::ColumnSchema;
     use readyset_data::{DfType, DfValue};
 
@@ -161,7 +160,7 @@ mod tests {
 
     #[tokio::test]
     async fn stream_resultset() {
-        let results = vec![Results::new(vec![vec![DfValue::Int(10)]])];
+        let results = vec![vec![vec![DfValue::Int(10)]]];
         let schema = SelectSchema(cl::SelectSchema {
             schema: Cow::Owned(vec![ColumnSchema {
                 column: "tab1.col1".into(),
@@ -180,9 +179,9 @@ mod tests {
     #[tokio::test]
     async fn stream_resultset_with_multiple_results() {
         let results = vec![
-            Results::new(vec![vec![DfValue::Int(10)]]),
-            Results::new(Vec::<Vec<DfValue>>::new()),
-            Results::new(vec![vec![DfValue::Int(11)], vec![DfValue::Int(12)]]),
+            vec![vec![DfValue::Int(10)]],
+            Vec::<Vec<DfValue>>::new(),
+            vec![vec![DfValue::Int(11)], vec![DfValue::Int(12)]],
         ];
         let schema = SelectSchema(cl::SelectSchema {
             schema: Cow::Owned(vec![ColumnSchema {


### PR DESCRIPTION
Previously, we were always reporting 0 as the number of misses for
queries against a cache. We were passing around a `ReadReplyStats` type
that was never actually populated with statistics. This commit resolves
the issue by removing the `ReadReplyStats` type altogther and instead
reporting the number of keys missed as computed directly from the
reader.

Release-Note-Core: Fixed an issue where one of our metrics was reporting
  the incorrect number of misses for reads against caches
