### PR TITLE
metrics: Rename eviction bytes histogram

### DIFF
--- a/benchmarks/src/eviction_benchmark.rs
+++ b/benchmarks/src/eviction_benchmark.rs
@@ -302,7 +302,7 @@ async fn metrics_task(
 
     let initial = scrape_metrics(&metrics_url, &metrics_client).await?;
     let query_count_metric = format!("{}_count", adapter_recorded::QUERY_LOG_EXECUTION_TIME);
-    let mut last_evicted = get_total_for_metric(&initial, server_recorded::EVICTION_FREED_MEMORY);
+    let mut last_evicted = get_total_for_metric(&initial, server_recorded::EVICTION_BYTES_FREED);
     let mut last_hits = get_metric(
         &initial,
         &query_count_metric,
@@ -323,7 +323,7 @@ async fn metrics_task(
 
         let metrics = scrape_metrics(&metrics_url, &metrics_client).await?;
 
-        let evicted = get_total_for_metric(&metrics, server_recorded::EVICTION_FREED_MEMORY);
+        let evicted = get_total_for_metric(&metrics, server_recorded::EVICTION_BYTES_FREED);
         let hit = get_metric(
             &metrics,
             &query_count_metric,

--- a/readyset-client/src/metrics/mod.rs
+++ b/readyset-client/src/metrics/mod.rs
@@ -164,8 +164,8 @@ pub mod recorded {
     /// Counter: The number of eviction packets received.
     pub const EVICTION_REQUESTS: &str = "readyset_eviction_requests";
 
-    /// Histogram: The total number of bytes evicted.
-    pub const EVICTION_FREED_MEMORY: &str = "readyset_eviction_freed_memory";
+    /// Histogram: The number of bytes evicted per `EvictRequest::Bytes` message.
+    pub const EVICTION_BYTES_FREED: &str = "readyset_eviction_bytes_freed";
 
     /// Histogram: The amount of time in microseconds spent waiting for an upquery during a read
     /// request.

--- a/readyset-dataflow/src/domain/domain_metrics.rs
+++ b/readyset-dataflow/src/domain/domain_metrics.rs
@@ -32,7 +32,7 @@ impl DomainMetrics {
 
     pub(super) fn rec_eviction_time(&self, time: Duration, total_freed: u64) {
         histogram!(recorded::EVICTION_TIME, time.as_micros() as f64);
-        histogram!(recorded::EVICTION_FREED_MEMORY, total_freed as f64);
+        histogram!(recorded::EVICTION_BYTES_FREED, total_freed as f64);
     }
 
     pub(super) fn rec_chunked_replay_start_time(&mut self, time: Duration) {


### PR DESCRIPTION
This commit renames the `EVICTION_FREED_MEMORY` metrics to be
`EVICTION_BYTES_FREED` to make it clearer what the metric is actually
measuring. It also updates the doc comment for the constant, which
incorrectly stated that it was measuring the "total" amount of memory
freed.

