### PR TITLE
build: Bump readyset version number for debian pkg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "readyset"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readyset"
-version = "1.1.0"
+version = "1.2.0"
 publish = false
 authors = ["ReadySet Technology, Inc. <info@readyset.io>"]
 edition = "2021"


### PR DESCRIPTION
The debian release package gets its version number from the readyset
version number in Cargo.toml.

