### PR TITLE
readyset-util: Add `BoundedRange`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,6 +2837,7 @@ name = "merging-interval-tree"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "readyset-util",
  "test-strategy",
 ]
 
@@ -3590,6 +3591,7 @@ name = "partial-map"
 version = "0.1.0"
 dependencies = [
  "merging-interval-tree",
+ "readyset-util",
 ]
 
 [[package]]
@@ -4380,6 +4382,7 @@ dependencies = [
  "quickcheck_macros",
  "rand 0.7.3",
  "readyset-client",
+ "readyset-util",
  "smallvec",
  "thiserror",
  "triomphe",
@@ -4755,6 +4758,7 @@ dependencies = [
  "tokio-postgres",
  "triomphe",
  "uuid 0.8.2",
+ "vec1",
 ]
 
 [[package]]
@@ -5230,10 +5234,13 @@ dependencies = [
  "eui48",
  "futures",
  "proptest",
+ "quickcheck",
+ "rand 0.7.3",
  "rust_decimal",
  "serde",
  "serde_json",
  "test-strategy",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid 0.8.2",

--- a/dataflow-state/benches/persistent_state.rs
+++ b/dataflow-state/benches/persistent_state.rs
@@ -36,8 +36,6 @@
 //! ```notrust
 //! $ cargo bench -- --help
 //! ```
-use std::ops::Bound;
-
 use clap::Parser;
 use common::{Index, IndexType, Record};
 use criterion::{black_box, Criterion};
@@ -45,7 +43,7 @@ use dataflow_state::{
     DurabilityMode, PersistenceParameters, PersistentState, PointKey, RangeKey, SnapshotMode, State,
 };
 use itertools::Itertools;
-use readyset_data::DfValue;
+use readyset_data::{DfValue, IntoBoundedRange};
 
 lazy_static::lazy_static! {
     static ref LARGE_STRINGS: Vec<String> = ["a", "b", "c"]
@@ -184,10 +182,7 @@ pub fn rocksdb_range_lookup(c: &mut Criterion, state: &PersistentState) {
     let mut group = c.benchmark_group("RocksDB lookup_range");
     group.bench_function("lookup_range", |b| {
         b.iter(|| {
-            black_box(state.lookup_range(
-                &[1],
-                &RangeKey::Single((Bound::Included(key.clone()), Bound::Unbounded)),
-            ));
+            black_box(state.lookup_range(&[1], &RangeKey::Single(key.clone().greater_than())));
         })
     });
     group.finish();
@@ -201,7 +196,7 @@ pub fn rocksdb_range_lookup_large_strings(c: &mut Criterion, state: &PersistentS
         b.iter(|| {
             black_box(state.lookup_range(
                 &[1],
-                &RangeKey::Single((Bound::Included(key.clone()), Bound::Unbounded)),
+                &RangeKey::Single(key.clone().greater_than_or_equal_to()),
             ));
         })
     });

--- a/dataflow-state/src/key.rs
+++ b/dataflow-state/src/key.rs
@@ -1,9 +1,9 @@
-use std::ops::{Bound, RangeBounds};
+use std::fmt;
 
 use common::DfValue;
 use derive_more::From;
 use readyset_data::TextRef;
-use readyset_util::intervals::BoundPair;
+use readyset_util::ranges::{Bound, BoundedRange, RangeBounds};
 use serde::ser::{SerializeSeq, SerializeTuple};
 use serde::Serialize;
 use test_strategy::Arbitrary;
@@ -150,15 +150,13 @@ impl Serialize for PointKey {
 
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 pub enum RangeKey {
-    /// Key-length-polymorphic double-unbounded range key
-    Unbounded,
-    Single(BoundPair<DfValue>),
-    Double(BoundPair<(DfValue, DfValue)>),
-    Tri(BoundPair<(DfValue, DfValue, DfValue)>),
-    Quad(BoundPair<(DfValue, DfValue, DfValue, DfValue)>),
-    Quin(BoundPair<(DfValue, DfValue, DfValue, DfValue, DfValue)>),
-    Sex(BoundPair<(DfValue, DfValue, DfValue, DfValue, DfValue, DfValue)>),
-    Multi(BoundPair<Box<[DfValue]>>),
+    Single(BoundedRange<DfValue>),
+    Double(BoundedRange<(DfValue, DfValue)>),
+    Tri(BoundedRange<(DfValue, DfValue, DfValue)>),
+    Quad(BoundedRange<(DfValue, DfValue, DfValue, DfValue)>),
+    Quin(BoundedRange<(DfValue, DfValue, DfValue, DfValue, DfValue)>),
+    Sex(BoundedRange<(DfValue, DfValue, DfValue, DfValue, DfValue, DfValue)>),
+    Multi(BoundedRange<Box<[DfValue]>>),
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -172,32 +170,24 @@ impl RangeKey {
     /// # Examples
     ///
     /// ```rust
-    /// use std::ops::Bound::*;
-    ///
     /// use dataflow_state::RangeKey;
-    /// use readyset_data::DfValue;
+    /// use readyset_data::Bound::*;
+    /// use readyset_data::{DfValue, range};
     /// use vec1::vec1;
     ///
-    /// // Can build RangeKeys from regular range expressions
-    /// assert_eq!(RangeKey::from(&(..)), RangeKey::Unbounded);
+    /// // Can build RangeKeys using the `range!` macro
     /// assert_eq!(
-    ///     RangeKey::from(&(vec1![DfValue::from(0)]..vec1![DfValue::from(1)])),
-    ///     RangeKey::Single((Included(0.into()), Excluded(1.into())))
+    ///     RangeKey::from(&range!(=vec1![DfValue::from(0)], vec1![DfValue::from(1)])),
+    ///     RangeKey::Single((Included(0.into()), Excluded(1.into())).into())
     /// );
     /// ```
-    pub fn from<R>(range: &R) -> Self
-    where
-        R: RangeBounds<Vec1<DfValue>>,
-    {
+    pub fn from(range: &BoundedRange<Vec1<DfValue>>) -> Self {
         use Bound::*;
-        let len = match (range.start_bound(), range.end_bound()) {
-            (Unbounded, Unbounded) => return RangeKey::Unbounded,
+        let len = match range {
             (Included(start) | Excluded(start), Included(end) | Excluded(end)) => {
                 assert_eq!(start.len(), end.len());
                 start.len()
             }
-            (Included(start) | Excluded(start), Unbounded) => start.len(),
-            (Unbounded, Included(end) | Excluded(end)) => end.len(),
         };
 
         macro_rules! make {
@@ -238,7 +228,6 @@ impl RangeKey {
     /// Returns the upper bound of the range key
     pub fn upper_bound(&self) -> Bound<Vec<&DfValue>> {
         match self {
-            RangeKey::Unbounded => Bound::Unbounded,
             RangeKey::Single((_, upper)) => upper.as_ref().map(|dt| vec![dt]),
             RangeKey::Double((_, upper)) => upper.as_ref().map(|dts| dts.elements().collect()),
             RangeKey::Tri((_, upper)) => upper.as_ref().map(|dts| dts.elements().collect()),
@@ -250,29 +239,21 @@ impl RangeKey {
     }
 
     /// Return the length of this range key, or None if the key is Unbounded
-    pub fn len(&self) -> Option<usize> {
+    pub fn len(&self) -> usize {
         match self {
-            RangeKey::Unbounded | RangeKey::Multi((Bound::Unbounded, Bound::Unbounded)) => None,
-            RangeKey::Single(_) => Some(1),
-            RangeKey::Double(_) => Some(2),
-            RangeKey::Tri(_) => Some(3),
-            RangeKey::Quad(_) => Some(4),
-            RangeKey::Quin(_) => Some(5),
-            RangeKey::Sex(_) => Some(6),
-            RangeKey::Multi(
-                (Bound::Included(k), _)
-                | (Bound::Excluded(k), _)
-                | (_, Bound::Included(k))
-                | (_, Bound::Excluded(k)),
-            ) => Some(k.len()),
+            RangeKey::Single(_) => 1,
+            RangeKey::Double(_) => 2,
+            RangeKey::Tri(_) => 3,
+            RangeKey::Quad(_) => 4,
+            RangeKey::Quin(_) => 5,
+            RangeKey::Sex(_) => 6,
+            RangeKey::Multi((Bound::Included(k), _) | (Bound::Excluded(k), _)) => k.len(),
         }
     }
 
     /// Convert this [`RangeKey`] into a pair of bounds on [`PointKey`]s, for use during
     /// serialization of lookup keys for ranges
-    pub(crate) fn into_point_keys(self) -> BoundPair<PointKey> {
-        use Bound::*;
-
+    pub(crate) fn into_point_keys(self) -> BoundedRange<PointKey> {
         macro_rules! point_keys {
             ($r:ident, $variant:ident) => {
                 ($r.0.map(PointKey::$variant), $r.1.map(PointKey::$variant))
@@ -280,7 +261,6 @@ impl RangeKey {
         }
 
         match self {
-            RangeKey::Unbounded => (Unbounded, Unbounded),
             RangeKey::Single((l, u)) => (l.map(PointKey::Single), u.map(PointKey::Single)),
             RangeKey::Double(r) => point_keys!(r, Double),
             RangeKey::Tri(r) => point_keys!(r, Tri),
@@ -291,10 +271,10 @@ impl RangeKey {
         }
     }
 
-    pub fn as_bound_pair(&self) -> BoundPair<Vec<DfValue>> {
-        fn as_bound_pair<T>(bound_pair: &BoundPair<T>) -> BoundPair<Vec<DfValue>>
+    pub fn as_bound_pair(&self) -> BoundedRange<Vec<DfValue>> {
+        fn as_bound_pair<T>(bound_pair: &BoundedRange<T>) -> BoundedRange<Vec<DfValue>>
         where
-            T: TupleElements<Element = DfValue>,
+            T: TupleElements<Element = DfValue> + fmt::Debug,
         {
             (
                 bound_pair
@@ -309,7 +289,6 @@ impl RangeKey {
         }
 
         match self {
-            RangeKey::Unbounded => (Bound::Unbounded, Bound::Unbounded),
             RangeKey::Single((lower, upper)) => (
                 lower.as_ref().map(|dt| vec![dt.clone()]),
                 upper.as_ref().map(|dt| vec![dt.clone()]),

--- a/dataflow-state/src/keyed_state.rs
+++ b/dataflow-state/src/keyed_state.rs
@@ -1,11 +1,10 @@
 use std::iter;
-use std::ops::{Bound, RangeBounds};
 
 use common::{Index, IndexType};
 use indexmap::IndexMap;
 use partial_map::PartialMap;
-use readyset_data::DfValue;
-use readyset_util::intervals::into_bound_endpoint;
+use readyset_data::{Bound, BoundedRange, DfValue};
+use readyset_util::ranges::RangeBounds;
 use tuple::TupleElements;
 use vec1::Vec1;
 
@@ -312,7 +311,7 @@ impl KeyedState {
     /// # Panics
     ///
     /// Panics if this `KeyedState` is backed by a HashMap index
-    pub(super) fn insert_range(&mut self, range: (Bound<Vec1<DfValue>>, Bound<Vec1<DfValue>>)) {
+    pub(super) fn insert_range(&mut self, range: BoundedRange<Vec1<DfValue>>) {
         match self {
             KeyedState::SingleBTree(ref mut map) => map.insert_range((
                 range.0.map(|k| k.split_off_first().0),
@@ -336,8 +335,7 @@ impl KeyedState {
             // This is unwieldy, but allowing callers to insert the wrong length of Vec into us
             // would be very bad!
             KeyedState::MultiBTree(ref mut map, len)
-                if (into_bound_endpoint(range.0.as_ref()).map_or(true, |x| x.len() == *len)
-                    && into_bound_endpoint(range.1.as_ref()).map_or(true, |x| x.len() == *len)) =>
+                if range.0.len() == *len && range.1.len() == *len =>
             {
                 map.insert_range((range.0.map(Vec1::into_vec), range.1.map(Vec1::into_vec)))
             }
@@ -345,6 +343,37 @@ impl KeyedState {
             #[allow(clippy::panic)] // documented invariant
             {
                 panic!("insert_range called on a HashMap KeyedState")
+            }
+        };
+    }
+
+    pub(super) fn insert_full_range(&mut self) {
+        match self {
+            KeyedState::SingleBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::DoubleBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::TriBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::QuadBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::QuinBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::SexBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::MultiBTree(ref mut map, _) => {
+                map.insert_full_range();
+            }
+            _ =>
+            #[allow(clippy::panic)] // documented invariant
+            {
+                panic!("insert_full_range called on a HashMap KeyedState")
             }
         };
     }
@@ -380,12 +409,6 @@ impl KeyedState {
             Box::new(r.flat_map(|(_, rows)| rows))
         }
 
-        macro_rules! full_range {
-            ($m: expr) => {
-                $m.range(&(..)).map(flatten_rows).map_err(to_misses)
-            };
-        }
-
         macro_rules! range {
             ($m: expr, $range: ident) => {
                 $m.range($range).map(flatten_rows).map_err(to_misses)
@@ -393,19 +416,6 @@ impl KeyedState {
         }
 
         match (self, key) {
-            (KeyedState::SingleBTree(m), &RangeKey::Unbounded) => m
-                .range(&(..))
-                .map_err(|misses| {
-                    misses
-                        .into_iter()
-                        .map(|(lower, upper)| (lower.map(|k| vec![k]), upper.map(|k| vec![k])))
-                        .collect()
-                })
-                .map(flatten_rows),
-            (KeyedState::DoubleBTree(m), &RangeKey::Unbounded) => full_range!(m),
-            (KeyedState::TriBTree(m), &RangeKey::Unbounded) => full_range!(m),
-            (KeyedState::QuadBTree(m), &RangeKey::Unbounded) => full_range!(m),
-            (KeyedState::SexBTree(m), &RangeKey::Unbounded) => full_range!(m),
             (KeyedState::SingleBTree(m), RangeKey::Single(range)) => {
                 m.range(range).map(flatten_rows).map_err(|misses| {
                     misses
@@ -417,7 +427,9 @@ impl KeyedState {
             (KeyedState::DoubleBTree(m), RangeKey::Double(range)) => range!(m, range),
             (KeyedState::TriBTree(m), RangeKey::Tri(range)) => range!(m, range),
             (KeyedState::QuadBTree(m), RangeKey::Quad(range)) => range!(m, range),
-            (KeyedState::SexBTree(m), RangeKey::Sex(range)) => range!(m, range),
+            (KeyedState::SexBTree(m), RangeKey::Sex(range)) => {
+                range!(m, range)
+            }
             (KeyedState::MultiBTree(m, _), RangeKey::Multi(range)) => m
                 .range::<_, [DfValue]>(&(
                     range.0.as_ref().map(|b| b.as_ref()),
@@ -575,10 +587,7 @@ impl KeyedState {
     /// # Panics
     ///
     /// Panics if this `KeyedState` is backed by a HashMap index
-    pub(super) fn evict_range<R>(&mut self, range: &R) -> Rows
-    where
-        R: RangeBounds<Vec1<DfValue>>,
-    {
+    pub(super) fn evict_range(&mut self, range: &BoundedRange<Vec1<DfValue>>) -> Rows {
         macro_rules! do_evict_range {
             ($m: expr, $range: expr, $hint: ty) => {
                 $m.remove_range(<$hint as MakeKey<DfValue>>::from_range($range))

--- a/dataflow-state/src/lib.rs
+++ b/dataflow-state/src/lib.rs
@@ -10,7 +10,7 @@ mod single_state;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
 use std::iter::FromIterator;
-use std::ops::{Bound, Deref};
+use std::ops::Deref;
 use std::rc::Rc;
 use std::vec;
 
@@ -23,7 +23,7 @@ pub use partial_map::PartialMap;
 use readyset_client::debug::info::KeyCount;
 use readyset_client::internal::Index;
 use readyset_client::{KeyComparison, PersistencePoint};
-use readyset_data::DfValue;
+use readyset_data::{BoundedRange, DfValue};
 use readyset_errors::ReadySetResult;
 use replication_offset::ReplicationOffset;
 use serde::{Deserialize, Serialize};
@@ -746,7 +746,7 @@ impl<'a> LookupResult<'a> {
     }
 }
 
-pub type Misses = Vec<(Bound<Vec<DfValue>>, Bound<Vec<DfValue>>)>;
+pub type Misses = Vec<BoundedRange<Vec<DfValue>>>;
 
 #[derive(Eq, PartialEq, Debug)]
 pub enum RangeLookupResult<'a> {

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use common::{IndexType, Record, Records, SizeOf, Tag};
@@ -204,78 +204,31 @@ impl State for MemoryState {
         // resulting in upqueries along an overlapping replay path.
         // FIXME(eta): a lot of this could be computed at index addition time.
         for state in self.state.iter() {
-            // Try other index types with the same columns
-            if state.columns() == columns && state.index_type() != self.state[index].index_type() {
-                let res = state.lookup(key);
-                if res.is_some() {
-                    return res;
-                }
-            }
-
-            // We might have another index with the same columns in another order
-            if state.columns() != columns && state.columns().len() == columns.len() {
-                // Make a map from column index -> the position in the index we're trying to do a
-                // lookup into
-                //
-                // eg if we're mapping [3, 4] to [4, 3]
-                // we get {4 => 0, 3 => 1}
-                let col_positions = state
-                    .columns()
-                    .iter()
-                    .copied()
-                    .enumerate()
-                    .map(|(idx, col)| (col, idx))
-                    .collect::<BTreeMap<_, _>>();
-                if columns.iter().all(|c| col_positions.contains_key(c)) {
-                    let mut shuffled_key = vec![DfValue::None; key.len()];
-                    for (key_pos, col) in columns.iter().enumerate() {
-                        let val = key
-                            .get(key_pos)
-                            .expect("Columns and key must have the same len");
-                        let pos = col_positions[col];
-                        shuffled_key[pos] = val.clone();
-                    }
-                    let key = PointKey::from(shuffled_key);
-                    let res = state.lookup(&key);
-                    if res.is_some() {
-                        return res;
-                    }
-                }
-            }
-
-            // otherwise the length must be strictly less than, because otherwise it's either the
-            // same index, or we'd have to magic up datatypes out of thin air
-            if state.columns().len() < columns.len() {
+            // We can only perform lookups on states that are indexed only on the columns in the key
+            // passed into this method
+            if state.columns().iter().all(|col| columns.contains(col)) {
                 // For each column in `columns`, find the corresponding column in `state.key()`,
                 // if there is one, and return (its position in state.key(), its value from `key`).
                 // FIXME(eta): this seems accidentally quadratic.
-                let mut positions = columns
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, col_idx)| {
-                        state
-                            .columns()
+                let vals = state.columns().iter().map(|col| {
+                    let i = columns.iter().position(|c| col == c).unwrap();
+                    key.get(i).unwrap().clone()
+                });
+                let kt = PointKey::from(vals);
+                if let LookupResult::Some(mut ret) = state.lookup(&kt) {
+                    // Filter the rows in this index to ones which actually match the key. This
+                    // is required if the desired key is a superset of the key we are looking up
+                    // here. For example, if the columns passed into this method were [0, 1] and we
+                    // do a lookup here on [0], we need to filter out the rows that don't match our
+                    // key on column 1
+                    // FIXME(eta): again, probably O(terrible)
+                    ret.retain(|row| {
+                        columns
                             .iter()
-                            .position(|x| x == col_idx)
-                            .map(|pos| (pos, key.get(i).expect("bogus key passed to lookup")))
-                    })
-                    .collect::<Vec<_>>();
-                if positions.len() == state.columns().len() {
-                    // the index only contains columns from `columns` (and none other).
-                    // make a new lookup key
-                    positions.sort_unstable_by_key(|(idx, _)| *idx);
-                    let kt = PointKey::from(positions.into_iter().map(|(_, val)| val.clone()));
-                    if let LookupResult::Some(mut ret) = state.lookup(&kt) {
-                        // filter the rows in this index to ones which actually match the key
-                        // FIXME(eta): again, probably O(terrible)
-                        ret.retain(|row| {
-                            columns
-                                .iter()
-                                .enumerate()
-                                .all(|(key_idx, &col_idx)| row.get(col_idx) == key.get(key_idx))
-                        });
-                        return LookupResult::Some(ret);
-                    }
+                            .enumerate()
+                            .all(|(key_idx, &col_idx)| row.get(col_idx) == key.get(key_idx))
+                    });
+                    return LookupResult::Some(ret);
                 }
             }
         }
@@ -666,6 +619,74 @@ mod tests {
         );
     }
 
+    // Tests that lookups on keys with duplicate columns can perform lookups on states with
+    // deduplicated set of columns
+    #[test]
+    fn duplicate_columns() {
+        let mut state = MemoryState::default();
+        state.add_index(Index::hash_map(vec![0]), Some(vec![Tag::new(0)]));
+        state.add_index(Index::hash_map(vec![0, 0]), Some(vec![Tag::new(1)]));
+
+        state.mark_filled(KeyComparison::Equal(vec1![1.into()]), Tag::new(0));
+        state.insert(
+            vec![1.into(), 1.into(), 1.into(), 1.into()],
+            Some(Tag::new(0)),
+        );
+
+        let res = state.lookup(&[0, 0], &PointKey::Double((1.into(), 1.into())));
+        assert!(res.is_some());
+        let rows = res.unwrap();
+        assert_eq!(
+            rows,
+            RecordResult::Owned(vec![vec![1.into(), 1.into(), 1.into(), 1.into()]])
+        );
+    }
+
+    // Tests that a lookup on a superset of columns in another index will still find the rows in
+    // that index
+    #[test]
+    fn superset_lookup() {
+        let mut state = MemoryState::default();
+        state.add_index(Index::hash_map(vec![0]), Some(vec![Tag::new(0)]));
+        state.add_index(Index::hash_map(vec![0, 1]), Some(vec![Tag::new(1)]));
+
+        state.mark_filled(KeyComparison::Equal(vec1![1.into()]), Tag::new(0));
+        state.insert(
+            vec![1.into(), 2.into(), 3.into(), 4.into()],
+            Some(Tag::new(0)),
+        );
+        state.insert(
+            vec![1.into(), 3.into(), 4.into(), 5.into()],
+            Some(Tag::new(0)),
+        );
+
+        let res = state.lookup(&[0, 1], &PointKey::Double((1.into(), 2.into())));
+        assert!(res.is_some());
+        let rows = res.unwrap();
+        assert_eq!(
+            rows,
+            RecordResult::Owned(vec![vec![1.into(), 2.into(), 3.into(), 4.into()]])
+        );
+    }
+
+    // Tests that lookups on a subset of columns from another index do not return rows from that
+    // index
+    #[test]
+    fn subset_lookup_miss() {
+        let mut state = MemoryState::default();
+        state.add_index(Index::hash_map(vec![0]), Some(vec![Tag::new(0)]));
+        state.add_index(Index::hash_map(vec![0, 1]), Some(vec![Tag::new(1)]));
+
+        state.mark_filled(KeyComparison::Equal(vec1![1.into(), 2.into()]), Tag::new(1));
+        state.insert(
+            vec![1.into(), 2.into(), 3.into(), 4.into()],
+            Some(Tag::new(1)),
+        );
+
+        let res = state.lookup(&[0], &PointKey::Single(1.into()));
+        assert!(res.is_missing());
+    }
+
     #[test]
     fn shuffled_columns() {
         let mut state = MemoryState::default();
@@ -1034,6 +1055,7 @@ mod tests {
     }
 
     mod weak_index_proptest {
+        use std::collections::BTreeMap;
         use std::ops::RangeInclusive;
         use std::time::Duration;
 

--- a/dataflow-state/src/mk_key.rs
+++ b/dataflow-state/src/mk_key.rs
@@ -1,5 +1,7 @@
 use std::borrow::Borrow;
-use std::ops::{Bound, RangeBounds};
+use std::fmt;
+
+use readyset_data::BoundedRange;
 
 #[macro_export]
 macro_rules! adapt_range {
@@ -19,20 +21,19 @@ macro_rules! adapt_range {
 pub(super) trait MakeKey<A> {
     fn from_row(key: &[usize], row: &[A]) -> Self;
     fn from_key(key: &[A]) -> Self;
-    fn from_range<R, I>(range: &R) -> (Bound<Self>, Bound<Self>)
+    fn from_range<I>((lower, upper): &BoundedRange<I>) -> BoundedRange<Self>
     where
-        R: RangeBounds<I>,
         I: Borrow<[A]>,
         Self: Sized,
     {
         (
-            range.start_bound().map(|k| Self::from_key(k.borrow())),
-            range.end_bound().map(|k| Self::from_key(k.borrow())),
+            lower.as_ref().map(|k| Self::from_key(k.borrow())),
+            upper.as_ref().map(|k| Self::from_key(k.borrow())),
         )
     }
 }
 
-impl<A: Clone> MakeKey<A> for (A, A) {
+impl<A: Clone + fmt::Debug> MakeKey<A> for (A, A) {
     #[inline(always)]
     fn from_row(key: &[usize], row: &[A]) -> Self {
         debug_assert_eq!(key.len(), 2);
@@ -59,7 +60,7 @@ impl<A: Clone> MakeKey<A> for A {
     }
 }
 
-impl<A: Clone> MakeKey<A> for (A, A, A) {
+impl<A: Clone + fmt::Debug> MakeKey<A> for (A, A, A) {
     #[inline(always)]
     fn from_row(key: &[usize], row: &[A]) -> Self {
         debug_assert_eq!(key.len(), 3);
@@ -76,7 +77,7 @@ impl<A: Clone> MakeKey<A> for (A, A, A) {
     }
 }
 
-impl<A: Clone> MakeKey<A> for (A, A, A, A) {
+impl<A: Clone + fmt::Debug> MakeKey<A> for (A, A, A, A) {
     #[inline(always)]
     fn from_row(key: &[usize], row: &[A]) -> Self {
         debug_assert_eq!(key.len(), 4);
@@ -99,7 +100,7 @@ impl<A: Clone> MakeKey<A> for (A, A, A, A) {
     }
 }
 
-impl<A: Clone> MakeKey<A> for (A, A, A, A, A) {
+impl<A: Clone + fmt::Debug> MakeKey<A> for (A, A, A, A, A) {
     #[inline(always)]
     fn from_row(key: &[usize], row: &[A]) -> Self {
         debug_assert_eq!(key.len(), 5);
@@ -124,7 +125,7 @@ impl<A: Clone> MakeKey<A> for (A, A, A, A, A) {
     }
 }
 
-impl<A: Clone> MakeKey<A> for (A, A, A, A, A, A) {
+impl<A: Clone + fmt::Debug> MakeKey<A> for (A, A, A, A, A, A) {
     #[inline(always)]
     fn from_row(key: &[usize], row: &[A]) -> Self {
         debug_assert_eq!(key.len(), 6);
@@ -150,7 +151,7 @@ impl<A: Clone> MakeKey<A> for (A, A, A, A, A, A) {
         )
     }
 }
-impl<A: Clone> MakeKey<A> for Vec<A> {
+impl<A: Clone + fmt::Debug> MakeKey<A> for Vec<A> {
     #[inline(always)]
     fn from_row(key: &[usize], row: &[A]) -> Self {
         key.iter().map(|&x| row[x].clone()).collect()

--- a/dataflow-state/src/persistent_state/mod.rs
+++ b/dataflow-state/src/persistent_state/mod.rs
@@ -65,7 +65,6 @@ mod handle;
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::io::{self, Read};
-use std::ops::Bound;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::mpsc::RecvTimeoutError;
@@ -84,9 +83,8 @@ use readyset_alloc::thread::StdThreadBuildWrapper;
 use readyset_client::debug::info::KeyCount;
 use readyset_client::internal::Index;
 use readyset_client::{KeyComparison, SqlIdentifier};
-use readyset_data::DfValue;
+use readyset_data::{Bound, BoundedRange, DfValue};
 use readyset_errors::{internal_err, invariant, ReadySetError, ReadySetResult};
-use readyset_util::intervals::BoundPair;
 use replication_offset::ReplicationOffset;
 use rocksdb::{
     self, BlockBasedOptions, ColumnFamilyDescriptor, CompactOptions, IteratorMode, SliceTransform,
@@ -936,7 +934,6 @@ impl State for PersistentStateHandle {
                 inclusive_end = Some(k.clone());
                 opts.set_iterate_upper_bound(k);
             }
-            _ => {}
         }
 
         let mut iterator = inner.db.raw_iterator_cf_opt(cf, opts);
@@ -956,7 +953,6 @@ impl State for PersistentStateHandle {
                     }
                 }
             }
-            Bound::Unbounded => iterator.seek_to_first(),
         }
 
         let mut rows = Vec::new();
@@ -1083,7 +1079,7 @@ fn serialize_key<K: Serialize, E: Serialize>(k: K, extra: E) -> Vec<u8> {
     bincode::options().serialize(&(size, k, extra)).unwrap()
 }
 
-fn serialize_range(range: RangeKey) -> BoundPair<Vec<u8>> {
+fn serialize_range(range: RangeKey) -> BoundedRange<Vec<u8>> {
     let (lower, upper) = range.into_point_keys();
     (
         lower.map(|v| serialize_key(v, ())),
@@ -3195,9 +3191,9 @@ mod tests {
 
     mod lookup_range {
         use std::iter;
-        use std::ops::Bound::*;
 
         use pretty_assertions::assert_eq;
+        use readyset_data::range;
         use vec1::vec1;
 
         use super::*;
@@ -3223,7 +3219,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(vec1![DfValue::from(11)]..vec1![DfValue::from(20)]))
+                    &RangeKey::from(&range!(=vec1![DfValue::from(11)], vec1![DfValue::from(20)]))
                 ),
                 RangeLookupResult::Some(vec![].into())
             );
@@ -3235,7 +3231,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(vec1![DfValue::from(3)]..vec1![DfValue::from(7)]))
+                    &RangeKey::from(&range!(=vec1![DfValue::from(3)], vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some((3..7).map(|n| vec![n.into()]).collect::<Vec<_>>().into())
             );
@@ -3247,7 +3243,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(vec1![DfValue::from(3)]..=vec1![DfValue::from(7)]))
+                    &RangeKey::from(&range!(=vec1![DfValue::from(3)], =vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some((3..=7).map(|n| vec![n.into()]).collect::<Vec<_>>().into())
             );
@@ -3259,10 +3255,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(
-                        Bound::Excluded(vec1![DfValue::from(3)]),
-                        Bound::Excluded(vec1![DfValue::from(7)])
-                    ))
+                    &RangeKey::from(&range!(vec1![DfValue::from(3)], vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some(
                     (3..7)
@@ -3285,10 +3278,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(
-                        Bound::Excluded(vec1![DfValue::from(3)]),
-                        Bound::Excluded(vec1![DfValue::from(7)])
-                    ))
+                    &RangeKey::from(&range!(vec1![DfValue::from(3)], vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some(
                     (3..7)
@@ -3306,9 +3296,9 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(
-                        Bound::Excluded(vec1![DfValue::from(3)]),
-                        Bound::Included(vec1![DfValue::from(7)])
+                    &RangeKey::from(&range!(
+                        vec1![DfValue::from(3)],
+                        =vec1![DfValue::from(7)]
                     ))
                 ),
                 RangeLookupResult::Some(
@@ -3337,9 +3327,9 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0],
-                    &RangeKey::from(&(
-                        Bound::Excluded(vec1![DfValue::from(3)]),
-                        Bound::Included(vec1![DfValue::from(7)])
+                    &RangeKey::from(&range!(
+                        vec1![DfValue::from(3)],
+                        =vec1![DfValue::from(7)]
                     ))
                 ),
                 RangeLookupResult::Some(
@@ -3356,7 +3346,10 @@ mod tests {
         fn inclusive_unbounded() {
             let state = setup();
             assert_eq!(
-                state.lookup_range(&[0], &RangeKey::from(&(vec1![DfValue::from(3)]..))),
+                state.lookup_range(
+                    &[0],
+                    &RangeKey::from(&range!(=vec1![DfValue::from(3)], infinity))
+                ),
                 RangeLookupResult::Some((3..10).map(|n| vec![n.into()]).collect::<Vec<_>>().into())
             );
         }
@@ -3369,7 +3362,10 @@ mod tests {
                 .unwrap();
 
             assert_eq!(
-                state.lookup_range(&[0], &RangeKey::from(&(..=vec1![DfValue::from(3)]))),
+                state.lookup_range(
+                    &[0],
+                    &RangeKey::from(&range!(-infinity, =vec1![DfValue::from(3)]))
+                ),
                 RangeLookupResult::Some(
                     vec![
                         vec![DfValue::from(0)],
@@ -3400,7 +3396,10 @@ mod tests {
             state.add_index(Index::btree_map(vec![0]), None);
 
             assert_eq!(
-                state.lookup_range(&[0], &RangeKey::from(&(vec1![DfValue::from(2)]..))),
+                state.lookup_range(
+                    &[0],
+                    &RangeKey::from(&range!(=vec1![DfValue::from(2)], infinity))
+                ),
                 RangeLookupResult::Some(
                     [(2, 4), (2, 5), (3, 6), (3, 7)]
                         .iter()
@@ -3415,7 +3414,10 @@ mod tests {
         fn unbounded_inclusive() {
             let state = setup();
             assert_eq!(
-                state.lookup_range(&[0], &RangeKey::from(&(..=vec1![DfValue::from(3)]))),
+                state.lookup_range(
+                    &[0],
+                    &RangeKey::from(&range!(-infinity, =vec1![DfValue::from(3)]))
+                ),
                 RangeLookupResult::Some((0..=3).map(|n| vec![n.into()]).collect::<Vec<_>>().into())
             );
         }
@@ -3424,7 +3426,10 @@ mod tests {
         fn unbounded_exclusive() {
             let state = setup();
             assert_eq!(
-                state.lookup_range(&[0], &RangeKey::from(&(..vec1![DfValue::from(3)]))),
+                state.lookup_range(
+                    &[0],
+                    &RangeKey::from(&range!(-infinity, vec1![DfValue::from(3)]))
+                ),
                 RangeLookupResult::Some((0..3).map(|n| vec![n.into()]).collect::<Vec<_>>().into())
             );
         }
@@ -3455,7 +3460,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(Included(vec1![DfValue::from(3)]), Unbounded))
+                    &RangeKey::from(&range!(=vec1![DfValue::from(3)], infinity))
                 ),
                 RangeLookupResult::Some(
                     (3..10)
@@ -3496,7 +3501,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(Excluded(vec1![DfValue::from(10)]), Unbounded))
+                    &RangeKey::from(&range!(vec1![DfValue::from(10)], infinity))
                 ),
                 RangeLookupResult::Some(
                     [(8, 555671065), (9, 925768521), (0, 1221662829)]
@@ -3515,9 +3520,9 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(
-                        Excluded(vec1![DfValue::from(3)]),
-                        Included(vec1![DfValue::from(7)])
+                    &RangeKey::from(&range!(
+                        vec1![DfValue::from(3)],
+                        =vec1![DfValue::from(7)]
                     ))
                 ),
                 RangeLookupResult::Some(
@@ -3535,10 +3540,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(
-                        Excluded(vec1![DfValue::from(3)]),
-                        Excluded(vec1![DfValue::from(7)])
-                    ))
+                    &RangeKey::from(&range!(vec1![DfValue::from(3)], vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some(
                     (4..7).map(row_for_secondary_key).collect::<Vec<_>>().into()
@@ -3552,9 +3554,9 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(
-                        Included(vec1![DfValue::from(3)]),
-                        Excluded(vec1![DfValue::from(7)])
+                    &RangeKey::from(&range!(
+                        =vec1![DfValue::from(3)],
+                        vec1![DfValue::from(7)]
                     ))
                 ),
                 RangeLookupResult::Some(
@@ -3569,9 +3571,9 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(
-                        Excluded(vec1![DfValue::from(3)]),
-                        Included(vec1![DfValue::from(7)])
+                    &RangeKey::from(&range!(
+                        vec1![DfValue::from(3)],
+                        =vec1![DfValue::from(7)]
                     ))
                 ),
                 RangeLookupResult::Some(
@@ -3589,7 +3591,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(Unbounded, Included(vec1![DfValue::from(7)])))
+                    &RangeKey::from(&range!(-infinity, =vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some(
                     (-10..=7)
@@ -3606,7 +3608,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(Unbounded, Excluded(vec1![DfValue::from(7)])))
+                    &RangeKey::from(&range!(-infinity, vec1![DfValue::from(7)]))
                 ),
                 RangeLookupResult::Some(
                     (-10..7)
@@ -3624,9 +3626,9 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[0, 1],
-                    &RangeKey::from(&(
-                        Included(vec1![DfValue::from(2), DfValue::from(3)]),
-                        Unbounded
+                    &RangeKey::from(&range!(
+                        =vec1![DfValue::from(2), DfValue::from(3)],
+                        infinity
                     ))
                 ),
                 RangeLookupResult::Some(
@@ -3655,7 +3657,7 @@ mod tests {
             assert_eq!(
                 state.lookup_range(
                     &[1],
-                    &RangeKey::from(&(Included(vec1![DfValue::from(3)]), Unbounded))
+                    &RangeKey::from(&range!(=vec1![DfValue::from(3)], infinity))
                 ),
                 RangeLookupResult::Some(
                     vec![vec![2.into(), 3.into(), 4.into()], extra_row_beginning]
@@ -3689,15 +3691,15 @@ mod tests {
             let result = state
                 .lookup_range(
                     &[0],
-                    &RangeKey::from(&(
-                        Included(vec1![DfValue::from_str_and_collation(
+                    &RangeKey::from(&range!(
+                        =vec1![DfValue::from_str_and_collation(
                             "b",
                             Collation::Citext
-                        )]),
-                        Included(vec1![DfValue::from_str_and_collation(
+                        )],
+                        =vec1![DfValue::from_str_and_collation(
                             "c",
                             Collation::Citext
-                        )]),
+                        )]
                     )),
                 )
                 .unwrap();

--- a/dataflow-state/src/single_state.rs
+++ b/dataflow-state/src/single_state.rs
@@ -1,4 +1,3 @@
-use std::ops::{Bound, RangeBounds};
 use std::rc::Rc;
 
 use common::{IndexType, SizeOf};
@@ -6,6 +5,7 @@ use itertools::Either;
 use readyset_client::internal::Index;
 use readyset_client::KeyComparison;
 use readyset_data::DfValue;
+use readyset_util::ranges::BoundedRange;
 use vec1::Vec1;
 
 use crate::keyed_state::KeyedState;
@@ -48,7 +48,7 @@ impl SingleState {
         if !partial && index.index_type == IndexType::BTreeMap {
             // For fully materialized indices, we never miss - so mark that the full range of keys
             // has been filled.
-            state.insert_range((Bound::Unbounded, Bound::Unbounded))
+            state.insert_full_range();
         }
         Self {
             index,
@@ -213,7 +213,7 @@ impl SingleState {
         assert!(replaced.is_none());
     }
 
-    fn mark_range_filled(&mut self, range: (Bound<Vec1<DfValue>>, Bound<Vec1<DfValue>>)) {
+    fn mark_range_filled(&mut self, range: BoundedRange<Vec1<DfValue>>) {
         self.state.insert_range(range);
     }
 
@@ -316,8 +316,8 @@ impl SingleState {
                     }
                     KeyedState::MultiBTree(ref mut m, _) => Box::new(
                         m.remove_range::<[DfValue], _>((
-                            range.start_bound().map(Vec1::as_slice),
-                            range.end_bound().map(Vec1::as_slice),
+                            range.0.as_ref().map(|x| x.as_slice()),
+                            range.1.as_ref().map(|x| x.as_slice()),
                         ))
                         .flat_map(|(_, rows)| rows),
                     ),
@@ -444,8 +444,7 @@ impl SingleState {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Bound;
-
+    use readyset_data::range;
     use vec1::vec1;
 
     use super::*;
@@ -460,13 +459,12 @@ mod tests {
     #[test]
     fn mark_filled_range() {
         let mut state = SingleState::new(Index::new(IndexType::BTreeMap, vec![0]), true);
-        state.mark_filled(KeyComparison::Range((
-            Bound::Included(vec1![0.into()]),
-            Bound::Excluded(vec1![5.into()]),
-        )));
+        state.mark_filled(KeyComparison::Range(
+            range!(=vec1![0.into()], vec1![5.into()]),
+        ));
         assert!(state.lookup(&PointKey::from([0.into()])).is_some());
         assert!(state
-            .lookup_range(&RangeKey::from(&(vec1![0.into()]..vec1![5.into()])))
+            .lookup_range(&RangeKey::from(&range!(=vec1![0.into()], vec1![5.into()])))
             .is_some());
     }
 
@@ -489,11 +487,11 @@ mod tests {
         fn range() {
             let mut state = SingleState::new(Index::new(IndexType::BTreeMap, vec![0]), true);
             let key =
-                KeyComparison::from_range(&(vec1![DfValue::from(0)]..vec1![DfValue::from(10)]));
+                KeyComparison::Range(range!(=vec1![DfValue::from(0)], vec1![DfValue::from(10)]));
             state.mark_filled(key.clone());
             assert!(state
                 .lookup_range(&RangeKey::from(
-                    &(vec1![DfValue::from(0)]..vec1![DfValue::from(10)])
+                    &range!(=vec1![DfValue::from(0)], vec1![DfValue::from(10)])
                 ))
                 .is_some());
 
@@ -502,7 +500,7 @@ mod tests {
             assert!(state.lookup(&PointKey::from([0.into()])).is_missing());
             assert!(state
                 .lookup_range(&RangeKey::from(
-                    &(vec1![DfValue::from(0)]..vec1![DfValue::from(10)])
+                    &range!(=vec1![DfValue::from(0)], vec1![DfValue::from(10)])
                 ))
                 .is_missing())
         }

--- a/merging-interval-tree/Cargo.toml
+++ b/merging-interval-tree/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 description = "An efficient non-overlapping interval tree that merges overlapping and adjacent intervals to prevent fragmentation"
 
 [dependencies]
+readyset-util = {path = "../readyset-util"}
 
 [dev-dependencies]
 test-strategy = "0.2"

--- a/partial-map/Cargo.toml
+++ b/partial-map/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 merging-interval-tree = { path = "../merging-interval-tree" }
+readyset-util = { path = "../readyset-util" }

--- a/partial-map/src/lib.rs
+++ b/partial-map/src/lib.rs
@@ -4,9 +4,9 @@ use std::borrow::Borrow;
 pub use std::collections::btree_map::{Iter, Keys, Range, Values, ValuesMut};
 use std::collections::{btree_map, BTreeMap};
 use std::fmt;
-use std::ops::{Bound, RangeBounds};
 
 use merging_interval_tree::IntervalTreeSet;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 /// A [`BTreeMap`] that knows what ranges of keys it has
 ///
@@ -211,7 +211,7 @@ where
         K: Borrow<Q>,
         Q: Ord + ?Sized,
     {
-        self.interval_tree.covers_interval(range)
+        self.interval_tree.covers_interval(&range.as_std_range())
     }
 
     /// Returns true if the map contains at least part of the given range
@@ -222,7 +222,7 @@ where
         Q: Ord + ?Sized,
     {
         self.interval_tree
-            .get_interval_overlaps(range)
+            .get_interval_overlaps(&range.as_std_range())
             .next()
             .is_some()
     }
@@ -245,7 +245,17 @@ where
         K: Clone,
         R: RangeBounds<K>,
     {
-        self.interval_tree.insert_interval(range);
+        self.interval_tree.insert_interval(range.as_std_range());
+    }
+
+    /// Mark the full range of keys as filled in this map.
+    ///
+    /// All keys will be considered to be set to the [`default`](std::Default::default) value.
+    pub fn insert_full_range(&mut self)
+    where
+        K: Clone,
+    {
+        self.interval_tree.insert_interval(..);
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
@@ -287,12 +297,17 @@ where
     {
         let diff = self
             .interval_tree
-            .get_interval_difference(range)
-            .map(|(lower, upper)| (lower.map(ToOwned::to_owned), upper.map(ToOwned::to_owned)))
+            .get_interval_difference(&range.as_std_range())
+            .map(|(lower, upper)| {
+                (
+                    lower.map(ToOwned::to_owned).try_into().unwrap(),
+                    upper.map(ToOwned::to_owned).try_into().unwrap(),
+                )
+            })
             .collect::<Vec<_>>();
 
         if diff.is_empty() {
-            Ok(self.map.range((range.start_bound(), range.end_bound())))
+            Ok(self.map.range(range.as_std_range()))
         } else {
             Err(diff)
         }
@@ -341,7 +356,7 @@ where
         B: Ord + ?Sized + ToOwned<Owned = K>,
         R: RangeBounds<B> + 'a,
     {
-        self.interval_tree.remove_interval(&range);
+        self.interval_tree.remove_interval(&range.as_std_range());
         // NOTE: it is deeply unfortunate that rust's BTreeMap doesn't have a drain(range) function
         // the way Vec does. This is forcing us into an O(n) operation where we could have an
         // O(log(n)) one.
@@ -451,7 +466,7 @@ mod tests {
     #[test]
     fn entry_filled() {
         let mut map: PartialMap<i32, ()> = PartialMap::new();
-        map.insert_range(1..);
+        map.insert_range((Bound::Included(1), Bound::Included(i32::MAX)));
         assert!(matches!(map.entry(2), Entry::Occupied(_)));
     }
 }

--- a/reader-map/Cargo.toml
+++ b/reader-map/Cargo.toml
@@ -13,6 +13,7 @@ left-right = "0.11"
 itertools = "0.10"
 
 readyset-client = { path = "../readyset-client" }
+readyset-util = { path = "../readyset-util" }
 partial-map = { path = "../partial-map" }
 thiserror = "1.0.31"
 iter-enum = "1.1.1"

--- a/reader-map/src/inner.rs
+++ b/reader-map/src/inner.rs
@@ -2,12 +2,12 @@ use std::borrow::Borrow;
 use std::collections::{hash_map, HashMap};
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::ops::{Bound, RangeBounds};
 
 use iter_enum::{ExactSizeIterator, Iterator};
 use itertools::Either;
 use partial_map::PartialMap;
 use readyset_client::internal::IndexType;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 use crate::eviction::{EvictionMeta, EvictionStrategy};
 use crate::values::Values;
@@ -143,6 +143,15 @@ impl<K, V, S> Data<K, V, S> {
     {
         if let Self::BTreeMap(ref mut map, ..) = self {
             map.insert_range(range);
+        }
+    }
+
+    pub(crate) fn add_full_range(&mut self)
+    where
+        K: Ord + Clone,
+    {
+        if let Self::BTreeMap(ref mut map, ..) = self {
+            map.insert_full_range();
         }
     }
 

--- a/reader-map/src/read/read_ref.rs
+++ b/reader-map/src/read/read_ref.rs
@@ -3,9 +3,9 @@ use std::collections::btree_map;
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::ops::RangeBounds;
 
 use left_right::ReadGuard;
+use readyset_util::ranges::RangeBounds;
 
 use crate::inner::{Inner, Miss};
 use crate::values::Values;

--- a/reader-map/src/write.rs
+++ b/reader-map/src/write.rs
@@ -1,11 +1,11 @@
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::ops::{Bound, RangeBounds};
 
 use left_right::Absorb;
 use partial_map::InsertionOrder;
 use readyset_client::internal::IndexType;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 use crate::eviction::EvictionMeta;
 use crate::inner::Inner;
@@ -175,6 +175,11 @@ where
             range.start_bound().cloned(),
             range.end_bound().cloned(),
         )))
+    }
+
+    /// Inserts the full range of keys into the map.
+    pub fn insert_full_range(&mut self) -> &mut Self {
+        self.add_op(Operation::AddFullRange)
     }
 
     /// Clear the value-bag of the given key, without removing it.
@@ -388,6 +393,7 @@ where
                 }
             }
             Operation::AddRange(range) => self.data.add_range(range.clone()),
+            Operation::AddFullRange => self.data.add_full_range(),
             Operation::Clear(key, eviction_meta) => {
                 self.data_entry(key.clone(), eviction_meta).clear()
             }
@@ -455,6 +461,7 @@ where
                 }
             }
             Operation::AddRange(range) => self.data.add_range(range),
+            Operation::AddFullRange => self.data.add_full_range(),
             Operation::Clear(key, mut eviction_meta) => {
                 self.data_entry(key, &mut eviction_meta).clear()
             }
@@ -516,6 +523,8 @@ pub(super) enum Operation<K, V, M, T> {
     Add(K, V, Option<EvictionMeta>, Option<usize>),
     /// Add an interval to the list of filled intervals
     AddRange((Bound<K>, Bound<K>)),
+    /// Add the full range of keys
+    AddFullRange,
     /// Remove this value from the set of entries for this key. Last element of the tuple is the
     /// removal index for [`absorb_second`] and computed in [`absorb_first`]
     RemoveValue(K, V, Option<usize>),
@@ -550,6 +559,7 @@ where
         match self {
             Operation::Add(a, b, c, _) => f.debug_tuple("Add").field(a).field(b).field(c).finish(),
             Operation::AddRange(a) => f.debug_tuple("AddRange").field(a).finish(),
+            Operation::AddFullRange => f.debug_tuple("AddFullRange").finish(),
             Operation::RemoveValue(a, b, _) => {
                 f.debug_tuple("RemoveValue").field(a).field(b).finish()
             }

--- a/reader-map/tests/quick.rs
+++ b/reader-map/tests/quick.rs
@@ -14,10 +14,11 @@ use std::cmp::{min, Ord};
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 use std::hash::{BuildHasher, Hash};
-use std::ops::{Bound, Deref, RangeBounds};
+use std::ops::Deref;
 
 use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 fn set<'a, T: 'a, I>(iter: I) -> HashSet<T>
 where

--- a/readyset-data/Cargo.toml
+++ b/readyset-data/Cargo.toml
@@ -35,6 +35,7 @@ nom_locate = "4.0.0"
 postgres-protocol = { workspace = true }
 cidr = "0.2.1"
 postgres-types = { workspace = true, features = ["with-cidr-0_2"] }
+vec1 = "1.6.0"
 
 # Local dependencies
 nom-sql = { path = "../nom-sql" }

--- a/readyset-data/src/ranges.rs
+++ b/readyset-data/src/ranges.rs
@@ -1,0 +1,119 @@
+//! A collection of utilities to make it easier to create [`readyset_util::ranges::BoundedRanges`]
+//! of [`DfValue`]s.
+pub use readyset_util::ranges::{Bound, BoundedRange};
+use vec1::Vec1;
+
+use super::DfValue;
+
+pub trait IntoBoundedRange: Sized {
+    /// Maps over `self`, returning a new object with all the values replaced with `value`.
+    fn map_value(&self, value: DfValue) -> Self;
+
+    /// Returns a [`BoundedRange`] that includes all non-NULL values greater than (but not equal
+    /// to) `self`.
+    fn greater_than(self) -> BoundedRange<Self> {
+        let upper = self.map_value(DfValue::MAX_VALUE);
+        (Bound::Excluded(self), Bound::Excluded(upper))
+    }
+
+    /// Returns a [`BoundedRange`] and includes all non-NULL values greater than or equal to `self`.
+    fn greater_than_or_equal_to(self) -> BoundedRange<Self> {
+        let upper = self.map_value(DfValue::MAX_VALUE);
+        (Bound::Included(self), Bound::Excluded(upper))
+    }
+
+    /// Returns a [`BoundedRange`] that includes all non-NULL values less than (but not equal
+    /// to) `self`.
+    fn less_than(self) -> BoundedRange<Self> {
+        let lower = self.map_value(DfValue::MIN_VALUE);
+        (Bound::Excluded(lower), Bound::Excluded(self))
+    }
+
+    /// Returns a [`BoundedRange`] and includes all non-NULL values less than or equal to `self`.
+    fn less_than_or_equal_to(self) -> BoundedRange<Self> {
+        let lower = self.map_value(DfValue::MIN_VALUE);
+        (Bound::Excluded(lower), Bound::Included(self))
+    }
+}
+
+impl IntoBoundedRange for Vec1<DfValue> {
+    fn map_value(&self, value: DfValue) -> Self {
+        self.mapped_ref(|_| value.clone())
+    }
+}
+
+impl IntoBoundedRange for DfValue {
+    fn map_value(&self, value: DfValue) -> Self {
+        value
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (value.clone(), value)
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (value.clone(), value.clone(), value)
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue, DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (value.clone(), value.clone(), value.clone(), value)
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue, DfValue, DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (
+            value.clone(),
+            value.clone(),
+            value.clone(),
+            value.clone(),
+            value,
+        )
+    }
+}
+
+#[macro_export]
+macro_rules! range {
+    (=$lower:expr, infinity) => {
+        ::readyset_data::IntoBoundedRange::greater_than_or_equal_to($lower)
+    };
+    ($lower:expr, infinity) => {
+        ::readyset_data::IntoBoundedRange::greater_than($lower)
+    };
+    (-infinity, =$upper:expr) => {
+        ::readyset_data::IntoBoundedRange::less_than_or_equal_to($upper)
+    };
+    (-infinity, $upper:expr) => {
+        ::readyset_data::IntoBoundedRange::less_than($upper)
+    };
+    ($lower:expr, $upper:expr) => {
+        (
+            ::readyset_data::Bound::Excluded($lower),
+            ::readyset_data::Bound::Excluded($upper),
+        )
+    };
+    ($lower:expr, =$upper:expr) => {
+        (
+            ::readyset_data::Bound::Excluded($lower),
+            ::readyset_data::Bound::Included($upper),
+        )
+    };
+    (=$lower:expr, $upper:expr) => {
+        (
+            ::readyset_data::Bound::Included($lower),
+            ::readyset_data::Bound::Excluded($upper),
+        )
+    };
+    (=$lower:expr, =$upper:expr) => {
+        (
+            ::readyset_data::Bound::Included($lower),
+            ::readyset_data::Bound::Included($upper),
+        )
+    };
+}

--- a/readyset-dataflow/src/backlog/multiw.rs
+++ b/readyset-dataflow/src/backlog/multiw.rs
@@ -1,9 +1,9 @@
-use std::ops::{Bound, RangeBounds};
-
 use ahash::RandomState;
 use dataflow_expression::PreInsertion;
 use reader_map::EvictionQuantity;
 use readyset_client::consistency::Timestamp;
+use readyset_data::BoundedRange;
+use readyset_util::ranges::RangeBounds;
 
 use super::{key_to_single, Key};
 use crate::prelude::*;
@@ -68,7 +68,7 @@ impl Handle {
         }
     }
 
-    pub fn empty_range(&mut self, range: (Bound<Vec<DfValue>>, Bound<Vec<DfValue>>)) {
+    pub fn empty_range(&mut self, range: BoundedRange<Vec<DfValue>>) {
         match self {
             Handle::Single(h) => {
                 h.remove_range((
@@ -178,20 +178,18 @@ impl Handle {
         }
     }
 
-    pub fn insert_range<R>(&mut self, range: R)
-    where
-        R: RangeBounds<Vec<DfValue>>,
-    {
+    pub fn insert_range(&mut self, range: BoundedRange<Vec<DfValue>>) {
         match self {
             Handle::Single(h) => {
                 h.insert_range((
                     range.start_bound().map(|r| {
                         debug_assert_eq!(r.len(), 1);
-                        &r[0]
+                        // TODO ethan remove clones
+                        r[0].clone()
                     }),
                     range.end_bound().map(|r| {
                         debug_assert_eq!(r.len(), 1);
-                        &r[0]
+                        r[0].clone()
                     }),
                 ));
             }

--- a/readyset-dataflow/src/node/special/packet_filter.rs
+++ b/readyset-dataflow/src/node/special/packet_filter.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::ops::Bound;
 
 use common::DfValue;
 use readyset_client::KeyComparison;
+use readyset_data::Bound;
 use readyset_errors::{internal, ReadySetResult};
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
@@ -174,7 +174,6 @@ fn check_lower_bound(lower_bound: &Bound<Vec1<DfValue>>, ci: &[usize], row: &[Df
             check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 >= d2)
         }
         Bound::Excluded(bound) => check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 > d2),
-        Bound::Unbounded => true,
     }
 }
 
@@ -184,7 +183,6 @@ fn check_upper_bound(upper_bound: &Bound<Vec1<DfValue>>, ci: &[usize], row: &[Df
             check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 <= d2)
         }
         Bound::Excluded(bound) => check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 < d2),
-        Bound::Unbounded => true,
     }
 }
 
@@ -231,9 +229,8 @@ mod test {
     }
 
     mod update_processing {
-        use std::ops::Bound;
-
         use common::Record;
+        use readyset_data::range;
 
         use super::*;
 
@@ -458,9 +455,9 @@ mod test {
 
             let ni = NodeIndex::new(3);
 
-            let key = KeyComparison::Range((
-                Bound::Included(vec1![10.into()]),
-                Bound::Excluded(vec1![20.into()]),
+            let key = KeyComparison::Range(range!(
+                =vec1![10.into()],
+                vec1![20.into()]
             ));
             let mut keys = HashSet::new();
             keys.insert(key);

--- a/readyset-dataflow/src/ops/join.rs
+++ b/readyset-dataflow/src/ops/join.rs
@@ -607,22 +607,22 @@ impl Ingredient for Join {
                     let mut right_upper =
                         upper.as_ref().map(|_| Vec::with_capacity(right_cols.len()));
 
-                    if let Some(lower_endpoint) = into_bound_endpoint(lower) {
+                    if let Some(lower_endpoint) = into_bound_endpoint(lower.into()) {
                         for (value, side) in lower_endpoint.into_iter().zip(&col_sides) {
                             into_bound_endpoint(match side {
-                                Side::Left => left_lower.as_mut(),
-                                Side::Right => right_lower.as_mut(),
+                                Side::Left => left_lower.as_mut().into(),
+                                Side::Right => right_lower.as_mut().into(),
                             })
                             .unwrap()
                             .push(value);
                         }
                     }
 
-                    if let Some(upper_endpoint) = into_bound_endpoint(upper) {
+                    if let Some(upper_endpoint) = into_bound_endpoint(upper.into()) {
                         for (value, side) in upper_endpoint.into_iter().zip(&col_sides) {
                             into_bound_endpoint(match side {
-                                Side::Left => left_upper.as_mut(),
-                                Side::Right => right_upper.as_mut(),
+                                Side::Left => left_upper.as_mut().into(),
+                                Side::Right => right_upper.as_mut().into(),
                             })
                             .unwrap()
                             .push(value);
@@ -897,7 +897,8 @@ mod tests {
     }
 
     mod handle_upquery {
-        use std::ops::Bound;
+
+        use readyset_data::range;
 
         use super::*;
 
@@ -979,17 +980,17 @@ mod tests {
                 .handle_upquery(ColumnMiss {
                     node,
                     column_indices: vec![0, 1, 2],
-                    missed_keys: vec1![KeyComparison::Range((
-                        Bound::Included(vec1![
+                    missed_keys: vec1![KeyComparison::Range(range!(
+                        =vec1![
                             DfValue::from(1),
                             DfValue::from(2),
                             DfValue::from(3)
-                        ]),
-                        Bound::Excluded(vec1![
+                        ],
+                        vec1![
                             DfValue::from(4),
                             DfValue::from(5),
                             DfValue::from(6)
-                        ])
+                        ]
                     ))],
                 })
                 .unwrap();
@@ -1002,16 +1003,16 @@ mod tests {
 
             assert_eq!(
                 left_miss.missed_keys,
-                vec1![KeyComparison::Range((
-                    Bound::Included(vec1![DfValue::from(1), DfValue::from(2)]),
-                    Bound::Excluded(vec1![DfValue::from(4), DfValue::from(5)])
+                vec1![KeyComparison::Range(range!(
+                    =vec1![DfValue::from(1), DfValue::from(2)],
+                    vec1![DfValue::from(4), DfValue::from(5)]
                 ))]
             );
             assert_eq!(
                 right_miss.missed_keys,
-                vec1![KeyComparison::Range((
-                    Bound::Included(vec1![DfValue::from(3)]),
-                    Bound::Excluded(vec1![DfValue::from(6)])
+                vec1![KeyComparison::Range(range!(
+                    =vec1![DfValue::from(3)],
+                    vec1![DfValue::from(6)]
                 ))]
             );
         }
@@ -1025,13 +1026,13 @@ mod tests {
                 .handle_upquery(ColumnMiss {
                     node,
                     column_indices: vec![0, 1, 2],
-                    missed_keys: vec1![KeyComparison::Range((
-                        Bound::Included(vec1![
+                    missed_keys: vec1![KeyComparison::Range(range!(
+                        =vec1![
                             DfValue::from(1),
                             DfValue::from(2),
                             DfValue::from(3)
-                        ]),
-                        Bound::Unbounded
+                        ],
+                        infinity
                     ))],
                 })
                 .unwrap();
@@ -1044,16 +1045,16 @@ mod tests {
 
             assert_eq!(
                 left_miss.missed_keys,
-                vec1![KeyComparison::Range((
-                    Bound::Included(vec1![DfValue::from(1), DfValue::from(2)]),
-                    Bound::Unbounded
+                vec1![KeyComparison::Range(range!(
+                    vec1![DfValue::from(1), DfValue::from(2)],
+                    infinity
                 ))]
             );
             assert_eq!(
                 right_miss.missed_keys,
-                vec1![KeyComparison::Range((
-                    Bound::Included(vec1![DfValue::from(3)]),
-                    Bound::Unbounded
+                vec1![KeyComparison::Range(range!(
+                    =vec1![DfValue::from(3)],
+                    infinity
                 ))]
             );
         }

--- a/readyset-dataflow/src/processing.rs
+++ b/readyset-dataflow/src/processing.rs
@@ -1,13 +1,14 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
-use std::ops::{Bound, RangeBounds};
 use std::{iter, mem};
 
 use dataflow_state::PointKey;
 use derive_more::From;
 use readyset_client::KeyComparison;
+use readyset_data::BoundedRange;
 use readyset_errors::ReadySetResult;
+use readyset_util::ranges::RangeBounds;
 use readyset_util::Indices;
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
@@ -35,7 +36,7 @@ pub(crate) enum MissReplayKey {
     ///
     /// * The endpoints of the range must be the same length
     /// * The endpoints of the range may not be empty
-    Range((Bound<Vec1<DfValue>>, Bound<Vec1<DfValue>>)),
+    Range(BoundedRange<Vec1<DfValue>>),
 }
 
 /// Indication, for a [`Miss`], for how to derive the key that was used for the lookup that resulted
@@ -228,9 +229,7 @@ impl Miss {
                 .unwrap()
                 .try_into()
                 .unwrap(),
-            MissReplayKey::Range((lower, upper)) => {
-                KeyComparison::Range((lower.clone(), upper.clone()))
-            }
+            MissReplayKey::Range(pair) => KeyComparison::Range(pair.clone()),
         })
     }
 

--- a/readyset-util/Cargo.toml
+++ b/readyset-util/Cargo.toml
@@ -23,6 +23,9 @@ bit-vec = { version = "0.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 async-stream = "0.3.2"
 cidr = "0.2.1"
+thiserror = "1.0.26"
+quickcheck = "0.9"
+rand = "0.7"
 
 [dev-dependencies]
 test-strategy = "0.2.0"

--- a/readyset-util/src/lib.rs
+++ b/readyset-util/src/lib.rs
@@ -17,6 +17,7 @@ pub mod math;
 pub mod nonmaxusize;
 pub mod progress;
 pub mod properties;
+pub mod ranges;
 pub mod redacted;
 pub mod shared_cache;
 pub mod shutdown;

--- a/readyset-util/src/ranges.rs
+++ b/readyset-util/src/ranges.rs
@@ -1,0 +1,199 @@
+//! Utilities for dealing with ranges and bounds.
+use std::hash::Hash;
+use std::ops::{self, Deref};
+use std::str;
+
+use proptest::arbitrary::Arbitrary;
+use proptest::prelude::*;
+use quickcheck::Gen;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+impl<T: quickcheck::Arbitrary> quickcheck::Arbitrary for Bound<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Bound<T> {
+        if g.gen::<bool>() {
+            Bound::Included(T::arbitrary(g))
+        } else {
+            Bound::Excluded(T::arbitrary(g))
+        }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Bound<T>>> {
+        match *self {
+            Bound::Included(ref x) => Box::new(x.shrink().map(Bound::Included)),
+            Bound::Excluded(ref x) => Box::new(x.shrink().map(Bound::Excluded)),
+        }
+    }
+}
+
+impl<T> RangeBounds<T> for (Bound<T>, Bound<T>) {
+    fn start_bound(&self) -> Bound<&T> {
+        self.0.as_ref()
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        self.1.as_ref()
+    }
+}
+
+impl<T: ?Sized> RangeBounds<T> for (Bound<&T>, Bound<&T>) {
+    fn start_bound(&self) -> Bound<&T> {
+        self.0
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        self.1
+    }
+}
+
+/// A trait that mirrors the functionality of [`std::ops::RangeBounds`] but whose bounds are never
+/// unbounded.
+pub trait RangeBounds<T: ?Sized> {
+    /// Returns the start bound of the range.
+    fn start_bound(&self) -> Bound<&T>;
+
+    /// Returns the end bound of the range.
+    fn end_bound(&self) -> Bound<&T>;
+
+    /// Returns `self` represented as a tuple of [`std::ops::Bound`]s.
+    fn as_std_range(&self) -> (ops::Bound<&T>, ops::Bound<&T>) {
+        (self.start_bound().into(), self.end_bound().into())
+    }
+
+    /// Returns true only if the range contains the given item.
+    fn contains<U>(&self, item: &U) -> bool
+    where
+        T: PartialOrd<U>,
+        U: ?Sized + PartialOrd<T>,
+    {
+        (match self.start_bound() {
+            Bound::Included(start) => start <= item,
+            Bound::Excluded(start) => start < item,
+        }) && (match self.end_bound() {
+            Bound::Included(end) => item <= end,
+            Bound::Excluded(end) => item < end,
+        })
+    }
+}
+
+/// docs
+#[derive(Error, Debug)]
+#[error("Cannot convert std::ops::Bound::Unbounded to readyset_data::Bound")]
+pub struct BoundConversionError;
+
+impl<T> TryFrom<ops::Bound<T>> for Bound<T> {
+    type Error = BoundConversionError;
+
+    fn try_from(value: ops::Bound<T>) -> Result<Self, Self::Error> {
+        match value {
+            ops::Bound::Included(b) => Ok(Bound::Included(b)),
+            ops::Bound::Excluded(b) => Ok(Bound::Excluded(b)),
+            ops::Bound::Unbounded => Err(BoundConversionError),
+        }
+    }
+}
+
+// TODO ethan
+/// docs
+pub type BoundedRange<T> = (Bound<T>, Bound<T>);
+
+/// docs
+#[derive(Copy, Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum Bound<T> {
+    /// docs
+    Included(T),
+    /// docs
+    Excluded(T),
+}
+
+impl<T> Arbitrary for Bound<T>
+where
+    T: Arbitrary + 'static,
+    T::Parameters: Clone,
+{
+    type Parameters = T::Parameters;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            any_with::<T>(args.clone()).prop_map(Bound::Included),
+            any_with::<T>(args).prop_map(Bound::Excluded)
+        ]
+        .boxed()
+    }
+}
+
+impl<T> Bound<T> {
+    /// docs
+    pub fn inner(&self) -> &T {
+        match self {
+            Bound::Included(b) => b,
+            Bound::Excluded(b) => b,
+        }
+    }
+
+    /// docs
+    pub fn as_mut(&mut self) -> Bound<&mut T> {
+        match *self {
+            Bound::Included(ref mut b) => Bound::Included(b),
+            Bound::Excluded(ref mut b) => Bound::Excluded(b),
+        }
+    }
+
+    /// docs
+    pub fn map<U, F>(self, f: F) -> Bound<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Bound::Included(b) => Bound::Included(f(b)),
+            Bound::Excluded(b) => Bound::Excluded(f(b)),
+        }
+    }
+
+    /// docs
+    pub fn as_ref(&self) -> Bound<&T> {
+        match self {
+            Bound::Excluded(b) => Bound::Excluded(b),
+            Bound::Included(b) => Bound::Included(b),
+        }
+    }
+}
+
+impl<T> Bound<&T>
+where
+    T: Clone,
+{
+    /// docs
+    pub fn cloned(&self) -> Bound<T> {
+        match *self {
+            Bound::Excluded(b) => Bound::Excluded(b.clone()),
+            Bound::Included(b) => Bound::Included(b.clone()),
+        }
+    }
+}
+
+impl<T> From<Bound<T>> for ops::Bound<T> {
+    fn from(value: Bound<T>) -> Self {
+        match value {
+            Bound::Included(b) => ops::Bound::Included(b),
+            Bound::Excluded(b) => ops::Bound::Excluded(b),
+        }
+    }
+}
+
+impl<T, I> Bound<T>
+where
+    T: Deref<Target = [I]>,
+{
+    /// docs
+    pub fn len(&self) -> usize {
+        self.inner().len()
+    }
+
+    /// docs
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}


### PR DESCRIPTION
This commit adds a new `BoundedRange` type, which represents ranges that
are necessarily bounded. This will be used in a future commit to ensure
that we never include unbounded bounds in range keys: NULLs should never
be included in result sets returned by range keys, so we need to make
sure we include NULL as an exclusive lower bound on range keys that
"look" unbounded (e.g. x < 1).

