### PR TITLE
psql-srv: Make Column an enum

### DIFF
--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -37,6 +37,7 @@ use protocol::Protocol;
 use readyset_adapter_types::DeallocateId;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_native_tls::TlsAcceptor;
+use tokio_postgres::OwnedField;
 
 pub use crate::bytes::BytesStr;
 pub use crate::error::Error;
@@ -125,20 +126,21 @@ pub trait PsqlBackend {
     fn in_transaction(&self) -> bool;
 }
 
+// TODO: There are several representations of Column/Field, we can probably consolidate them.
 /// A description of a column, either in the parameters to a query or in a resultset
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct Column {
-    /// The name of the column
-    pub name: SqlIdentifier,
-
-    /// The OID of the column's table, if known
-    pub table_oid: Option<u32>,
-
-    /// The attribute number of the column, if known
-    pub attnum: Option<i16>,
-
-    /// The type of the column
-    pub col_type: Type,
+pub enum Column {
+    Column {
+        /// The name of the column
+        name: SqlIdentifier,
+        /// The OID of the column's table, if known
+        table_oid: Option<u32>,
+        /// The attribute number of the column, if known
+        attnum: Option<i16>,
+        /// The type of the column
+        col_type: Type,
+    },
+    OwnedField(OwnedField),
 }
 
 /// A response produced by `Backend::on_prepare`, containing metadata about a newly created

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -59,7 +59,7 @@ impl PsqlBackend for ErrorBackend {
             Ok(PrepareResponse {
                 prepared_statement_id: 1,
                 param_schema: vec![],
-                row_schema: vec![Column {
+                row_schema: vec![Column::Column {
                     name: "x".into(),
                     table_oid: None,
                     attnum: None,
@@ -78,7 +78,7 @@ impl PsqlBackend for ErrorBackend {
         match self.0 {
             ErrorPosition::Execute => Err(Error::InternalError("a database".to_owned())),
             ErrorPosition::Serialize => Ok(QueryResponse::Select {
-                schema: vec![Column {
+                schema: vec![Column::Column {
                     name: "x".into(),
                     table_oid: None,
                     attnum: None,

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -159,7 +159,7 @@ impl PsqlBackend for Backend {
                 .map(|row| {
                     row.columns()
                         .iter()
-                        .map(|col| psql_srv::Column {
+                        .map(|col| psql_srv::Column::Column {
                             name: col.name().into(),
                             col_type: col.type_().clone(),
                             table_oid: None,
@@ -189,7 +189,7 @@ impl PsqlBackend for Backend {
             row_schema: stmt
                 .columns()
                 .iter()
-                .map(|c| psql_srv::Column {
+                .map(|c| psql_srv::Column::Column {
                     name: c.name().into(),
                     col_type: c.type_().clone(),
                     table_oid: None,
@@ -234,7 +234,7 @@ impl PsqlBackend for Backend {
             .map(|row| {
                 row.columns()
                     .iter()
-                    .map(|col| psql_srv::Column {
+                    .map(|col| psql_srv::Column::Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
                         table_oid: None,

--- a/readyset-psql/src/schema.rs
+++ b/readyset-psql/src/schema.rs
@@ -39,7 +39,7 @@ impl<'a> TryFrom<NoriaSchema<'a>> for Vec<ps::Column> {
     fn try_from(s: NoriaSchema<'a>) -> Result<Self, Self::Error> {
         s.0.iter()
             .map(|c| {
-                Ok(ps::Column {
+                Ok(ps::Column::Column {
                     name: c.column.name.clone(),
                     col_type: type_to_pgsql(&c.column_type)?,
                     table_oid: c.base.as_ref().and_then(|b| b.table_oid),

--- a/readyset-psql/src/upstream.rs
+++ b/readyset-psql/src/upstream.rs
@@ -245,7 +245,7 @@ impl UpstreamDatabase for PostgreSqlUpstream {
                 .columns()
                 .iter()
                 .map(|col| -> Result<_, Error> {
-                    Ok(Column {
+                    Ok(Column::Column {
                         name: col.name().into(),
                         col_type: col.type_().clone(),
                         table_oid: col.table_oid(),


### PR DESCRIPTION
There are multiple similar representations of Column/Field, and they may
be able to be consolidated, but as a first step towards being able to
plumb through tokio-postgres's OwnedField through the Row description
path (which is needed for streaming a SimpleQueryStream), this commit
extends the Column struct to be either the existing format or the
OwnedField format from tokio-postgres.

