### PR TITLE
replicators: Mark Numeric::(NaN, Infinity, -Infinity) as unsupported

### DIFF
--- a/replicators/src/postgres_connector/wal.rs
+++ b/replicators/src/postgres_connector/wal.rs
@@ -40,6 +40,11 @@ pub enum WalError {
     },
 }
 
+#[derive(Debug)]
+pub enum NumericParseErrorKind {
+    RustDecimalError(rust_decimal::Error),
+    UnsupportedValue(String),
+}
 /// The kinds of table-specific errors that can arise during replication
 #[derive(Debug)]
 pub enum TableErrorKind {
@@ -54,7 +59,7 @@ pub enum TableErrorKind {
     TimestampTzParseError,
     DateParseError,
     TimeParseError(mysql_time::ConvertError),
-    NumericParseError(rust_decimal::Error),
+    NumericParseError(NumericParseErrorKind),
     BitVectorParseError(String),
     ArrayParseError,
     InvalidMapping(String),


### PR DESCRIPTION
rust_decimal does not provide a way to represent NaN, Infinity, or
-Infinity. Rather than propagating the parse error, construct a more
explicit error to represent the fact that we don't currently support
these.

Once we move to a bigdecimal representation, we can handle representing
these variants.

