### PR TITLE
util: Add BoundRange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4754,7 +4754,9 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "triomphe",
+ "tuple",
  "uuid 0.8.2",
+ "vec1",
 ]
 
 [[package]]
@@ -5234,6 +5236,7 @@ dependencies = [
  "serde",
  "serde_json",
  "test-strategy",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid 0.8.2",

--- a/dataflow-state/benches/persistent_state.rs
+++ b/dataflow-state/benches/persistent_state.rs
@@ -46,6 +46,7 @@ use dataflow_state::{
 };
 use itertools::Itertools;
 use readyset_data::DfValue;
+use readyset_util::ranges::BoundRange;
 
 lazy_static::lazy_static! {
     static ref LARGE_STRINGS: Vec<String> = ["a", "b", "c"]
@@ -186,7 +187,7 @@ pub fn rocksdb_range_lookup(c: &mut Criterion, state: &PersistentState) {
         b.iter(|| {
             black_box(state.lookup_range(
                 &[1],
-                &RangeKey::Single((Bound::Included(key.clone()), Bound::Unbounded)),
+                &RangeKey::Single(BoundRange(Bound::Included(key.clone()), Bound::Unbounded)),
             ));
         })
     });
@@ -201,7 +202,7 @@ pub fn rocksdb_range_lookup_large_strings(c: &mut Criterion, state: &PersistentS
         b.iter(|| {
             black_box(state.lookup_range(
                 &[1],
-                &RangeKey::Single((Bound::Included(key.clone()), Bound::Unbounded)),
+                &RangeKey::Single(BoundRange(Bound::Included(key.clone()), Bound::Unbounded)),
             ));
         })
     });

--- a/dataflow-state/src/lib.rs
+++ b/dataflow-state/src/lib.rs
@@ -10,7 +10,7 @@ mod single_state;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
 use std::iter::FromIterator;
-use std::ops::{Bound, Deref};
+use std::ops::Deref;
 use std::rc::Rc;
 use std::vec;
 
@@ -25,6 +25,7 @@ use readyset_client::internal::Index;
 use readyset_client::{KeyComparison, PersistencePoint};
 use readyset_data::DfValue;
 use readyset_errors::ReadySetResult;
+use readyset_util::ranges::BoundRange;
 use replication_offset::ReplicationOffset;
 use serde::{Deserialize, Serialize};
 
@@ -746,7 +747,7 @@ impl<'a> LookupResult<'a> {
     }
 }
 
