### PR TITLE
readyset-psql: Stream SimpleQuery responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 [[package]]
 name = "postgres"
 version = "0.19.7"
-source = "git+https://github.com/readysettech/rust-postgres.git#5774049efa0629110ddd16f62a0ac870791fae57"
+source = "git+https://github.com/readysettech/rust-postgres.git#dd34e4c4c38a2882c8722674456ef2f6e1d28297"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "postgres-derive"
 version = "0.4.5"
-source = "git+https://github.com/readysettech/rust-postgres.git#5774049efa0629110ddd16f62a0ac870791fae57"
+source = "git+https://github.com/readysettech/rust-postgres.git#dd34e4c4c38a2882c8722674456ef2f6e1d28297"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.69",
@@ -3847,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/readysettech/rust-postgres.git#5774049efa0629110ddd16f62a0ac870791fae57"
+source = "git+https://github.com/readysettech/rust-postgres.git#dd34e4c4c38a2882c8722674456ef2f6e1d28297"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.6"
-source = "git+https://github.com/readysettech/rust-postgres.git#5774049efa0629110ddd16f62a0ac870791fae57"
+source = "git+https://github.com/readysettech/rust-postgres.git#dd34e4c4c38a2882c8722674456ef2f6e1d28297"
 dependencies = [
  "base64 0.21.0",
  "byteorder",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.6"
-source = "git+https://github.com/readysettech/rust-postgres.git#5774049efa0629110ddd16f62a0ac870791fae57"
+source = "git+https://github.com/readysettech/rust-postgres.git#dd34e4c4c38a2882c8722674456ef2f6e1d28297"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.10"
-source = "git+https://github.com/readysettech/rust-postgres.git#5774049efa0629110ddd16f62a0ac870791fae57"
+source = "git+https://github.com/readysettech/rust-postgres.git#dd34e4c4c38a2882c8722674456ef2f6e1d28297"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -6980,7 +6980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/psql-srv/src/message/backend.rs
+++ b/psql-srv/src/message/backend.rs
@@ -6,7 +6,7 @@ use postgres::error::ErrorPosition;
 pub use postgres::error::SqlState;
 use postgres::{Row, SimpleQueryRow};
 use postgres_types::Type;
-use tokio_postgres::OwnedField;
+use tokio_postgres::{OwnedField, SimpleQueryMessage};
 
 use crate::message::TransferFormat;
 use crate::value::PsqlValue;
@@ -167,6 +167,7 @@ pub struct FieldDescription {
 
 #[derive(Debug)]
 pub enum PsqlSrvRow {
+    SimpleQueryMessage(SimpleQueryMessage),
     RawRow(Row),
     ValueVec(Vec<PsqlValue>),
 }
@@ -180,5 +181,10 @@ impl From<Vec<PsqlValue>> for PsqlSrvRow {
 impl From<Row> for PsqlSrvRow {
     fn from(value: Row) -> Self {
         Self::RawRow(value)
+    }
+}
+impl From<SimpleQueryRow> for PsqlSrvRow {
+    fn from(value: SimpleQueryRow) -> Self {
+        Self::SimpleQueryMessage(SimpleQueryMessage::Row(value))
     }
 }

--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;
 
@@ -6,6 +7,7 @@ use futures::stream;
 use postgres::config::{ChannelBinding, SslMode};
 use postgres::error::SqlState;
 use postgres::NoTls;
+use postgres_protocol::Oid;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlSrvRow,
@@ -79,6 +81,10 @@ impl PsqlBackend for ScramSha256Backend {
 
     fn in_transaction(&self) -> bool {
         false
+    }
+
+    async fn load_extended_types(&mut self) -> Result<HashMap<Oid, i16>, psql_srv::Error> {
+        Ok(HashMap::default())
     }
 }
 

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::vec;
 
 use async_trait::async_trait;
 use futures::{stream, Future};
 use postgres::NoTls;
+use postgres_protocol::Oid;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Column, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend,
@@ -103,6 +105,10 @@ impl PsqlBackend for ErrorBackend {
 
     fn in_transaction(&self) -> bool {
         false
+    }
+
+    async fn load_extended_types(&mut self) -> Result<HashMap<Oid, i16>, psql_srv::Error> {
+        Ok(HashMap::default())
     }
 }
 

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::vec;
 
 use async_trait::async_trait;
 use database_utils::{DatabaseURL, QueryableConnection};
 use futures::stream;
+use postgres_protocol::Oid;
 use postgres_types::Type;
 use psql_srv::{
     run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow, TransferFormat,
@@ -76,6 +78,10 @@ impl PsqlBackend for TestBackend {
 
     fn in_transaction(&self) -> bool {
         false
+    }
+
+    async fn load_extended_types(&mut self) -> Result<HashMap<Oid, i16>, psql_srv::Error> {
+        Ok(HashMap::default())
     }
 }
 

--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -469,6 +469,12 @@ where
     match result {
         Ok(QueryResult::Noria(result)) => handle_readyset_result(result, writer).await,
         Ok(QueryResult::Upstream(result)) => handle_upstream_result(result, writer).await,
+        Ok(QueryResult::UpstreamBufferedInMemory(..)) => handle_error!(
+            Error::ReadySet(readyset_errors::unsupported_err!(
+                "Execute should not use simple query protocol"
+            )),
+            writer
+        ),
         Ok(QueryResult::Parser(..)) => handle_error!(
             Error::ReadySet(readyset_errors::unsupported_err!(
                 "Should not parse SQL commands in execute"

--- a/readyset-mysql/src/upstream.rs
+++ b/readyset-mysql/src/upstream.rs
@@ -321,6 +321,14 @@ impl UpstreamDatabase for MySqlUpstream {
         handle_query_result!(result)
     }
 
+    // MySQL does not have a separation of Simple/Extended query protocols like Postgres does.
+    async fn simple_query<'a>(
+        &'a mut self,
+        _query: &'a str,
+    ) -> Result<Self::QueryResult<'a>, Error> {
+        unsupported!("MySQL does not have a simple_query protocol");
+    }
+
     /// Executes the given query on the mysql backend.
     async fn handle_ryw_write<'a, S>(
         &'a mut self,

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -12,6 +12,7 @@
 //! $ cargo criterion -p readyset-psql --bench proxy
 //! ```
 
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -22,7 +23,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use futures::future::{try_select, Either};
 use futures::stream::Peekable;
 use futures::{ready, Stream, StreamExt, TryStreamExt};
-use postgres_types::Type;
+use postgres_types::{Oid, Type};
 use psql_srv::{
     Credentials, CredentialsNeeded, PrepareResponse, PsqlBackend, PsqlSrvRow, QueryResponse,
     TransferFormat,
@@ -259,6 +260,10 @@ impl PsqlBackend for Backend {
 
     fn in_transaction(&self) -> bool {
         false
+    }
+
+    async fn load_extended_types(&mut self) -> Result<HashMap<Oid, i16>, psql_srv::Error> {
+        Ok(HashMap::new())
     }
 }
 


### PR DESCRIPTION
When we receive a query from the postgres simple query protocol, we use
tokio-postgres's SimpleQuery structures and apis to perform the query.
This can be for queries that have a small payload or for proxied queries
that have a large result set.

`fn simple_query` (what we were using before this), collects all rows in
the result into a Vec, which we were then mapping to our own SmallVec
before returning. This meant that we buffered a lot of memory before
returning.

This changes the way we proxy selects to use a streaming
protocol--tokio-postgres's SimpleQueryStream, which means we write out
rows as we stream them in rather than buffering in readyset.

Our Response structures already stream for the postgres binary protocol,
so the main changes in this patch are to add a separate, parallel way
for us to use a SimpleQueryStream, similarly to how we have PassThrough
version of RowDescription and CommandComplete that forward along the
already-serialized data from tokio-postgres.

Since the streaming was only used to provide the responses for a single
select (or execute) before, but SimpleQueryStream allows pipelining of
several responses (each will have a CommandComplete and potentially data
rows preceding it), this patch changes the logic a bit to allow for
detecting these separate result sets and injecting the appropriate
RowDescriptions. (We were already doing this logic for the simple_query
path and aggregating it into a vec.)

We had one part of our code that relied on the response being a
SimpleQuery (load_extended_types). In order to accomodate this, I moved
load_extended_types to be a part of the backend trait and added a
separate internal way of using the previous simple query protocol for
that use case.

The lack of needing to double buffer seems to also come with a
signficant performance speedup for simple query protocol SELECTs. Some
non-scientific sampling if different result sizes seems to indicate a
20-30% speedup for smaller result sizes, but for larger ones, it grows
to 40%+. This should hopefully speed up a lot of our tests as well,
which often use `simple_query`.

The psql cli tool only uses the simple query protocol, and python
psychopg2 seems to default to it as well, so this memory reduction and
speedup could be a significant win for a large set of clients.

Fixes: REA-4114
Release-Note-Core: Readyset now streams proxied results for
  postgres for queries using the simple query protocol similarly to how it
  already does for the extended query protocol. This vastly reduces the
  memory consumption for text-protocol queries as well as improves
  performance of them in many cases.
