### PR TITLE
readyset-server: Remove unneeded #[allow(dead_code)]

### DIFF
--- a/readyset-server/src/handle.rs
+++ b/readyset-server/src/handle.rs
@@ -17,7 +17,6 @@ pub struct Handle {
     /// Has a valid controller handle on `new` and is set to None if the
     /// controller has been shutdown.
     pub c: Option<ReadySetHandle>,
-    #[allow(dead_code)]
     event_tx: Option<Sender<HandleRequest>>,
     descriptor: ControllerDescriptor,
 }


### PR DESCRIPTION
The event_tx is used, so this allow is not needed and is itself the dead
code.

