### PR TITLE
build: Compile with fat LTO and 1 codegen unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,10 +80,15 @@ metrics = { git = "https://github.com/readysettech/metrics.git" }
 metrics-util = { git = "https://github.com/readysettech/metrics.git" }
 
 [profile.release]
-debug=true
+debug = true
+
+[profile.release-lto]
+inherits = "release"
+lto = "fat"
+codegen-units = 1
 
 [profile.release-dist]
 # configs for distro release packages (i.e. deb, rpm, etc.)
-inherits = "release"
+inherits = "release-lto"
 debug = false
 strip = "debuginfo"

--- a/benchmarks/scripts/open_write_latency.sh
+++ b/benchmarks/scripts/open_write_latency.sh
@@ -21,7 +21,7 @@ for num_indices in "${indices[@]}"; do
     fi
 done
 
-cargo build --release --bin benchmarks
+cargo build --profile=release-lto --bin benchmarks
 for num_indices in "${indices[@]}"; do
     echo "=== Benchmarking ${num_indices} indices ==="
     target/release/benchmarks \

--- a/reader-map/benchmark/README.md
+++ b/reader-map/benchmark/README.md
@@ -1,7 +1,7 @@
 To reproduce results, run with:
 
 ```shell
-cargo build --release
+cargo build --profile=release-lto
 rm results.log
 for w in 1 2 4; do
   for d in uniform skewed; do


### PR DESCRIPTION
This commit ensures that we are always building Readyset with "fat" LTO
enabled and only one codegen unit. This opts us into a higher degree of
compile-time optimization across all the crates in the dependency graph.

Per system-benchmarks, this dramatically improves performance on our
lobste.rs benchmark with a 50% memory limit:

```
time:   [-56.324% -40.668% -20.800%] (p = 0.00 < 0.05)
thrpt:  [+26.263% +68.544% +128.96%]
```

Release-Note-Core: Optimized release builds using "fat" LTO, improving
  performance considerably for certain workloads