-pub type Misses = Vec<(Bound<Vec<DfValue>>, Bound<Vec<DfValue>>)>;
+pub type Misses = Vec<BoundRange<Vec<DfValue>>>;
 
 #[derive(Eq, PartialEq, Debug)]
 pub enum RangeLookupResult<'a> {

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use common::{IndexType, Record, Records, SizeOf, Tag};
@@ -204,78 +204,31 @@ impl State for MemoryState {
         // resulting in upqueries along an overlapping replay path.
         // FIXME(eta): a lot of this could be computed at index addition time.
         for state in self.state.iter() {
-            // Try other index types with the same columns
-            if state.columns() == columns && state.index_type() != self.state[index].index_type() {
-                let res = state.lookup(key);
-                if res.is_some() {
-                    return res;
-                }
-            }
-
-            // We might have another index with the same columns in another order
-            if state.columns() != columns && state.columns().len() == columns.len() {
-                // Make a map from column index -> the position in the index we're trying to do a
-                // lookup into
-                //
-                // eg if we're mapping [3, 4] to [4, 3]
-                // we get {4 => 0, 3 => 1}
-                let col_positions = state
-                    .columns()
-                    .iter()
-                    .copied()
-                    .enumerate()
-                    .map(|(idx, col)| (col, idx))
-                    .collect::<BTreeMap<_, _>>();
-                if columns.iter().all(|c| col_positions.contains_key(c)) {
-                    let mut shuffled_key = vec![DfValue::None; key.len()];
-                    for (key_pos, col) in columns.iter().enumerate() {
-                        let val = key
-                            .get(key_pos)
-                            .expect("Columns and key must have the same len");
-                        let pos = col_positions[col];
-                        shuffled_key[pos] = val.clone();
-                    }
-                    let key = PointKey::from(shuffled_key);
-                    let res = state.lookup(&key);
-                    if res.is_some() {
-                        return res;
-                    }
-                }
-            }
-
-            // otherwise the length must be strictly less than, because otherwise it's either the
-            // same index, or we'd have to magic up datatypes out of thin air
-            if state.columns().len() < columns.len() {
+            // We can only perform lookups on states that are indexed only on the columns in the key
+            // passed into this method
+            if state.columns().iter().all(|col| columns.contains(col)) {
                 // For each column in `columns`, find the corresponding column in `state.key()`,
                 // if there is one, and return (its position in state.key(), its value from `key`).
                 // FIXME(eta): this seems accidentally quadratic.
-                let mut positions = columns
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, col_idx)| {
-                        state
-                            .columns()
+                let vals = state.columns().iter().map(|col| {
+                    let i = columns.iter().position(|c| col == c).unwrap();
+                    key.get(i).unwrap().clone()
+                });
+                let kt = PointKey::from(vals);
+                if let LookupResult::Some(mut ret) = state.lookup(&kt) {
+                    // Filter the rows in this index to ones which actually match the key. This
+                    // is required if the desired key is a superset of the key we are looking up
+                    // here. For example, if the columns passed into this method were [0, 1] and we
+                    // do a lookup here on [0], we need to filter out the rows that don't match our
+                    // key on column 1
+                    // FIXME(eta): again, probably O(terrible)
+                    ret.retain(|row| {
+                        columns
                             .iter()
-                            .position(|x| x == col_idx)
-                            .map(|pos| (pos, key.get(i).expect("bogus key passed to lookup")))
-                    })
-                    .collect::<Vec<_>>();
-                if positions.len() == state.columns().len() {
-                    // the index only contains columns from `columns` (and none other).
-                    // make a new lookup key
-                    positions.sort_unstable_by_key(|(idx, _)| *idx);
-                    let kt = PointKey::from(positions.into_iter().map(|(_, val)| val.clone()));
-                    if let LookupResult::Some(mut ret) = state.lookup(&kt) {
-                        // filter the rows in this index to ones which actually match the key
-                        // FIXME(eta): again, probably O(terrible)
-                        ret.retain(|row| {
-                            columns
-                                .iter()
-                                .enumerate()
-                                .all(|(key_idx, &col_idx)| row.get(col_idx) == key.get(key_idx))
-                        });
-                        return LookupResult::Some(ret);
-                    }
+                            .enumerate()
+                            .all(|(key_idx, &col_idx)| row.get(col_idx) == key.get(key_idx))
+                    });
+                    return LookupResult::Some(ret);
                 }
             }
         }
@@ -666,6 +619,74 @@ mod tests {
         );
     }
 
