### PR TITLE
readyset-adapter: Remove clone in read hot path

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2530,7 +2530,7 @@ where
         let noria_res = {
             event.destination = Some(QueryDestination::Readyset);
             let ctx = ExecuteSelectContext::AdHoc {
-                statement: view_request.statement.clone(),
+                statement: &view_request.statement,
                 create_if_missing: settings.migration_mode == MigrationMode::InRequestPath,
                 processed_query_params,
             };

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -348,7 +348,7 @@ pub(crate) enum ExecuteSelectContext<'ctx> {
         params: &'ctx [DfValue],
     },
     AdHoc {
-        statement: nom_sql::SelectStatement,
+        statement: &'ctx nom_sql::SelectStatement,
         create_if_missing: bool,
         processed_query_params: ProcessedQueryParams,
     },
@@ -1503,7 +1503,7 @@ impl NoriaConnector {
                 processed_query_params,
             } => {
                 let name = self
-                    .get_view_name_cached(&statement, false, create_if_missing, None)
+                    .get_view_name_cached(statement, false, create_if_missing, None)
                     .await?;
                 (
                     Cow::Owned(name),

--- a/readyset-client/src/view.rs
+++ b/readyset-client/src/view.rs
@@ -1093,7 +1093,7 @@ impl fmt::Debug for ReaderHandle {
             .field("node", &self.node)
             .field("columns", &self.columns)
             .field("shard_addrs", &self.shard_addrs)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
We were unnecessarily cloning a view_request's select statement in the
adhoc read path.

