### PR TITLE
nom-sql: Fix GROUP BY parsing for Postgres

### DIFF
--- a/logictests/psql/numeric_references.test
+++ b/logictests/psql/numeric_references.test
@@ -1,0 +1,54 @@
+statement ok
+create table t (
+    id int,
+    val int
+);
+
+statement ok
+insert into t (id, val) values
+(1, 1),
+(2, 1),
+(3, 2),
+(4, 2);
+
+query II nosort
+select id, val from t order by 1
+----
+1
+1
+2
+1
+3
+2
+4
+2
+
+
+query II nosort
+select val, id from t order by 2
+----
+1
+1
+1
+2
+2
+3
+2
+4
+
+query II rowsort
+select max(id), val from t group by 2
+----
+2
+1
+4
+2
+
+
+query II nosort
+select max(id), val from t group by 2 order by 2 desc
+----
+4
+2
+2
+1

--- a/nom-sql/src/common.rs
+++ b/nom-sql/src/common.rs
@@ -827,21 +827,16 @@ pub fn field_reference(
     dialect: Dialect,
 ) -> impl Fn(LocatedSpan<&[u8]>) -> NomSqlResult<&[u8], FieldReference> {
     move |i| {
-        match dialect {
-            Dialect::PostgreSQL => map(expression(dialect), FieldReference::Expr)(i),
-            // Only MySQL supports numeric field references (postgresql considers them integer
-            // literals, I'm pretty sure)
-            Dialect::MySQL => alt((
-                map(
-                    map_res(
-                        map_res(digit1, |i: LocatedSpan<&[u8]>| str::from_utf8(&i)),
-                        u64::from_str,
-                    ),
-                    FieldReference::Numeric,
+        alt((
+            map(
+                map_res(
+                    map_res(digit1, |i: LocatedSpan<&[u8]>| str::from_utf8(&i)),
+                    u64::from_str,
                 ),
-                map(expression(dialect), FieldReference::Expr),
-            ))(i),
-        }
+                FieldReference::Numeric,
+            ),
+            map(expression(dialect), FieldReference::Expr),
+        ))(i)
     }
 }
 


### PR DESCRIPTION
Postgres allows you to identify columns in a `GROUP BY` clause by their
ordinal position in the column list of a query; however our parser was
written with the assumption that this was only possible for MySQL. This
commit updates our parser to support column indices in the `GROUP BY`
clause for both MySQL *and* Postgres.

Release-Note-Core: Fixed an issue where Readyset was not correctly
  handling entries in the `GROUP BY` clause that identified columns by
  their position in the column list of the query