+    // Tests that lookups on keys with duplicate columns can perform lookups on states with
+    // deduplicated set of columns
+    #[test]
+    fn duplicate_columns() {
+        let mut state = MemoryState::default();
+        state.add_index(Index::hash_map(vec![0]), Some(vec![Tag::new(0)]));
+        state.add_index(Index::hash_map(vec![0, 0]), Some(vec![Tag::new(1)]));
+
+        state.mark_filled(KeyComparison::Equal(vec1![1.into()]), Tag::new(0));
+        state.insert(
+            vec![1.into(), 1.into(), 1.into(), 1.into()],
+            Some(Tag::new(0)),
+        );
+
+        let res = state.lookup(&[0, 0], &PointKey::Double((1.into(), 1.into())));
+        assert!(res.is_some());
+        let rows = res.unwrap();
+        assert_eq!(
+            rows,
+            RecordResult::Owned(vec![vec![1.into(), 1.into(), 1.into(), 1.into()]])
+        );
+    }
+
+    // Tests that a lookup on a superset of columns in another index will still find the rows in
+    // that index
+    #[test]
+    fn superset_lookup() {
+        let mut state = MemoryState::default();
+        state.add_index(Index::hash_map(vec![0]), Some(vec![Tag::new(0)]));
+        state.add_index(Index::hash_map(vec![0, 1]), Some(vec![Tag::new(1)]));
+
+        state.mark_filled(KeyComparison::Equal(vec1![1.into()]), Tag::new(0));
+        state.insert(
+            vec![1.into(), 2.into(), 3.into(), 4.into()],
+            Some(Tag::new(0)),
+        );
+        state.insert(
+            vec![1.into(), 3.into(), 4.into(), 5.into()],
+            Some(Tag::new(0)),
+        );
+
+        let res = state.lookup(&[0, 1], &PointKey::Double((1.into(), 2.into())));
+        assert!(res.is_some());
+        let rows = res.unwrap();
+        assert_eq!(
+            rows,
+            RecordResult::Owned(vec![vec![1.into(), 2.into(), 3.into(), 4.into()]])
+        );
+    }
+
+    // Tests that lookups on a subset of columns from another index do not return rows from that
+    // index
+    #[test]
+    fn subset_lookup_miss() {
+        let mut state = MemoryState::default();
+        state.add_index(Index::hash_map(vec![0]), Some(vec![Tag::new(0)]));
+        state.add_index(Index::hash_map(vec![0, 1]), Some(vec![Tag::new(1)]));
+
+        state.mark_filled(KeyComparison::Equal(vec1![1.into(), 2.into()]), Tag::new(1));
+        state.insert(
+            vec![1.into(), 2.into(), 3.into(), 4.into()],
+            Some(Tag::new(1)),
+        );
+
+        let res = state.lookup(&[0], &PointKey::Single(1.into()));
+        assert!(res.is_missing());
+    }
+
     #[test]
     fn shuffled_columns() {
         let mut state = MemoryState::default();
@@ -1034,6 +1055,7 @@ mod tests {
     }
 
     mod weak_index_proptest {
+        use std::collections::BTreeMap;
         use std::ops::RangeInclusive;
         use std::time::Duration;
 

--- a/dataflow-state/src/memory_state.rs
+++ b/dataflow-state/src/memory_state.rs
@@ -499,6 +499,7 @@ mod tests {
     use std::convert::TryInto;
     use std::ops::Bound;
 
+    use readyset_util::ranges::BoundRange;
     use vec1::vec1;
 
     use super::*;
@@ -596,7 +597,7 @@ mod tests {
             state
                 .lookup_range(
                     &[0],
-                    &RangeKey::Single((Bound::Unbounded, Bound::Included(3.into())))
+                    &RangeKey::Single(BoundRange(Bound::Unbounded, Bound::Included(3.into())))
                 )
                 .unwrap()
                 .len(),
@@ -790,7 +791,7 @@ mod tests {
                 let range = vec1![DfValue::from(11)]..vec1![DfValue::from(20)];
                 assert_eq!(
                     state.lookup_range(&[0], &RangeKey::from(&range)),
-                    RangeLookupResult::Missing(vec![(
+                    RangeLookupResult::Missing(vec![BoundRange(
                         range.start_bound().map(Vec1::as_vec).cloned(),
                         range.end_bound().map(Vec1::as_vec).cloned()
                     )])

--- a/dataflow-state/src/single_state.rs
+++ b/dataflow-state/src/single_state.rs
@@ -1,4 +1,4 @@
-use std::ops::{Bound, RangeBounds};
+use std::ops::Bound;
 use std::rc::Rc;
 
 use common::{IndexType, SizeOf};
@@ -6,6 +6,7 @@ use itertools::Either;
 use readyset_client::internal::Index;
 use readyset_client::KeyComparison;
 use readyset_data::DfValue;
+use readyset_util::ranges::BoundRange;
 use vec1::Vec1;
 
 use crate::keyed_state::KeyedState;
@@ -48,7 +49,7 @@ impl SingleState {
         if !partial && index.index_type == IndexType::BTreeMap {
             // For fully materialized indices, we never miss - so mark that the full range of keys
             // has been filled.
-            state.insert_range((Bound::Unbounded, Bound::Unbounded))
+            state.insert_range(BoundRange(Bound::Unbounded, Bound::Unbounded))
         }
         Self {
             index,
@@ -213,7 +214,7 @@ impl SingleState {
         assert!(replaced.is_none());
     }
 
-    fn mark_range_filled(&mut self, range: (Bound<Vec1<DfValue>>, Bound<Vec1<DfValue>>)) {
+    fn mark_range_filled(&mut self, range: BoundRange<Vec1<DfValue>>) {
         self.state.insert_range(range);
     }
 
@@ -460,7 +461,7 @@ mod tests {
     #[test]
     fn mark_filled_range() {
         let mut state = SingleState::new(Index::new(IndexType::BTreeMap, vec![0]), true);
-        state.mark_filled(KeyComparison::Range((
+        state.mark_filled(KeyComparison::Range(BoundRange(
             Bound::Included(vec1![0.into()]),
             Bound::Excluded(vec1![5.into()]),
         )));

--- a/readyset-data/Cargo.toml
+++ b/readyset-data/Cargo.toml
@@ -35,6 +35,8 @@ nom_locate = "4.0.0"
 postgres-protocol = { workspace = true }
 cidr = "0.2.1"
 postgres-types = { workspace = true, features = ["with-cidr-0_2"] }
+vec1 = "1.6"
+tuple = "0.5"
 
 # Local dependencies
 nom-sql = { path = "../nom-sql" }

--- a/readyset-data/src/bounds.rs
+++ b/readyset-data/src/bounds.rs
@@ -1,0 +1,60 @@
+use std::ops;
+
+pub use readyset_util::ranges::BoundRange;
+use tuple::TupleElements;
+use vec1::Vec1;
+
+use super::DfValue;
+
+pub trait IntoBoundRange: Sized {
+    fn map_value(&self, value: DfValue) -> Self;
+
+    fn greater_than(self) -> BoundRange<Self> {
+        let upper = self.map_value(DfValue::MAX_VALUE);
+        BoundRange(ops::Bound::Excluded(self), ops::Bound::Excluded(upper))
+    }
+
+    fn greater_than_or_equal_to(self) -> BoundRange<Self> {
+        let upper = self.map_value(DfValue::MAX_VALUE);
+        BoundRange(ops::Bound::Excluded(self), ops::Bound::Included(upper))
+    }
+
+    fn less_than(self) -> BoundRange<Self> {
+        let lower = self.map_value(DfValue::MIN_VALUE);
+        BoundRange(ops::Bound::Excluded(lower), ops::Bound::Excluded(self))
+    }
+
+    fn less_than_or_equal_to(self) -> BoundRange<Self> {
+        let lower = self.map_value(DfValue::MIN_VALUE);
+        BoundRange(ops::Bound::Included(lower), ops::Bound::Excluded(self))
+    }
+}
+
+impl IntoBoundRange for Vec1<DfValue> {
+    fn map_value(&self, value: DfValue) -> Self {
+        self.mapped_ref(|_| value.clone())
+    }
+}
+
+impl IntoBoundRange for DfValue {
+    fn map_value(&self, value: DfValue) -> Self {
+        value
+    }
+}
+
+// TODO ethan performance?
+macro_rules! impl_into_bound_pair_tuple {
+    ($tuple:ty) => {
+        impl IntoBoundRange for $tuple {
+            fn map_value(&self, value: DfValue) -> Self {
+                <$tuple>::from_iter(self.elements().map(|_| value.clone())).unwrap()
+            }
+        }
+    };
+}
+
+impl_into_bound_pair_tuple!((DfValue,));
+impl_into_bound_pair_tuple!((DfValue, DfValue));
+impl_into_bound_pair_tuple!((DfValue, DfValue, DfValue));
+impl_into_bound_pair_tuple!((DfValue, DfValue, DfValue, DfValue));
+impl_into_bound_pair_tuple!((DfValue, DfValue, DfValue, DfValue, DfValue));

--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -31,6 +31,7 @@ use tokio_postgres::types::{to_sql_checked, FromSql, IsNull, Kind, ToSql, Type};
 use uuid::Uuid;
 
 mod array;
+mod bounds;
 mod collation;
 pub mod dialect;
 mod r#enum;
@@ -179,6 +180,9 @@ impl fmt::Display for DfValue {
 pub const TIME_FORMAT: &str = "%H:%M:%S";
 
 impl DfValue {
+    pub const MIN_VALUE: Self = Self::None;
+    pub const MAX_VALUE: Self = Self::Max;
+
     /// Construct a new [`DfValue::Array`] containing an empty array
     pub fn empty_array() -> Self {
         // TODO: static singleton empty array?

--- a/readyset-dataflow/src/node/special/packet_filter.rs
+++ b/readyset-dataflow/src/node/special/packet_filter.rs
@@ -5,6 +5,7 @@ use std::ops::Bound;
 use common::DfValue;
 use readyset_client::KeyComparison;
 use readyset_errors::{internal, ReadySetResult};
+use readyset_util::ranges::BoundRange;
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
 
@@ -103,7 +104,7 @@ impl PacketFilter {
                             KeyComparison::Equal(ref cond) => {
                                 check_bound(ci, row, cond, |d1, d2| d1 == d2)
                             }
-                            KeyComparison::Range((ref lower_bound, ref upper_bound)) => {
+                            KeyComparison::Range(BoundRange(ref lower_bound, ref upper_bound)) => {
                                 check_lower_bound(lower_bound, ci, row)
                                     && check_upper_bound(upper_bound, ci, row)
                             }
@@ -234,6 +235,7 @@ mod test {
         use std::ops::Bound;
 
         use common::Record;
+        use readyset_util::ranges::BoundRange;
 
         use super::*;
 
@@ -458,7 +460,7 @@ mod test {
 
             let ni = NodeIndex::new(3);
 
-            let key = KeyComparison::Range((
+            let key = KeyComparison::Range(BoundRange(
                 Bound::Included(vec1![10.into()]),
                 Bound::Excluded(vec1![20.into()]),
             ));

--- a/readyset-dataflow/src/ops/join.rs
+++ b/readyset-dataflow/src/ops/join.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use readyset_client::KeyComparison;
 use readyset_errors::{internal_err, ReadySetResult};
 use readyset_util::intervals::into_bound_endpoint;
+use readyset_util::ranges::BoundRange;
 use readyset_util::Indices;
 use serde::{Deserialize, Serialize};
 use vec1::{vec1, Vec1};
@@ -597,7 +598,7 @@ impl Ingredient for Join {
                         })?,
                     )
                 }
-                KeyComparison::Range((lower, upper)) => {
+                KeyComparison::Range(BoundRange(lower, upper)) => {
                     let mut left_lower =
                         lower.as_ref().map(|_| Vec::with_capacity(left_cols.len()));
                     let mut right_lower =
@@ -633,11 +634,11 @@ impl Ingredient for Join {
                     // If any of these is empty, that means the columns weren't actually straddling
                     // both parents - which is an invariant of this function!
                     (
-                        KeyComparison::Range((
+                        KeyComparison::Range(BoundRange(
                             left_lower.map(|k| k.try_into().unwrap()),
                             left_upper.map(|k| k.try_into().unwrap()),
                         )),
-                        KeyComparison::Range((
+                        KeyComparison::Range(BoundRange(
                             right_lower.map(|k| k.try_into().unwrap()),
                             right_upper.map(|k| k.try_into().unwrap()),
                         )),
@@ -979,7 +980,7 @@ mod tests {
                 .handle_upquery(ColumnMiss {
                     node,
                     column_indices: vec![0, 1, 2],
-                    missed_keys: vec1![KeyComparison::Range((
+                    missed_keys: vec1![KeyComparison::Range(BoundRange(
                         Bound::Included(vec1![
                             DfValue::from(1),
                             DfValue::from(2),
@@ -1002,14 +1003,14 @@ mod tests {
 
             assert_eq!(
                 left_miss.missed_keys,
-                vec1![KeyComparison::Range((
+                vec1![KeyComparison::Range(BoundRange(
                     Bound::Included(vec1![DfValue::from(1), DfValue::from(2)]),
                     Bound::Excluded(vec1![DfValue::from(4), DfValue::from(5)])
                 ))]
             );
             assert_eq!(
                 right_miss.missed_keys,
-                vec1![KeyComparison::Range((
+                vec1![KeyComparison::Range(BoundRange(
                     Bound::Included(vec1![DfValue::from(3)]),
                     Bound::Excluded(vec1![DfValue::from(6)])
                 ))]
@@ -1025,7 +1026,7 @@ mod tests {
                 .handle_upquery(ColumnMiss {
                     node,
                     column_indices: vec![0, 1, 2],
-                    missed_keys: vec1![KeyComparison::Range((
+                    missed_keys: vec1![KeyComparison::Range(BoundRange(
                         Bound::Included(vec1![
                             DfValue::from(1),
                             DfValue::from(2),
@@ -1044,14 +1045,14 @@ mod tests {
 
             assert_eq!(
                 left_miss.missed_keys,
-                vec1![KeyComparison::Range((
+                vec1![KeyComparison::Range(BoundRange(
                     Bound::Included(vec1![DfValue::from(1), DfValue::from(2)]),
                     Bound::Unbounded
                 ))]
             );
             assert_eq!(
                 right_miss.missed_keys,
-                vec1![KeyComparison::Range((
+                vec1![KeyComparison::Range(BoundRange(
                     Bound::Included(vec1![DfValue::from(3)]),
                     Bound::Unbounded
                 ))]

--- a/readyset-dataflow/src/processing.rs
+++ b/readyset-dataflow/src/processing.rs
@@ -1,13 +1,14 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
-use std::ops::{Bound, RangeBounds};
+use std::ops::RangeBounds;
 use std::{iter, mem};
 
 use dataflow_state::PointKey;
 use derive_more::From;
 use readyset_client::KeyComparison;
 use readyset_errors::ReadySetResult;
+use readyset_util::ranges::BoundRange;
 use readyset_util::Indices;
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
@@ -35,7 +36,7 @@ pub(crate) enum MissReplayKey {
     ///
     /// * The endpoints of the range must be the same length
     /// * The endpoints of the range may not be empty
-    Range((Bound<Vec1<DfValue>>, Bound<Vec1<DfValue>>)),
+    Range(BoundRange<Vec1<DfValue>>),
 }
 
 /// Indication, for a [`Miss`], for how to derive the key that was used for the lookup that resulted
@@ -178,7 +179,7 @@ impl<'a> MissBuilder<'a> {
                     // NOTE: Since overlapping range queries will be deduplicated by the domain, we
                     // can be assured that we will find at most one range that covers our record
                     // here.
-                    .find(|(lower, upper)| {
+                    .find(|BoundRange(lower, upper)| {
                         (
                             lower.as_ref().map(|b| b.as_ref()),
                             upper.as_ref().map(|b| b.as_ref()),
@@ -228,8 +229,8 @@ impl Miss {
                 .unwrap()
                 .try_into()
                 .unwrap(),
-            MissReplayKey::Range((lower, upper)) => {
-                KeyComparison::Range((lower.clone(), upper.clone()))
+            MissReplayKey::Range(BoundRange(lower, upper)) => {
+                KeyComparison::Range(BoundRange(lower.clone(), upper.clone()))
             }
         })
     }

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -39,6 +39,7 @@ use readyset_client::{KeyComparison, Modification, SchemaType, ViewPlaceholder, 
 use readyset_data::{DfType, DfValue, Dialect};
 use readyset_errors::ReadySetError::{self, RpcFailed, SelectQueryCreationFailed};
 use readyset_util::eventually;
+use readyset_util::ranges::BoundRange;
 use readyset_util::shutdown::ShutdownSender;
 use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
@@ -7091,7 +7092,7 @@ async fn straddled_join_range_query() {
 
     let rows = q
         .multi_lookup(
-            vec![KeyComparison::Range((
+            vec![KeyComparison::Range(BoundRange(
                 Bound::Excluded(vec1![1i32.into(), 1i32.into()]),
                 Bound::Unbounded,
             ))],
@@ -7145,7 +7146,7 @@ async fn overlapping_range_queries() {
             let mut q = g.view("q").await.unwrap().into_reader_handle().unwrap();
             let results = q
                 .multi_lookup(
-                    vec![KeyComparison::Range((
+                    vec![KeyComparison::Range(BoundRange(
                         Bound::Included(vec1![DfValue::from(m * 10)]),
                         Bound::Unbounded,
                     ))],
@@ -7219,7 +7220,7 @@ async fn overlapping_remapped_range_queries() {
             let mut q = g.view("q").await.unwrap().into_reader_handle().unwrap();
             let results = q
                 .multi_lookup(
-                    vec![KeyComparison::Range((
+                    vec![KeyComparison::Range(BoundRange(
                         Bound::Included(vec1![DfValue::from(m * 10), DfValue::from(m * 10)]),
                         Bound::Unbounded,
                     ))],
@@ -7293,7 +7294,7 @@ async fn range_query_through_union() {
 
     let rows = q
         .multi_lookup(
-            vec![KeyComparison::Range((
+            vec![KeyComparison::Range(BoundRange(
                 Bound::Excluded(vec1![1.into()]),
                 Bound::Unbounded,
             ))],
@@ -7924,7 +7925,7 @@ async fn aggressive_eviction_range_impl() {
     for i in (0..500).rev() {
         let offset = i % 10;
         let vq = ViewQuery::from((
-            vec![KeyComparison::Range((
+            vec![KeyComparison::Range(BoundRange(
                 Bound::Included(vec1![DfValue::Int(offset)]),
                 Bound::Excluded(vec1![DfValue::Int(offset + 20)]),
             ))],

--- a/readyset-util/Cargo.toml
+++ b/readyset-util/Cargo.toml
@@ -23,6 +23,7 @@ bit-vec = { version = "0.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 async-stream = "0.3.2"
 cidr = "0.2.1"
+thiserror = "1.0.26"
 
 [dev-dependencies]
 test-strategy = "0.2.0"

--- a/readyset-util/src/lib.rs
+++ b/readyset-util/src/lib.rs
@@ -17,6 +17,7 @@ pub mod math;
 pub mod nonmaxusize;
 pub mod progress;
 pub mod properties;
+pub mod ranges;
 pub mod redacted;
 pub mod shared_cache;
 pub mod shutdown;

--- a/readyset-util/src/ranges.rs
+++ b/readyset-util/src/ranges.rs
@@ -1,0 +1,200 @@
+//! docs
+use std::hash::Hash;
+use std::ops::{self, Deref, RangeBounds};
+use std::str;
+
+use proptest::arbitrary::Arbitrary;
+use proptest::prelude::*;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+impl<T> RangeBounds<T> for &BoundRange<T> {
+    fn start_bound(&self) -> ops::Bound<&T> {
+        self.0.as_ref()
+    }
+
+    fn end_bound(&self) -> ops::Bound<&T> {
+        self.1.as_ref()
+    }
+}
+
+impl<T> RangeBounds<T> for BoundRange<T> {
+    fn start_bound(&self) -> ops::Bound<&T> {
+        self.0.as_ref()
+    }
+
+    fn end_bound(&self) -> ops::Bound<&T> {
+        self.1.as_ref()
+    }
+}
+
+impl<T> RangeBounds<T> for BoundRange<&T>
+where
+    T: ?Sized,
+{
+    fn start_bound(&self) -> ops::Bound<&T> {
+        self.0
+    }
+
+    fn end_bound(&self) -> ops::Bound<&T> {
+        self.1
+    }
+}
+
+// TODO ethan deduplicate/fix these/remove clones
+impl<T> RangeBounds<T> for &BoundRange<&T>
+where
+    T: ?Sized,
+{
+    fn start_bound(&self) -> ops::Bound<&T> {
+        self.0
+    }
+
+    fn end_bound(&self) -> ops::Bound<&T> {
+        self.1
+    }
+}
+
+/// docs
+#[derive(Debug, Copy, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub struct BoundRange<T>(pub ops::Bound<T>, pub ops::Bound<T>);
+
+impl<T> BoundRange<T> {
+    /// docs
+    pub fn start_bound(&self) -> ops::Bound<&T> {
+        self.0.as_ref()
+    }
+
+    /// docs
+    pub fn end_bound(&self) -> ops::Bound<&T> {
+        self.1.as_ref()
+    }
+
+    /// docs
+    pub fn as_ref(&self) -> BoundRange<&T> {
+        BoundRange(self.0.as_ref(), self.1.as_ref())
+    }
+}
+
+impl<T> From<(ops::Bound<T>, ops::Bound<T>)> for BoundRange<T> {
+    fn from(value: (ops::Bound<T>, ops::Bound<T>)) -> Self {
+        BoundRange(value.0, value.1)
+    }
+}
+
+/// docs
+#[derive(Error, Debug)]
+#[error("Cannot convert std::ops::Bound::Unbounded to readyset_data::Bound")]
+pub struct BoundConversionError;
+
+impl<T> TryFrom<ops::Bound<T>> for Bound<T> {
+    type Error = BoundConversionError;
+
+    fn try_from(value: ops::Bound<T>) -> Result<Self, Self::Error> {
+        match value {
+            ops::Bound::Included(b) => Ok(Bound::Included(b)),
+            ops::Bound::Excluded(b) => Ok(Bound::Excluded(b)),
+            ops::Bound::Unbounded => Err(BoundConversionError),
+        }
+    }
+}
+
+/// docs
+#[derive(Copy, Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum Bound<T> {
+    /// docs
+    Included(T),
+    /// docs
+    Excluded(T),
+}
+
+impl<T> Arbitrary for Bound<T>
+where
+    T: Arbitrary + 'static,
+    T::Parameters: Clone,
+{
+    type Parameters = T::Parameters;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            any_with::<T>(args.clone()).prop_map(Bound::Included),
+            any_with::<T>(args).prop_map(Bound::Excluded)
+        ]
+        .boxed()
+    }
+}
+
+impl<T> Bound<T> {
+    /// docs
+    pub fn inner(&self) -> &T {
+        match self {
+            Bound::Included(b) => b,
+            Bound::Excluded(b) => b,
+        }
+    }
+
+    /// docs
+    pub fn as_mut(&mut self) -> Bound<&mut T> {
+        match *self {
+            Bound::Included(ref mut b) => Bound::Included(b),
+            Bound::Excluded(ref mut b) => Bound::Excluded(b),
+        }
+    }
+
+    /// docs
+    pub fn map<U, F>(self, f: F) -> Bound<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Bound::Included(b) => Bound::Included(f(b)),
+            Bound::Excluded(b) => Bound::Excluded(f(b)),
+        }
+    }
+
+    /// docs
+    pub fn as_ref(&self) -> Bound<&T> {
+        match self {
+            Bound::Excluded(b) => Bound::Excluded(b),
+            Bound::Included(b) => Bound::Included(b),
+        }
+    }
+}
+
+impl<T> Bound<&T>
+where
+    T: Clone,
+{
+    /// docs
+    pub fn cloned(&self) -> Bound<T> {
+        match *self {
+            Bound::Excluded(b) => Bound::Excluded(b.clone()),
+            Bound::Included(b) => Bound::Included(b.clone()),
+        }
+    }
+}
+
+impl<T> From<Bound<T>> for ops::Bound<T> {
+    fn from(value: Bound<T>) -> Self {
+        match value {
+            Bound::Included(b) => ops::Bound::Included(b),
+            Bound::Excluded(b) => ops::Bound::Excluded(b),
+        }
+    }
+}
+
+impl<T, I> Bound<T>
+where
+    T: Deref<Target = [I]>,
+{
+    /// docs
+    pub fn len(&self) -> usize {
+        self.inner().len()
+    }
+
+    /// docs
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}


### PR DESCRIPTION
This commit adds a new `BoundRange` type to encapsulate the ranges we
use to lookup keys in B-Tree indexes. Currently, `BoundRange` just
contains two `std::ops::Bound`s, but in a future commit, that `Bound`
type will be replaced with a custom `Bound` enum without an `Unbounded`
variant. This sets the stage for us to fix issues relating to range
queries that errantly include NULL values in result sets: we should
*never* include true unbounded bounds on a range key because NULL values
should never be considered "included" in a range key.

