### PR TITLE
readyset-util+data: Add range utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4755,6 +4755,7 @@ dependencies = [
  "tokio-postgres",
  "triomphe",
  "uuid 0.8.2",
+ "vec1",
 ]
 
 [[package]]
@@ -5230,10 +5231,13 @@ dependencies = [
  "eui48",
  "futures",
  "proptest",
+ "quickcheck",
+ "rand 0.7.3",
  "rust_decimal",
  "serde",
  "serde_json",
  "test-strategy",
+ "thiserror",
  "tokio",
  "tracing",
  "uuid 0.8.2",

--- a/readyset-data/Cargo.toml
+++ b/readyset-data/Cargo.toml
@@ -35,6 +35,7 @@ nom_locate = "4.0.0"
 postgres-protocol = { workspace = true }
 cidr = "0.2.1"
 postgres-types = { workspace = true, features = ["with-cidr-0_2"] }
+vec1 = "1.6.0"
 
 # Local dependencies
 nom-sql = { path = "../nom-sql" }

--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -36,6 +36,7 @@ pub mod dialect;
 mod r#enum;
 mod float;
 mod integer;
+mod ranges;
 mod serde;
 mod text;
 mod timestamp;
@@ -43,11 +44,13 @@ mod r#type;
 
 pub use ndarray::{ArrayD, IxDyn};
 use proptest::arbitrary::Arbitrary;
+use proptest::prelude::*;
 
 pub use crate::array::Array;
 pub use crate::collation::Collation;
 pub use crate::dialect::Dialect;
 pub use crate::r#type::{DfType, PgEnumMetadata, PgTypeCategory};
+pub use crate::ranges::{Bound, BoundedRange, IntoBoundedRange, RangeBounds};
 pub use crate::serde::TextRef;
 pub use crate::text::{Text, TinyText};
 pub use crate::timestamp::{TimestampTz, TIMESTAMP_FORMAT, TIMESTAMP_PARSE_FORMAT};
@@ -183,6 +186,12 @@ impl fmt::Display for DfValue {
 pub const TIME_FORMAT: &str = "%H:%M:%S";
 
 impl DfValue {
+    /// The minimum possible DfValue.
+    pub const MIN: Self = DfValue::None;
+
+    /// The maximum possible DfValue.
+    pub const MAX: Self = DfValue::Max;
+
     /// Construct a new [`DfValue::Array`] containing an empty array
     pub fn empty_array() -> Self {
         // TODO: static singleton empty array?
@@ -2318,7 +2327,6 @@ mod arbitrary {
 #[cfg(test)]
 mod tests {
     use derive_more::{From, Into};
-    use proptest::prelude::*;
     use readyset_util::{eq_laws, hash_laws, ord_laws};
     use test_strategy::proptest;
 

--- a/readyset-data/src/ranges.rs
+++ b/readyset-data/src/ranges.rs
@@ -1,0 +1,81 @@
+//! A collection of utilities to make it easier to create [`readyset_util::ranges::BoundedRanges`]
+//! of [`DfValue`]s.
+pub use readyset_util::ranges::{Bound, BoundedRange, RangeBounds};
+use vec1::Vec1;
+
+use super::DfValue;
+
+/// A trait that eases the creation of [`BoundedRange`]s for its implementors.
+pub trait IntoBoundedRange: Sized {
+    /// Maps over `self`, returning a new object with all the values replaced with `value`.
+    fn map_value(&self, value: DfValue) -> Self;
+
+    /// Returns a [`BoundedRange`] that includes all non-NULL values greater than (but not equal
+    /// to) `self`.
+    fn range_from(self) -> BoundedRange<Self> {
+        let upper = self.map_value(DfValue::MAX);
+        (Bound::Excluded(self), Bound::Excluded(upper))
+    }
+
+    /// Returns a [`BoundedRange`] that includes all non-NULL values greater than or equal to
+    /// `self`.
+    fn range_from_inclusive(self) -> BoundedRange<Self> {
+        let upper = self.map_value(DfValue::MAX);
+        (Bound::Included(self), Bound::Excluded(upper))
+    }
+
+    /// Returns a [`BoundedRange`] that includes all non-NULL values less than (but not equal
+    /// to) `self`.
+    fn range_to(self) -> BoundedRange<Self> {
+        let lower = self.map_value(DfValue::MIN);
+        (Bound::Excluded(lower), Bound::Excluded(self))
+    }
+
+    /// Returns a [`BoundedRange`] and includes all non-NULL values less than or equal to `self`.
+    fn range_to_inclusive(self) -> BoundedRange<Self> {
+        let lower = self.map_value(DfValue::MIN);
+        (Bound::Excluded(lower), Bound::Included(self))
+    }
+}
+
+impl IntoBoundedRange for Vec1<DfValue> {
+    fn map_value(&self, value: DfValue) -> Self {
+        self.mapped_ref(|_| value.clone())
+    }
+}
+
+impl IntoBoundedRange for DfValue {
+    fn map_value(&self, value: DfValue) -> Self {
+        value
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (value.clone(), value)
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (value.clone(), value.clone(), value)
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue, DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (value.clone(), value.clone(), value.clone(), value)
+    }
+}
+
+impl IntoBoundedRange for (DfValue, DfValue, DfValue, DfValue, DfValue) {
+    fn map_value(&self, value: DfValue) -> Self {
+        (
+            value.clone(),
+            value.clone(),
+            value.clone(),
+            value.clone(),
+            value,
+        )
+    }
+}

--- a/readyset-util/Cargo.toml
+++ b/readyset-util/Cargo.toml
@@ -23,6 +23,9 @@ bit-vec = { version = "0.6", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 async-stream = "0.3.2"
 cidr = "0.2.1"
+thiserror = "1.0.26"
+quickcheck = "0.9"
+rand = "0.7"
 
 [dev-dependencies]
 test-strategy = "0.2.0"

--- a/readyset-util/src/lib.rs
+++ b/readyset-util/src/lib.rs
@@ -17,6 +17,7 @@ pub mod math;
 pub mod nonmaxusize;
 pub mod progress;
 pub mod properties;
+pub mod ranges;
 pub mod redacted;
 pub mod shared_cache;
 pub mod shutdown;

--- a/readyset-util/src/ranges.rs
+++ b/readyset-util/src/ranges.rs
@@ -1,0 +1,217 @@
+//! Utilities for dealing with ranges and bounds.
+use std::hash::Hash;
+use std::ops::{self, Deref, Range, RangeInclusive};
+use std::str;
+
+use proptest::arbitrary::Arbitrary;
+use proptest::prelude::*;
+use quickcheck::Gen;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Represents a *bounded* range, encapsulating a lower and upper [`Bound`]. See the documentation
+/// for [`Bound`] for more information.
+pub type BoundedRange<T> = (Bound<T>, Bound<T>);
+
+/// A trait that mirrors the functionality of [`std::ops::RangeBounds`] but whose bounds are never
+/// unbounded.
+pub trait RangeBounds<T: ?Sized> {
+    /// Returns the start bound of the range.
+    fn start_bound(&self) -> Bound<&T>;
+
+    /// Returns the end bound of the range.
+    fn end_bound(&self) -> Bound<&T>;
+
+    /// Returns `self` represented as a tuple of [`std::ops::Bound`]s.
+    fn as_std_range(&self) -> (ops::Bound<&T>, ops::Bound<&T>) {
+        (self.start_bound().into(), self.end_bound().into())
+    }
+
+    /// Returns true only if the range contains the given item.
+    fn contains<U>(&self, item: &U) -> bool
+    where
+        T: PartialOrd<U>,
+        U: ?Sized + PartialOrd<T>,
+    {
+        (match self.start_bound() {
+            Bound::Included(start) => start <= item,
+            Bound::Excluded(start) => start < item,
+        }) && (match self.end_bound() {
+            Bound::Included(end) => item <= end,
+            Bound::Excluded(end) => item < end,
+        })
+    }
+}
+
+impl<T> RangeBounds<T> for Range<T> {
+    fn start_bound(&self) -> Bound<&T> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        Bound::Excluded(&self.end)
+    }
+}
+
+impl<T> RangeBounds<T> for RangeInclusive<T> {
+    fn start_bound(&self) -> Bound<&T> {
+        Bound::Included(self.start())
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        Bound::Included(self.end())
+    }
+}
+
+impl<T> RangeBounds<T> for BoundedRange<T> {
+    fn start_bound(&self) -> Bound<&T> {
+        self.0.as_ref()
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        self.1.as_ref()
+    }
+}
+
+impl<T: ?Sized> RangeBounds<T> for BoundedRange<&T> {
+    fn start_bound(&self) -> Bound<&T> {
+        self.0
+    }
+
+    fn end_bound(&self) -> Bound<&T> {
+        self.1
+    }
+}
+
+/// A type similar to [`std::ops::Bound`] that can never be unbounded. Its primary use case is to
+/// represent bounds in ranges that are bounded on both sides. Ranges that are unbounded from
+/// above and/or below would not be representable using this type.
+#[derive(Copy, Debug, Hash, Serialize, Deserialize, Clone, Eq, PartialEq)]
+pub enum Bound<T> {
+    /// A bound that includes the wrapped value
+    Included(T),
+    /// A bound that excludes the wrapped value
+    Excluded(T),
+}
+
+impl<T> Arbitrary for Bound<T>
+where
+    T: Arbitrary + 'static,
+    T::Parameters: Clone,
+{
+    type Parameters = T::Parameters;
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            any_with::<T>(args.clone()).prop_map(Bound::Included),
+            any_with::<T>(args).prop_map(Bound::Excluded)
+        ]
+        .boxed()
+    }
+}
+
+impl<T> Bound<T> {
+    /// Returns a mutable reference to the value wrapped by the [`Bound`].
+    pub fn inner_mut(&mut self) -> &mut T {
+        match *self {
+            Bound::Included(ref mut b) => b,
+            Bound::Excluded(ref mut b) => b,
+        }
+    }
+
+    /// Applies the given function to the value wrapped by the [`Bound`], returning the
+    /// newly-created [`Bound`].
+    pub fn map<U, F>(self, f: F) -> Bound<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Bound::Included(b) => Bound::Included(f(b)),
+            Bound::Excluded(b) => Bound::Excluded(f(b)),
+        }
+    }
+
+    /// Converts from `&Bound<T>` to `Bound<&T>`.
+    pub fn as_ref(&self) -> Bound<&T> {
+        match self {
+            Bound::Excluded(b) => Bound::Excluded(b),
+            Bound::Included(b) => Bound::Included(b),
+        }
+    }
+}
+
+impl<T> Bound<&T>
+where
+    T: Clone,
+{
+    /// Converts from `Bound<&T>` to `Bound<T>` by cloning the value wrapped by the [`Bound`].
+    pub fn cloned(&self) -> Bound<T> {
+        match *self {
+            Bound::Excluded(b) => Bound::Excluded(b.clone()),
+            Bound::Included(b) => Bound::Included(b.clone()),
+        }
+    }
+}
+
+impl<T> From<Bound<T>> for ops::Bound<T> {
+    fn from(value: Bound<T>) -> Self {
+        match value {
+            Bound::Included(b) => ops::Bound::Included(b),
+            Bound::Excluded(b) => ops::Bound::Excluded(b),
+        }
+    }
+}
+
+impl<T, I> Bound<T>
+where
+    T: Deref<Target = [I]>,
+{
+    /// Returns the length of the value wrapped by the [`Bound`].
+    pub fn len(&self) -> usize {
+        match self {
+            Bound::Included(b) | Bound::Excluded(b) => b.len(),
+        }
+    }
+
+    /// Returns true only if the length of the value wrapped by the [`Bound`] is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// The error returned after a failed conversion from [`std::ops::Bound`] to [`Bound`]. This error
+/// only occurs if [`std::ops::Bound`] is unbounded.
+#[derive(Error, Debug)]
+#[error("Cannot convert std::ops::Bound::Unbounded to readyset_data::Bound")]
+pub struct BoundConversionError;
+
+impl<T> TryFrom<ops::Bound<T>> for Bound<T> {
+    type Error = BoundConversionError;
+
+    fn try_from(value: ops::Bound<T>) -> Result<Self, Self::Error> {
+        match value {
+            ops::Bound::Included(b) => Ok(Bound::Included(b)),
+            ops::Bound::Excluded(b) => Ok(Bound::Excluded(b)),
+            ops::Bound::Unbounded => Err(BoundConversionError),
+        }
+    }
+}
+
+impl<T: quickcheck::Arbitrary> quickcheck::Arbitrary for Bound<T> {
+    fn arbitrary<G: Gen>(g: &mut G) -> Bound<T> {
+        if g.gen::<bool>() {
+            Bound::Included(T::arbitrary(g))
+        } else {
+            Bound::Excluded(T::arbitrary(g))
+        }
+    }
+
+    fn shrink(&self) -> Box<dyn Iterator<Item = Bound<T>>> {
+        match *self {
+            Bound::Included(ref x) => Box::new(x.shrink().map(Bound::Included)),
+            Bound::Excluded(ref x) => Box::new(x.shrink().map(Bound::Excluded)),
+        }
+    }
+}


### PR DESCRIPTION
This commit adds a number of new utilities for working with *bounded*
ranges. A bounded range is a range whose upper and lower bounds are
never unbounded. Among the utilities added in this commit are:

- A `Bound` type very similar to `std::ops::Bound` except that it does
  not have an `Unbounded` variant
- A `BoundedRange` type alias similar to the existing `BoundPair` type
  alias except that it contains a pair of our custom `Bound` type
  instead of `std::ops::Bound`s
- A `RangeBounds` trait very similar to `std::ops::RangeBounds` except
  that the methods return our own custom `Bound` type
- An `IntoBoundedRange` trait that makes it easier to simulate unbounded
  ranges using the minimum and maximum `DfValue`s

These utilities will all be used in a future commit to ensure that we
always work with *bounded* ranges when constructing range keys.

Refs: REA-4287
