### PR TITLE
nom-sql: Fix parsing for alias after numeric cast

### DIFF
--- a/nom-sql/src/macros.rs
+++ b/nom-sql/src/macros.rs
@@ -25,6 +25,14 @@ macro_rules! test_parse {
 }
 
 #[cfg(test)]
+macro_rules! test_parse_expect_err {
+    ($parser: expr, $src: expr) => {{
+        let res = crate::to_nom_result($parser(nom_locate::LocatedSpan::new($src)));
+        assert!(res.is_err(), "res expected to be err but is ok",);
+    }};
+}
+
+#[cfg(test)]
 /// Generates a round-trip test that displays and then parses a provided type with a provided
 /// parser.
 ///

--- a/nom-sql/src/sql_type.rs
+++ b/nom-sql/src/sql_type.rs
@@ -789,6 +789,7 @@ fn type_identifier_part1(
                     tag_no_case("double"),
                     opt(preceded(whitespace1, tag_no_case("precision"))),
                     whitespace0,
+                    // FIXME: postgres does not support this precision field
                     opt(precision),
                     whitespace0,
                     opt_signed,
@@ -796,8 +797,11 @@ fn type_identifier_part1(
                 |_| SqlType::Double,
             ),
             map(
-                tuple((tag_no_case("numeric"), whitespace0, opt(numeric_precision))),
-                |t| SqlType::Numeric(t.2),
+                tuple((
+                    tag_no_case("numeric"),
+                    opt(preceded(whitespace0, numeric_precision)),
+                )),
+                |t| SqlType::Numeric(t.1),
             ),
             enum_type(dialect),
             map(


### PR DESCRIPTION
Our parsing for a numeric type identifier was consuming trailing
whitespace incorrectly.

Fixes: REA-4192
Release-Note-Core: Fixed a bug where we didn't properly parse type alias
  following a numeric type cast.
