### PR TITLE
readyset-errors: extend is_view_not_found()

### DIFF
--- a/readyset-errors/src/lib.rs
+++ b/readyset-errors/src/lib.rs
@@ -768,9 +768,12 @@ impl ReadySetError {
         self.any_cause(|e| e.is_unsupported())
     }
 
-    /// Returns `true` if self is ['ViewNotFound'].
+    /// Returns `true` if self is ['ViewNotFound'] or ['ViewNotFoundForQuery'].
     pub fn is_view_not_found(&self) -> bool {
-        matches!(self, Self::ViewNotFound(..))
+        matches!(
+            self,
+            Self::ViewNotFound(..) | Self::ViewNotFoundForQuery { .. }
+        )
     }
 
     /// Returns `true` if self either *is* [`ViewNotFound`], or was *caused by* [`ViewNotFound`].


### PR DESCRIPTION
This extends our is_view_not_found() helper for determining if a
particular error is of a "view not found" flavor, so that a
ViewNotFoundForQuery doesn't result in an error log in the
mirror_prepare workflow.

