### PR TITLE
state: Never look up unbounded ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,23 +187,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -6659,9 +6660,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
 dependencies = [
  "async-stream",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6127,9 +6127,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structmeta"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59915b528a896f2e3bfa1a6ace65f7bb0ff9f9863de6213b0c01cb6fd3c3ac71"
+checksum = "104842d6278bf64aa9d2f182ba4bde31e8aec7a131d29b7f444bb9b344a09e2a"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",
@@ -6139,9 +6139,9 @@ dependencies = [
 
 [[package]]
 name = "structmeta-derive"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73800bcca56045d5ab138a48cd28a96093335335deaa916f22b5749c4150c79"
+checksum = "24420be405b590e2d746d83b01f09af673270cf80e9b003a5fa7b651c58c7d93"
 dependencies = [
  "proc-macro2 1.0.69",
  "quote 1.0.33",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ name = "partial-map"
 version = "0.1.0"
 dependencies = [
  "merging-interval-tree",
+ "readyset-util",
 ]
 
 [[package]]
@@ -4382,6 +4383,7 @@ dependencies = [
  "quickcheck_macros",
  "rand 0.7.3",
  "readyset-client",
+ "readyset-util",
  "smallvec",
  "thiserror",
  "triomphe",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "mysql_async",
  "nom-sql",
  "partial-map",
+ "postgres 0.19.7",
  "proptest",
  "readyset-data",
  "readyset-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ postgres-protocol = {  git = "https://github.com/readysettech/rust-postgres.git"
 postgres-types = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio-postgres = {  git = "https://github.com/readysettech/rust-postgres.git"}
 tokio = { version = "1.32",  features = ["full"] }
+tokio-test = { version = "0.4.3" }
 rocksdb = { git = "https://github.com/readysettech/rust-rocksdb.git", default-features = false, features = ["lz4", "jemalloc"] }
 metrics-exporter-prometheus = { git = "https://github.com/readysettech/metrics.git" }
 metrics = { git = "https://github.com/readysettech/metrics.git" }

--- a/benchmarks/src/utils/prometheus/metric/parser.rs
+++ b/benchmarks/src/utils/prometheus/metric/parser.rs
@@ -237,7 +237,7 @@ where
                 (Line::Empty, _) => (),
                 (Line::Help(name, description), true) => {
                     let metric = current_metric.as_mut().unwrap();
-                    if(metric.name == name) {
+                    if metric.name == name {
                         metric.description = Some(description);
                     } else {
                         yield current_metric.take().unwrap().try_into();
@@ -249,7 +249,7 @@ where
                 },
                 (Line::Type(name, kind), true) => {
                     let metric = current_metric.as_mut().unwrap();
-                    if(metric.name == name) {
+                    if metric.name == name {
                         metric.kind = Some(kind);
                     } else {
                         yield current_metric.take().unwrap().try_into();

--- a/dataflow-expression/Cargo.toml
+++ b/dataflow-expression/Cargo.toml
@@ -16,6 +16,7 @@ regex = "1.4.3"
 itertools = "0.10.3"
 vec1 = "1.6"
 proptest = "1.0.0"
+test-strategy = "0.2.0"
 
 # Local deps
 readyset-util = { path = "../readyset-util" }
@@ -26,7 +27,7 @@ readyset-errors = { path = "../readyset-errors" }
 partial-map = { path = "../partial-map" }
 
 [dev-dependencies]
-test-strategy = "0.2.0"
 tokio = { workspace = true, features = ["full"] }
 tokio-postgres = { workspace = true, features = ["with-chrono-0_4", "with-eui48-1", "with-uuid-0_8", "with-serde_json-1", "with-bit-vec-0_6"] }
+postgres = { workspace = true, features = ["with-chrono-0_4", "with-eui48-1", "with-uuid-0_8", "with-serde_json-1", "with-bit-vec-0_6"] }
 mysql_async = { workspace = true }

--- a/dataflow-expression/src/eval.rs
+++ b/dataflow-expression/src/eval.rs
@@ -16,7 +16,7 @@ macro_rules! non_null {
     };
 }
 
-mod builtins;
+pub(crate) mod builtins;
 mod json;
 
 fn eval_binary_op(op: BinaryOperator, left: &DfValue, right: &DfValue) -> ReadySetResult<DfValue> {

--- a/dataflow-expression/src/lib.rs
+++ b/dataflow-expression/src/lib.rs
@@ -9,6 +9,7 @@ pub mod utils;
 
 use std::fmt::{self, Display, Formatter};
 
+pub use eval::builtins::DateTruncPrecision;
 use itertools::Itertools;
 pub use readyset_data::Dialect;
 use readyset_data::{DfType, DfValue};
@@ -108,6 +109,9 @@ pub enum BuiltinFunction {
 
     /// [`array_to_string`](https://www.postgresql.org/docs/current/functions-array.html)
     ArrayToString(Expr, Expr, Option<Expr>),
+
+    /// [`date_trunc`](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC)
+    DateTrunc(Expr, Expr),
 }
 
 impl BuiltinFunction {
@@ -141,6 +145,7 @@ impl BuiltinFunction {
             Greatest { .. } => "greatest",
             Least { .. } => "least",
             ArrayToString { .. } => "array_to_string",
+            DateTrunc { .. } => "date_trunc",
         }
     }
 }
@@ -235,6 +240,9 @@ impl Display for BuiltinFunction {
                     write!(f, ", {null_string}")?;
                 }
                 write!(f, ")")
+            }
+            DateTrunc(field, source) => {
+                write!(f, "({}, {})", field, source)
             }
         }
     }

--- a/dataflow-expression/src/lower.rs
+++ b/dataflow-expression/src/lower.rs
@@ -429,6 +429,25 @@ impl BuiltinFunction {
                     DfType::DEFAULT_TEXT,
                 )
             }
+            "date_trunc" => {
+                // this is the time unit (precision) to truncate by ('hour', 'minute', and so on).
+                // called 'field' in the postgres docs.
+                let precision = next_arg()?;
+
+                // next is an Expr that evaluates to either timestamp or timestamptz.
+                // the postgres date_trunc() function also accepts INTERVAL, but that's
+                // not a supported type in DfType as of March-2024.
+                let source = next_arg()?;
+                let ret_type = source.ty().clone();
+
+                // last is an optional time zone argument to the function.
+                // We do not yet support the optional time zone.
+                if args.next().is_some() {
+                    unsupported!("The time zone parameter is not yet supported.");
+                }
+
+                (Self::DateTrunc(precision, source), ret_type)
+            }
             _ => unsupported!("Function {name} does not exist"),
         };
 

--- a/dataflow-expression/tests/postgres_oracle.rs
+++ b/dataflow-expression/tests/postgres_oracle.rs
@@ -1,14 +1,19 @@
+use std::cell::RefCell;
 use std::env;
 
+use chrono::{DateTime, FixedOffset};
+use dataflow_expression::DateTruncPrecision;
+use postgres::{Client, Config, NoTls};
+use proptest::prelude::*;
 use readyset_data::DfValue;
-use tokio_postgres::{Client, NoTls};
+use readyset_util::arbitrary::{arbitrary_date_time_timezone, arbitrary_timestamp_naive_date_time};
 
 use self::common::parse_lower_eval;
 
 mod common;
 
-fn config() -> tokio_postgres::Config {
-    let mut config = tokio_postgres::Config::new();
+fn config() -> Config {
+    let mut config = Config::new();
     config
         .host(env::var("PGHOST").as_deref().unwrap_or("localhost"))
         .port(
@@ -21,48 +26,39 @@ fn config() -> tokio_postgres::Config {
         .password(env::var("PGPASSWORD").unwrap_or_else(|_| "noria".into()));
     config
 }
-async fn postgres_eval(expr: &str, client: &Client) -> DfValue {
+
+fn postgres_eval(expr: &str, client: &mut Client) -> DfValue {
     client
         .query_one(&format!("SELECT {expr};"), &[])
-        .await
         .unwrap_or_else(|e| panic!("Error evaluating `{expr}`: {e}"))
         .get(0)
 }
 
-async fn compare_eval(expr: &str, client: &Client) {
+fn compare_eval(expr: &str, client: &mut Client) {
     let our_result = parse_lower_eval(
         expr,
         nom_sql::Dialect::PostgreSQL,
         dataflow_expression::Dialect::DEFAULT_POSTGRESQL,
     );
-    let pg_result = postgres_eval(expr, client).await;
+    let pg_result = postgres_eval(expr, client);
     assert_eq!(
         our_result, pg_result,
         "mismatched results for {expr} (left: us, right: postgres)"
     );
 }
 
-#[tokio::test]
-async fn example_exprs_eval_same_as_postgres() {
-    let (client, conn) = config().connect(NoTls).await.unwrap();
-    tokio::spawn(conn);
+#[test]
+fn example_exprs_eval_same_as_postgres() {
+    let mut client = config().connect(NoTls).unwrap();
 
-    client
-        .simple_query("DROP TYPE IF EXISTS abc;")
-        .await
-        .unwrap();
+    client.simple_query("DROP TYPE IF EXISTS abc;").unwrap();
     client
         .simple_query("CREATE TYPE abc AS ENUM ('a', 'b', 'c')")
-        .await
         .unwrap();
 
-    client
-        .simple_query("DROP TYPE IF EXISTS cba;")
-        .await
-        .unwrap();
+    client.simple_query("DROP TYPE IF EXISTS cba;").unwrap();
     client
         .simple_query("CREATE TYPE cba AS ENUM ('c', 'b', 'a')")
-        .await
         .unwrap();
 
     for expr in [
@@ -107,6 +103,74 @@ async fn example_exprs_eval_same_as_postgres() {
         "split_part('a.b.c', '.', -1)",
         "split_part('a.b.c', '.', -4)",
     ] {
-        compare_eval(expr, &client).await;
+        compare_eval(expr, &mut client);
     }
+}
+
+// Normalize the UTC offset to hours and minutes (dropping any seconds).
+// This is currently necessary as `chrono::FixedOffset` does not correctly
+// parse seconds in all circumstances (https://github.com/chronotope/chrono/pull/1083).
+fn normalize_offset(datetime: DateTime<FixedOffset>) -> DateTime<FixedOffset> {
+    let offset = datetime.timezone().local_minus_utc();
+    let normalized_offset = (offset / 60) * 60;
+    let new_offset = FixedOffset::east_opt(normalized_offset).unwrap();
+    datetime.with_timezone(&new_offset)
+}
+
+/// Test the `date_trunc` built-in function. Passes a simple timestamp,
+/// with no timezone information, and does not pass the optional timezone
+/// for normalized conversions.
+#[test]
+fn date_trunc_timestamp_no_opt_tz() {
+    let client = RefCell::new(config().connect(NoTls).unwrap());
+
+    proptest!(| (precision: DateTruncPrecision, datetime in arbitrary_timestamp_naive_date_time()) | {
+        let mut client = client.borrow_mut();
+        let expr = format!("date_trunc('{}', '{}'::timestamp)", precision, datetime);
+        compare_eval(expr.as_str(), &mut client);
+    });
+}
+
+/// Test the `date_trunc` built-in function. Passes a timestamp with
+/// timezone information, and does not pass the optional timezone for
+/// normalized conversions.
+#[test]
+fn date_trunc_timestamptz_no_opt_tz() {
+    let client = RefCell::new(config().connect(NoTls).unwrap());
+
+    proptest!(| (precision: DateTruncPrecision, datetime in arbitrary_date_time_timezone()) | {
+       let dt = normalize_offset(datetime);
+       let mut client = client.borrow_mut();
+       let expr = format!("date_trunc('{}', '{}'::timestamptz)", precision, dt);
+       compare_eval(expr.as_str(), &mut client);
+    });
+}
+
+/// Test the `date_trunc` built-in function. Passes a timestamp with
+/// timezone information but casts to a timestamp, and does not pass
+/// the optional timezone for normalized conversions.
+#[test]
+fn date_trunc_timestamptz_downcast_no_opt_tz() {
+    let client = RefCell::new(config().connect(NoTls).unwrap());
+
+    proptest!(| (precision: DateTruncPrecision, datetime in arbitrary_date_time_timezone()) | {
+       let dt = normalize_offset(datetime);
+       let mut client = client.borrow_mut();
+       let expr = format!("date_trunc('{}', '{}'::timestamp)", precision, dt);
+       compare_eval(expr.as_str(), &mut client);
+    });
+}
+
+/// Test the `date_trunc` built-in function. Passes a timestamp without
+/// timezone information but casts to a timestamptz, and does not pass
+/// the optional timezone for normalized conversions.
+#[test]
+fn date_trunc_timestamp_upcast_no_opt_tz() {
+    let client = RefCell::new(config().connect(NoTls).unwrap());
+
+    proptest!(| (precision: DateTruncPrecision, datetime in arbitrary_timestamp_naive_date_time()) | {
+       let mut client = client.borrow_mut();
+       let expr = format!("date_trunc('{}', '{}'::timestamptz)", precision, datetime);
+       compare_eval(expr.as_str(), &mut client);
+    });
 }

--- a/dataflow-state/benches/persistent_state.rs
+++ b/dataflow-state/benches/persistent_state.rs
@@ -36,8 +36,6 @@
 //! ```notrust
 //! $ cargo bench -- --help
 //! ```
-use std::ops::Bound;
-
 use clap::Parser;
 use common::{Index, IndexType, Record};
 use criterion::{black_box, Criterion};
@@ -45,7 +43,7 @@ use dataflow_state::{
     DurabilityMode, PersistenceParameters, PersistentState, PointKey, RangeKey, SnapshotMode, State,
 };
 use itertools::Itertools;
-use readyset_data::DfValue;
+use readyset_data::{DfValue, IntoBoundedRange};
 
 lazy_static::lazy_static! {
     static ref LARGE_STRINGS: Vec<String> = ["a", "b", "c"]
@@ -184,10 +182,7 @@ pub fn rocksdb_range_lookup(c: &mut Criterion, state: &PersistentState) {
     let mut group = c.benchmark_group("RocksDB lookup_range");
     group.bench_function("lookup_range", |b| {
         b.iter(|| {
-            black_box(state.lookup_range(
-                &[1],
-                &RangeKey::Single((Bound::Included(key.clone()), Bound::Unbounded)),
-            ));
+            black_box(state.lookup_range(&[1], &RangeKey::Single(key.clone().range_from())));
         })
     });
     group.finish();
@@ -199,10 +194,9 @@ pub fn rocksdb_range_lookup_large_strings(c: &mut Criterion, state: &PersistentS
     let mut group = c.benchmark_group("RocksDB with large strings");
     group.bench_function("lookup_range", |b| {
         b.iter(|| {
-            black_box(state.lookup_range(
-                &[1],
-                &RangeKey::Single((Bound::Included(key.clone()), Bound::Unbounded)),
-            ));
+            black_box(
+                state.lookup_range(&[1], &RangeKey::Single(key.clone().range_from_inclusive())),
+            );
         })
     });
     group.finish();

--- a/dataflow-state/src/key.rs
+++ b/dataflow-state/src/key.rs
@@ -1,9 +1,6 @@
-use std::ops::{Bound, RangeBounds};
-
 use common::DfValue;
 use derive_more::From;
-use readyset_data::TextRef;
-use readyset_util::intervals::BoundPair;
+use readyset_data::{Bound, BoundedRange, RangeBounds, TextRef};
 use serde::ser::{SerializeSeq, SerializeTuple};
 use serde::Serialize;
 use test_strategy::Arbitrary;
@@ -150,15 +147,13 @@ impl Serialize for PointKey {
 
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 pub enum RangeKey {
-    /// Key-length-polymorphic double-unbounded range key
-    Unbounded,
-    Single(BoundPair<DfValue>),
-    Double(BoundPair<(DfValue, DfValue)>),
-    Tri(BoundPair<(DfValue, DfValue, DfValue)>),
-    Quad(BoundPair<(DfValue, DfValue, DfValue, DfValue)>),
-    Quin(BoundPair<(DfValue, DfValue, DfValue, DfValue, DfValue)>),
-    Sex(BoundPair<(DfValue, DfValue, DfValue, DfValue, DfValue, DfValue)>),
-    Multi(BoundPair<Box<[DfValue]>>),
+    Single(BoundedRange<DfValue>),
+    Double(BoundedRange<(DfValue, DfValue)>),
+    Tri(BoundedRange<(DfValue, DfValue, DfValue)>),
+    Quad(BoundedRange<(DfValue, DfValue, DfValue, DfValue)>),
+    Quin(BoundedRange<(DfValue, DfValue, DfValue, DfValue, DfValue)>),
+    Sex(BoundedRange<(DfValue, DfValue, DfValue, DfValue, DfValue, DfValue)>),
+    Multi(BoundedRange<Box<[DfValue]>>),
 }
 
 #[allow(clippy::len_without_is_empty)]
@@ -172,14 +167,12 @@ impl RangeKey {
     /// # Examples
     ///
     /// ```rust
-    /// use std::ops::Bound::*;
-    ///
     /// use dataflow_state::RangeKey;
+    /// use readyset_data::Bound::*;
     /// use readyset_data::DfValue;
     /// use vec1::vec1;
     ///
-    /// // Can build RangeKeys from regular range expressions
-    /// assert_eq!(RangeKey::from(&(..)), RangeKey::Unbounded);
+    /// // Can build RangeKeys from bounded range expressions
     /// assert_eq!(
     ///     RangeKey::from(&(vec1![DfValue::from(0)]..vec1![DfValue::from(1)])),
     ///     RangeKey::Single((Included(0.into()), Excluded(1.into())))
@@ -191,13 +184,10 @@ impl RangeKey {
     {
         use Bound::*;
         let len = match (range.start_bound(), range.end_bound()) {
-            (Unbounded, Unbounded) => return RangeKey::Unbounded,
             (Included(start) | Excluded(start), Included(end) | Excluded(end)) => {
                 assert_eq!(start.len(), end.len());
                 start.len()
             }
-            (Included(start) | Excluded(start), Unbounded) => start.len(),
-            (Unbounded, Included(end) | Excluded(end)) => end.len(),
         };
 
         macro_rules! make {
@@ -234,11 +224,13 @@ impl RangeKey {
             )),
         }
     }
+}
 
+#[allow(clippy::len_without_is_empty)]
+impl RangeKey {
     /// Returns the upper bound of the range key
     pub fn upper_bound(&self) -> Bound<Vec<&DfValue>> {
         match self {
-            RangeKey::Unbounded => Bound::Unbounded,
             RangeKey::Single((_, upper)) => upper.as_ref().map(|dt| vec![dt]),
             RangeKey::Double((_, upper)) => upper.as_ref().map(|dts| dts.elements().collect()),
             RangeKey::Tri((_, upper)) => upper.as_ref().map(|dts| dts.elements().collect()),
@@ -249,30 +241,22 @@ impl RangeKey {
         }
     }
 
-    /// Return the length of this range key, or None if the key is Unbounded
-    pub fn len(&self) -> Option<usize> {
+    /// Return the length of this range key
+    pub fn len(&self) -> usize {
         match self {
-            RangeKey::Unbounded | RangeKey::Multi((Bound::Unbounded, Bound::Unbounded)) => None,
-            RangeKey::Single(_) => Some(1),
-            RangeKey::Double(_) => Some(2),
-            RangeKey::Tri(_) => Some(3),
-            RangeKey::Quad(_) => Some(4),
-            RangeKey::Quin(_) => Some(5),
-            RangeKey::Sex(_) => Some(6),
-            RangeKey::Multi(
-                (Bound::Included(k), _)
-                | (Bound::Excluded(k), _)
-                | (_, Bound::Included(k))
-                | (_, Bound::Excluded(k)),
-            ) => Some(k.len()),
+            RangeKey::Single(_) => 1,
+            RangeKey::Double(_) => 2,
+            RangeKey::Tri(_) => 3,
+            RangeKey::Quad(_) => 4,
+            RangeKey::Quin(_) => 5,
+            RangeKey::Sex(_) => 6,
+            RangeKey::Multi((Bound::Included(k), _) | (Bound::Excluded(k), _)) => k.len(),
         }
     }
 
     /// Convert this [`RangeKey`] into a pair of bounds on [`PointKey`]s, for use during
     /// serialization of lookup keys for ranges
-    pub(crate) fn into_point_keys(self) -> BoundPair<PointKey> {
-        use Bound::*;
-
+    pub(crate) fn into_point_keys(self) -> BoundedRange<PointKey> {
         macro_rules! point_keys {
             ($r:ident, $variant:ident) => {
                 ($r.0.map(PointKey::$variant), $r.1.map(PointKey::$variant))
@@ -280,7 +264,6 @@ impl RangeKey {
         }
 
         match self {
-            RangeKey::Unbounded => (Unbounded, Unbounded),
             RangeKey::Single((l, u)) => (l.map(PointKey::Single), u.map(PointKey::Single)),
             RangeKey::Double(r) => point_keys!(r, Double),
             RangeKey::Tri(r) => point_keys!(r, Tri),
@@ -291,8 +274,8 @@ impl RangeKey {
         }
     }
 
-    pub fn as_bound_pair(&self) -> BoundPair<Vec<DfValue>> {
-        fn as_bound_pair<T>(bound_pair: &BoundPair<T>) -> BoundPair<Vec<DfValue>>
+    pub fn as_bounded_range(&self) -> BoundedRange<Vec<DfValue>> {
+        fn as_bounded_range<T>(bound_pair: &BoundedRange<T>) -> BoundedRange<Vec<DfValue>>
         where
             T: TupleElements<Element = DfValue>,
         {
@@ -309,16 +292,15 @@ impl RangeKey {
         }
 
         match self {
-            RangeKey::Unbounded => (Bound::Unbounded, Bound::Unbounded),
             RangeKey::Single((lower, upper)) => (
                 lower.as_ref().map(|dt| vec![dt.clone()]),
                 upper.as_ref().map(|dt| vec![dt.clone()]),
             ),
-            RangeKey::Double(bp) => as_bound_pair(bp),
-            RangeKey::Tri(bp) => as_bound_pair(bp),
-            RangeKey::Quad(bp) => as_bound_pair(bp),
-            RangeKey::Quin(bp) => as_bound_pair(bp),
-            RangeKey::Sex(bp) => as_bound_pair(bp),
+            RangeKey::Double(bp) => as_bounded_range(bp),
+            RangeKey::Tri(bp) => as_bounded_range(bp),
+            RangeKey::Quad(bp) => as_bounded_range(bp),
+            RangeKey::Quin(bp) => as_bounded_range(bp),
+            RangeKey::Sex(bp) => as_bounded_range(bp),
             RangeKey::Multi((lower, upper)) => (
                 lower.as_ref().map(|dts| dts.to_vec()),
                 upper.as_ref().map(|dts| dts.to_vec()),

--- a/dataflow-state/src/keyed_state.rs
+++ b/dataflow-state/src/keyed_state.rs
@@ -1,11 +1,10 @@
 use std::iter;
-use std::ops::{Bound, RangeBounds};
 
 use common::{Index, IndexType};
 use indexmap::IndexMap;
 use partial_map::PartialMap;
-use readyset_data::DfValue;
-use readyset_util::intervals::into_bound_endpoint;
+use readyset_data::{Bound, DfValue};
+use readyset_util::ranges::RangeBounds;
 use tuple::TupleElements;
 use vec1::Vec1;
 
@@ -335,16 +334,66 @@ impl KeyedState {
             }
             // This is unwieldy, but allowing callers to insert the wrong length of Vec into us
             // would be very bad!
-            KeyedState::MultiBTree(ref mut map, len)
-                if (into_bound_endpoint(range.0.as_ref()).map_or(true, |x| x.len() == *len)
-                    && into_bound_endpoint(range.1.as_ref()).map_or(true, |x| x.len() == *len)) =>
-            {
+            KeyedState::MultiBTree(ref mut map, len) => {
+                assert!(range.0.len() == *len && range.1.len() == *len);
                 map.insert_range((range.0.map(Vec1::into_vec), range.1.map(Vec1::into_vec)))
             }
-            _ =>
+            KeyedState::AllRows(_) => panic!("insert_range called on an AllRows KeyedState"),
+            KeyedState::SingleHash(_)
+            | KeyedState::DoubleHash(_)
+            | KeyedState::TriHash(_)
+            | KeyedState::QuadHash(_)
+            | KeyedState::QuinHash(_)
+            | KeyedState::SexHash(_)
+            | KeyedState::MultiHash(_, _) =>
             #[allow(clippy::panic)] // documented invariant
             {
                 panic!("insert_range called on a HashMap KeyedState")
+            }
+        };
+    }
+
+    /// Mark every key in the state as filled. Note that `KeyedState::insert_range()` cannot be
+    /// used for this purpose, since a [`Bound`] cannot be used to represent an unbounded upper or
+    /// lower bound.
+    ///
+    /// # Panics
+    ///
+    /// Panics if this `KeyedState` is backed by a HashMap index
+    pub(super) fn insert_full_range(&mut self) {
+        match self {
+            KeyedState::SingleBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::DoubleBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::TriBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::QuadBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::QuinBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::SexBTree(ref mut map) => {
+                map.insert_full_range();
+            }
+            KeyedState::MultiBTree(ref mut map, _) => {
+                map.insert_full_range();
+            }
+            KeyedState::AllRows(_) => panic!("insert_full_range called on an AllRows KeyedState"),
+            KeyedState::SingleHash(_)
+            | KeyedState::DoubleHash(_)
+            | KeyedState::TriHash(_)
+            | KeyedState::QuadHash(_)
+            | KeyedState::QuinHash(_)
+            | KeyedState::SexHash(_)
+            | KeyedState::MultiHash(_, _) =>
+            #[allow(clippy::panic)] // documented invariant
+            {
+                panic!("insert_full_range called on a HashMap KeyedState")
             }
         };
     }
@@ -380,12 +429,6 @@ impl KeyedState {
             Box::new(r.flat_map(|(_, rows)| rows))
         }
 
-        macro_rules! full_range {
-            ($m: expr) => {
-                $m.range(&(..)).map(flatten_rows).map_err(to_misses)
-            };
-        }
-
         macro_rules! range {
             ($m: expr, $range: ident) => {
                 $m.range($range).map(flatten_rows).map_err(to_misses)
@@ -393,19 +436,6 @@ impl KeyedState {
         }
 
         match (self, key) {
-            (KeyedState::SingleBTree(m), &RangeKey::Unbounded) => m
-                .range(&(..))
-                .map_err(|misses| {
-                    misses
-                        .into_iter()
-                        .map(|(lower, upper)| (lower.map(|k| vec![k]), upper.map(|k| vec![k])))
-                        .collect()
-                })
-                .map(flatten_rows),
-            (KeyedState::DoubleBTree(m), &RangeKey::Unbounded) => full_range!(m),
-            (KeyedState::TriBTree(m), &RangeKey::Unbounded) => full_range!(m),
-            (KeyedState::QuadBTree(m), &RangeKey::Unbounded) => full_range!(m),
-            (KeyedState::SexBTree(m), &RangeKey::Unbounded) => full_range!(m),
             (KeyedState::SingleBTree(m), RangeKey::Single(range)) => {
                 m.range(range).map(flatten_rows).map_err(|misses| {
                     misses

--- a/dataflow-state/src/lib.rs
+++ b/dataflow-state/src/lib.rs
@@ -10,7 +10,7 @@ mod single_state;
 use std::borrow::Cow;
 use std::fmt::{self, Debug};
 use std::iter::FromIterator;
-use std::ops::{Bound, Deref};
+use std::ops::Deref;
 use std::rc::Rc;
 use std::vec;
 
@@ -23,7 +23,7 @@ pub use partial_map::PartialMap;
 use readyset_client::debug::info::KeyCount;
 use readyset_client::internal::Index;
 use readyset_client::{KeyComparison, PersistencePoint};
-use readyset_data::DfValue;
+use readyset_data::{Bound, DfValue};
 use readyset_errors::ReadySetResult;
 use replication_offset::ReplicationOffset;
 use serde::{Deserialize, Serialize};

--- a/dataflow-state/src/mk_key.rs
+++ b/dataflow-state/src/mk_key.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
-use std::ops::{Bound, RangeBounds};
+
+use readyset_data::{Bound, RangeBounds};
 
 #[macro_export]
 macro_rules! adapt_range {

--- a/dataflow-state/src/single_state.rs
+++ b/dataflow-state/src/single_state.rs
@@ -1,11 +1,10 @@
-use std::ops::{Bound, RangeBounds};
 use std::rc::Rc;
 
 use common::{IndexType, SizeOf};
 use itertools::Either;
 use readyset_client::internal::Index;
 use readyset_client::KeyComparison;
-use readyset_data::DfValue;
+use readyset_data::{Bound, DfValue, RangeBounds};
 use vec1::Vec1;
 
 use crate::keyed_state::KeyedState;
@@ -48,7 +47,7 @@ impl SingleState {
         if !partial && index.index_type == IndexType::BTreeMap {
             // For fully materialized indices, we never miss - so mark that the full range of keys
             // has been filled.
-            state.insert_range((Bound::Unbounded, Bound::Unbounded))
+            state.insert_full_range();
         }
         Self {
             index,
@@ -444,8 +443,7 @@ impl SingleState {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Bound;
-
+    use readyset_data::Bound;
     use vec1::vec1;
 
     use super::*;

--- a/logictests/null_ranges.test
+++ b/logictests/null_ranges.test
@@ -1,0 +1,18 @@
+statement ok
+CREATE TABLE t (x int)
+
+statement ok
+INSERT INTO t (x) VALUES (1), (NULL), (2)
+
+query nosort
+SELECT x FROM t WHERE x < 3
+----
+1
+2
+
+query nosort
+SELECT x FROM t WHERE x > 0
+----
+1
+2
+

--- a/logictests/psql/date_trunc.test
+++ b/logictests/psql/date_trunc.test
@@ -1,0 +1,111 @@
+# tests for readyset's support of the postgres builtin function `date_trunc`.
+# these are based on the tests from postgres's regression tests (located in
+# `//postgres/src/test/regress/expected/`).
+# Note: the outputs from the postgres regression files are in a different `datestyle`
+# than ISO (which is all readyset deals with), so the outputs here a slightly
+# translated from the original test code.
+
+# `timestamp` type conversions
+statement ok
+CREATE TABLE trunc_test_ts(id int, ts timestamp)
+
+statement ok
+INSERT INTO trunc_test_ts values(1, '1970-03-20 04:30:00.00000')
+
+query D nosort
+SELECT DATE_TRUNC('millennium', ts) from trunc_test_ts where id = 1 
+----
+1001-01-01 00:00:00
+
+query D nosort
+SELECT DATE_TRUNC('CENTURY', ts) from trunc_test_ts where id = 1 
+----
+1901-01-01 00:00:00
+
+statement ok
+INSERT INTO trunc_test_ts values(2, '2004-02-29 15:44:17.71393')
+
+query D nosort
+SELECT DATE_TRUNC('week', ts) from trunc_test_ts where id = 2 
+----
+2004-02-23 00:00:00
+
+statement ok
+INSERT INTO trunc_test_ts values(3, '214-02-05 15:40:00 BC')
+
+query D nosort
+SELECT ts from trunc_test_ts where id = 3
+----
+0214-02-05 15:40:00 BC
+
+query D nosort
+SELECT DATE_TRUNC('year', ts) from trunc_test_ts where id = 3
+----
+0214-01-01 00:00:00 BC
+
+query D nosort
+SELECT DATE_TRUNC('century', ts) from trunc_test_ts where id = 3
+----
+0300-01-01 00:00:00 BC
+
+query D nosort
+SELECT DATE_TRUNC('millennium', ts) from trunc_test_ts where id = 3
+----
+1000-01-01 00:00:00 BC
+
+
+# `timestamptz` type conversions
+statement ok
+CREATE TABLE trunc_test_tstz(id int, ts timestamptz)
+
+statement ok
+INSERT INTO trunc_test_tstz values(1, '2004-02-29 15:44:17.71393-0800')
+
+query Z nosort
+SELECT DATE_TRUNC('week', ts) from trunc_test_tstz where id = 1
+----
+2004-02-23 00:00:00-0000
+
+
+# `date` type conversions
+statement ok
+CREATE TABLE trunc_test_date(id int, d date)
+
+statement ok
+INSERT INTO trunc_test_date values(1, '1970-03-20')
+
+query D nosort
+SELECT DATE_TRUNC('millennium', d) from trunc_test_date where id = 1
+----
+1001-01-01 00:00:00
+
+query D nosort
+SELECT DATE_TRUNC('century', d) from trunc_test_date where id = 1
+----
+1901-01-01 00:00:00
+
+statement ok
+INSERT INTO trunc_test_date values(2, '2004-08-10')
+
+query D nosort
+SELECT DATE_TRUNC('century', d) from trunc_test_date where id = 2
+----
+2001-01-01 00:00:00
+
+statement ok
+INSERT INTO trunc_test_date values(3, '0004-02-02')
+
+query D nosort
+SELECT DATE_TRUNC('century', d) from trunc_test_date where id = 3
+----
+0001-01-01 00:00:00
+
+statement ok
+INSERT INTO trunc_test_date values(4, '1993-12-25')
+
+query D nosort
+SELECT DATE_TRUNC('decade', d) from trunc_test_date where id = 4
+----
+1990-01-01 00:00:00
+
+

--- a/mysql-srv/src/lib.rs
+++ b/mysql-srv/src/lib.rs
@@ -172,7 +172,7 @@ use std::io;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use constants::{CLIENT_PLUGIN_AUTH, PROTOCOL_41, RESERVED, SECURE_CONNECTION};
+use constants::{CLIENT_PLUGIN_AUTH, CONNECT_WITH_DB, PROTOCOL_41, RESERVED, SECURE_CONNECTION};
 use error::{other_error, OtherErrorKind};
 use mysql_common::constants::CapabilityFlags;
 use readyset_adapter_types::{DeallocateId, ParsedCommand};
@@ -388,7 +388,8 @@ struct StatementData {
     params: u16,
 }
 
-const CAPABILITIES: u32 = PROTOCOL_41 | SECURE_CONNECTION | RESERVED | CLIENT_PLUGIN_AUTH;
+const CAPABILITIES: u32 =
+    PROTOCOL_41 | SECURE_CONNECTION | RESERVED | CLIENT_PLUGIN_AUTH | CONNECT_WITH_DB;
 
 impl<B: MySqlShim<W> + Send, R: AsyncRead + Unpin, W: AsyncWrite + Unpin + Send>
     MySqlIntermediary<B, R, W>

--- a/partial-map/Cargo.toml
+++ b/partial-map/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 merging-interval-tree = { path = "../merging-interval-tree" }
+readyset-util = { path = "../readyset-util" }

--- a/psql-srv/Cargo.toml
+++ b/psql-srv/Cargo.toml
@@ -43,7 +43,7 @@ readyset-data = { path = "../readyset-data" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-tokio-test = "0.4.1"
+tokio-test = { workspace = true }
 database-utils = { path = "../database-utils" }
 readyset-tracing = { path = "../readyset-tracing" }
 postgres-native-tls = { workspace = true }

--- a/reader-map/Cargo.toml
+++ b/reader-map/Cargo.toml
@@ -13,6 +13,7 @@ left-right = "0.11"
 itertools = "0.10"
 
 readyset-client = { path = "../readyset-client" }
+readyset-util = { path = "../readyset-util" }
 partial-map = { path = "../partial-map" }
 thiserror = "1.0.31"
 iter-enum = "1.1.1"

--- a/reader-map/src/inner.rs
+++ b/reader-map/src/inner.rs
@@ -2,12 +2,12 @@ use std::borrow::Borrow;
 use std::collections::{hash_map, HashMap};
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::ops::{Bound, RangeBounds};
 
 use iter_enum::{ExactSizeIterator, Iterator};
 use itertools::Either;
 use partial_map::PartialMap;
 use readyset_client::internal::IndexType;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 use crate::eviction::{EvictionMeta, EvictionStrategy};
 use crate::values::Values;
@@ -143,6 +143,15 @@ impl<K, V, S> Data<K, V, S> {
     {
         if let Self::BTreeMap(ref mut map, ..) = self {
             map.insert_range(range);
+        }
+    }
+
+    pub(crate) fn add_full_range(&mut self)
+    where
+        K: Ord + Clone,
+    {
+        if let Self::BTreeMap(ref mut map, ..) = self {
+            map.insert_full_range();
         }
     }
 

--- a/reader-map/src/read/read_ref.rs
+++ b/reader-map/src/read/read_ref.rs
@@ -3,9 +3,9 @@ use std::collections::btree_map;
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::ops::RangeBounds;
 
 use left_right::ReadGuard;
+use readyset_util::ranges::RangeBounds;
 
 use crate::inner::{Inner, Miss};
 use crate::values::Values;

--- a/reader-map/src/write.rs
+++ b/reader-map/src/write.rs
@@ -1,11 +1,11 @@
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
-use std::ops::{Bound, RangeBounds};
 
 use left_right::Absorb;
 use partial_map::InsertionOrder;
 use readyset_client::internal::IndexType;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 use crate::eviction::EvictionMeta;
 use crate::inner::Inner;
@@ -175,6 +175,11 @@ where
             range.start_bound().cloned(),
             range.end_bound().cloned(),
         )))
+    }
+
+    /// Inserts the full range of keys into the map.
+    pub fn insert_full_range(&mut self) -> &mut Self {
+        self.add_op(Operation::AddFullRange)
     }
 
     /// Clear the value-bag of the given key, without removing it.
@@ -388,6 +393,7 @@ where
                 }
             }
             Operation::AddRange(range) => self.data.add_range(range.clone()),
+            Operation::AddFullRange => self.data.add_full_range(),
             Operation::Clear(key, eviction_meta) => {
                 self.data_entry(key.clone(), eviction_meta).clear()
             }
@@ -455,6 +461,7 @@ where
                 }
             }
             Operation::AddRange(range) => self.data.add_range(range),
+            Operation::AddFullRange => self.data.add_full_range(),
             Operation::Clear(key, mut eviction_meta) => {
                 self.data_entry(key, &mut eviction_meta).clear()
             }
@@ -516,6 +523,8 @@ pub(super) enum Operation<K, V, M, T> {
     Add(K, V, Option<EvictionMeta>, Option<usize>),
     /// Add an interval to the list of filled intervals
     AddRange((Bound<K>, Bound<K>)),
+    /// Add the full range of keys
+    AddFullRange,
     /// Remove this value from the set of entries for this key. Last element of the tuple is the
     /// removal index for [`absorb_second`] and computed in [`absorb_first`]
     RemoveValue(K, V, Option<usize>),
@@ -550,6 +559,7 @@ where
         match self {
             Operation::Add(a, b, c, _) => f.debug_tuple("Add").field(a).field(b).field(c).finish(),
             Operation::AddRange(a) => f.debug_tuple("AddRange").field(a).finish(),
+            Operation::AddFullRange => f.debug_tuple("AddFullRange").finish(),
             Operation::RemoveValue(a, b, _) => {
                 f.debug_tuple("RemoveValue").field(a).field(b).finish()
             }

--- a/reader-map/tests/quick.rs
+++ b/reader-map/tests/quick.rs
@@ -14,10 +14,11 @@ use std::cmp::{min, Ord};
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Debug;
 use std::hash::{BuildHasher, Hash};
-use std::ops::{Bound, Deref, RangeBounds};
+use std::ops::Deref;
 
 use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
+use readyset_util::ranges::{Bound, RangeBounds};
 
 fn set<'a, T: 'a, I>(iter: I) -> HashSet<T>
 where

--- a/readyset-client/src/view.rs
+++ b/readyset-client/src/view.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
-use std::ops::{Bound, Range, RangeBounds};
+use std::ops::Range;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -26,7 +26,7 @@ use petgraph::graph::NodeIndex;
 use proptest::arbitrary::Arbitrary;
 use rand::prelude::IteratorRandom;
 use rand::thread_rng;
-use readyset_data::{DfType, DfValue};
+use readyset_data::{Bound, BoundedRange, DfType, DfValue, IntoBoundedRange, RangeBounds};
 use readyset_errors::{
     internal, internal_err, rpc_err, unsupported, view_err, ReadySetError, ReadySetResult,
 };
@@ -34,7 +34,7 @@ use readyset_sql_passes::anonymize::{Anonymize, Anonymizer};
 use readyset_tracing::child_span;
 use readyset_tracing::presampled::instrument_if_enabled;
 use readyset_tracing::propagation::Instrumented;
-use readyset_util::intervals::{cmp_start_end, BoundPair};
+use readyset_util::intervals::cmp_start_end;
 use readyset_util::redacted::Sensitive;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -378,7 +378,7 @@ pub enum KeyComparison {
     Equal(Vec1<DfValue>),
 
     /// Look up all keys within a range
-    Range(BoundPair<Vec1<DfValue>>),
+    Range(BoundedRange<Vec1<DfValue>>),
 }
 
 #[allow(clippy::len_without_is_empty)] // can never be empty
@@ -393,10 +393,10 @@ impl KeyComparison {
 
         let key = Vec1::try_from(key).map_err(|_| ReadySetError::EmptyKey)?;
         let inner = match operator {
-            Greater => (Bound::Excluded(key), Bound::Unbounded),
-            GreaterOrEqual => (Bound::Included(key), Bound::Unbounded),
-            Less => (Bound::Unbounded, Bound::Excluded(key)),
-            LessOrEqual => (Bound::Unbounded, Bound::Included(key)),
+            Greater => key.range_from(),
+            GreaterOrEqual => key.range_from_inclusive(),
+            Less => key.range_to(),
+            LessOrEqual => key.range_to_inclusive(),
             Equal => return Ok(key.into()),
             _ => unsupported!("Unsupported operator `{operator}` in key"),
         };
@@ -434,7 +434,7 @@ impl KeyComparison {
 
     /// Project a KeyComparison into an optional range predicate, or return None if it's a range
     /// predicate
-    pub fn range(&self) -> Option<&BoundPair<Vec1<DfValue>>> {
+    pub fn range(&self) -> Option<&BoundedRange<Vec1<DfValue>>> {
         match self {
             KeyComparison::Range(ref range) => Some(range),
             _ => None,
@@ -489,8 +489,8 @@ impl KeyComparison {
     /// ```
     pub fn is_reversed_range(&self) -> bool {
         cmp_start_end(
-            <Self as RangeBounds<Vec1<DfValue>>>::start_bound(self),
-            <Self as RangeBounds<Vec1<DfValue>>>::end_bound(self),
+            <Self as RangeBounds<Vec1<DfValue>>>::start_bound(self).into(),
+            <Self as RangeBounds<Vec1<DfValue>>>::end_bound(self).into(),
         ) == Ordering::Greater
     }
 
@@ -522,24 +522,18 @@ impl KeyComparison {
         self.shard_keys_at(0, num_shards)
     }
 
-    /// Returns the length of the key this [`KeyComparison`] is comparing against, or None if this
-    /// is an unbounded lookup
+    /// Returns the length of the key this [`KeyComparison`] is comparing against.
     ///
-    /// Since all KeyComparisons wrap a [`Vec1`], this function will never return `Some(0)`
-    pub fn len(&self) -> Option<usize> {
+    /// Since all KeyComparisons wrap a [`Vec1`], this function will never return 0
+    pub fn len(&self) -> usize {
         match self {
-            Self::Equal(key) => Some(key.len()),
-            Self::Range((Bound::Unbounded, Bound::Unbounded)) => None,
-            Self::Range(
-                (Bound::Included(ref key) | Bound::Excluded(ref key), Bound::Unbounded)
-                | (Bound::Unbounded, Bound::Included(ref key) | Bound::Excluded(ref key)),
-            ) => Some(key.len()),
+            Self::Equal(key) => key.len(),
             Self::Range((
                 Bound::Included(ref start) | Bound::Excluded(ref start),
                 Bound::Included(ref end) | Bound::Excluded(ref end),
             )) => {
                 debug_assert_eq!(start.len(), end.len());
-                Some(start.len())
+                start.len()
             }
         }
     }
@@ -569,9 +563,8 @@ impl KeyComparison {
     /// Range keys contain anything in the range, comparing lexicographically
     ///
     /// ```rust
-    /// use std::ops::Bound::*;
-    ///
     /// use readyset_client::KeyComparison;
+    /// use readyset_data::Bound::*;
     /// use readyset_data::DfValue;
     /// use vec1::vec1;
     ///
@@ -593,11 +586,9 @@ impl KeyComparison {
                 (match lower {
                     Bound::Included(start) => key.clone().into_iter().cmp(start.iter()).is_ge(),
                     Bound::Excluded(start) => key.clone().into_iter().cmp(start.iter()).is_gt(),
-                    Bound::Unbounded => true,
                 }) && (match upper {
                     Bound::Included(end) => key.into_iter().cmp(end.iter()).is_le(),
                     Bound::Excluded(end) => key.into_iter().cmp(end.iter()).is_lt(),
-                    Bound::Unbounded => true,
                 })
             }
         }
@@ -678,24 +669,16 @@ impl From<Range<Vec1<DfValue>>> for KeyComparison {
     }
 }
 
-impl TryFrom<BoundPair<Vec<DfValue>>> for KeyComparison {
+impl TryFrom<BoundedRange<Vec<DfValue>>> for KeyComparison {
     type Error = vec1::Size0Error;
 
     /// Converts to a [`KeyComparison::Range`]
-    fn try_from((lower, upper): BoundPair<Vec<DfValue>>) -> Result<Self, Self::Error> {
+    fn try_from((lower, upper): BoundedRange<Vec<DfValue>>) -> Result<Self, Self::Error> {
         let convert_bound = |bound| match bound {
-            Bound::Unbounded => Ok(Bound::Unbounded),
             Bound::Included(x) => Ok(Bound::Included(Vec1::try_from(x)?)),
             Bound::Excluded(x) => Ok(Bound::Excluded(Vec1::try_from(x)?)),
         };
         Ok(Self::Range((convert_bound(lower)?, convert_bound(upper)?)))
-    }
-}
-
-impl From<BoundPair<Vec1<DfValue>>> for KeyComparison {
-    /// Converts to a [`KeyComparison::Range`]
-    fn from(range: BoundPair<Vec1<DfValue>>) -> Self {
-        KeyComparison::Range(range)
     }
 }
 
@@ -705,9 +688,7 @@ impl RangeBounds<Vec1<DfValue>> for KeyComparison {
         use KeyComparison::*;
         match self {
             Equal(ref key) => Included(key),
-            Range((Unbounded, _)) => Unbounded,
-            Range((Included(ref k), _)) => Included(k),
-            Range((Excluded(ref k), _)) => Excluded(k),
+            Range(bp) => bp.start_bound(),
         }
     }
 
@@ -716,9 +697,7 @@ impl RangeBounds<Vec1<DfValue>> for KeyComparison {
         use KeyComparison::*;
         match self {
             Equal(ref key) => Included(key),
-            Range((_, Unbounded)) => Unbounded,
-            Range((_, Included(ref k))) => Included(k),
-            Range((_, Excluded(ref k))) => Excluded(k),
+            Range(bp) => bp.end_bound(),
         }
     }
 }
@@ -735,24 +714,18 @@ impl RangeBounds<Vec<DfValue>> for KeyComparison {
 
 impl RangeBounds<Vec1<DfValue>> for &KeyComparison {
     fn start_bound(&self) -> Bound<&Vec1<DfValue>> {
-        use Bound::*;
         use KeyComparison::*;
         match self {
-            Equal(ref key) => Included(key),
-            Range((Unbounded, _)) => Unbounded,
-            Range((Included(ref k), _)) => Included(k),
-            Range((Excluded(ref k), _)) => Excluded(k),
+            Equal(ref key) => Bound::Included(key),
+            Range(bp) => bp.start_bound(),
         }
     }
 
     fn end_bound(&self) -> Bound<&Vec1<DfValue>> {
-        use Bound::*;
         use KeyComparison::*;
         match self {
-            Equal(ref key) => Included(key),
-            Range((_, Unbounded)) => Unbounded,
-            Range((_, Included(ref k))) => Included(k),
-            Range((_, Excluded(ref k))) => Excluded(k),
+            Equal(ref key) => Bound::Included(key),
+            Range(bp) => bp.end_bound(),
         }
     }
 }
@@ -764,6 +737,16 @@ impl RangeBounds<Vec<DfValue>> for &KeyComparison {
 
     fn end_bound(&self) -> Bound<&Vec<DfValue>> {
         (**self).end_bound()
+    }
+}
+
+impl std::ops::RangeBounds<Vec<DfValue>> for KeyComparison {
+    fn start_bound(&self) -> std::ops::Bound<&Vec<DfValue>> {
+        RangeBounds::start_bound(self).into()
+    }
+
+    fn end_bound(&self) -> std::ops::Bound<&Vec<DfValue>> {
+        RangeBounds::end_bound(self).into()
     }
 }
 
@@ -2351,10 +2334,9 @@ mod tests {
 
             assert_eq!(
                 query.key_comparisons,
-                vec![KeyComparison::Range((
-                    Bound::Excluded(vec1![DfValue::from(1), DfValue::from("a")]),
-                    Bound::Unbounded
-                ))]
+                vec![KeyComparison::Range(
+                    vec1![DfValue::from(1), DfValue::from("a")].range_from()
+                )]
             );
         }
 
@@ -2396,10 +2378,9 @@ mod tests {
 
             assert_eq!(
                 query.key_comparisons,
-                vec![KeyComparison::Range((
-                    Bound::Included(vec1![DfValue::from(1), DfValue::from("a")]),
-                    Bound::Unbounded
-                ))]
+                vec![KeyComparison::Range(
+                    vec1![DfValue::from(1), DfValue::from("a")].range_from_inclusive(),
+                )]
             );
         }
 

--- a/readyset-data/src/timestamp.rs
+++ b/readyset-data/src/timestamp.rs
@@ -260,6 +260,10 @@ impl FromStr for TimestampTz {
                     TIMESTAMP_TZ_PARSE_FORMAT,
                 ) {
                     Ok(dt.into())
+                } else if let Ok(dt) =
+                    NaiveDateTime::parse_from_str(&neg_year_str, TIMESTAMP_PARSE_FORMAT)
+                {
+                    Ok(dt.into())
                 } else {
                     let d = NaiveDate::parse_from_str(&neg_year_str, DATE_FORMAT)?;
                     Ok(d.into())
@@ -726,6 +730,7 @@ mod tests {
 
         #[allow(clippy::zero_prefixed_literal)]
         let year_5_bce = -0004;
+        // BC date with time zone
         assert_eq!(
             TimestampTz::from_str("0005-02-29 12:34:56+00 BC")
                 .unwrap()
@@ -733,6 +738,17 @@ mod tests {
             chrono::FixedOffset::east_opt(0)
                 .unwrap()
                 .with_ymd_and_hms(year_5_bce, 2, 29, 12, 34, 56)
+                .single()
+                .unwrap()
+        );
+        // BC date without time zone
+        assert_eq!(
+            TimestampTz::from_str("0005-02-21 12:34:56 BC")
+                .unwrap()
+                .to_chrono(),
+            chrono::FixedOffset::east_opt(0)
+                .unwrap()
+                .with_ymd_and_hms(year_5_bce, 2, 21, 12, 34, 56)
                 .single()
                 .unwrap()
         );

--- a/readyset-dataflow/src/backlog/multir.rs
+++ b/readyset-dataflow/src/backlog/multir.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::convert::TryInto;
-use std::ops::RangeBounds;
 
 use ahash::RandomState;
 use common::DfValue;
@@ -11,6 +10,7 @@ use readyset_client::consistency::Timestamp;
 use readyset_client::results::{SharedResults, SharedRows};
 use readyset_client::KeyComparison;
 use readyset_errors::ReadySetError;
+use readyset_util::ranges::RangeBounds;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use vec1::{vec1, Vec1};
@@ -353,10 +353,9 @@ impl Handle {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Bound;
-
     use proptest::prelude::*;
     use reader_map::handles::WriteHandle;
+    use readyset_data::Bound;
 
     use super::*;
 

--- a/readyset-dataflow/src/backlog/multiw.rs
+++ b/readyset-dataflow/src/backlog/multiw.rs
@@ -1,9 +1,9 @@
-use std::ops::{Bound, RangeBounds};
-
 use ahash::RandomState;
 use dataflow_expression::PreInsertion;
 use reader_map::EvictionQuantity;
 use readyset_client::consistency::Timestamp;
+use readyset_data::Bound;
+use readyset_util::ranges::RangeBounds;
 
 use super::{key_to_single, Key};
 use crate::prelude::*;

--- a/readyset-dataflow/src/node/special/packet_filter.rs
+++ b/readyset-dataflow/src/node/special/packet_filter.rs
@@ -1,9 +1,9 @@
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::ops::Bound;
 
 use common::DfValue;
 use readyset_client::KeyComparison;
+use readyset_data::Bound;
 use readyset_errors::{internal, ReadySetResult};
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;
@@ -174,7 +174,6 @@ fn check_lower_bound(lower_bound: &Bound<Vec1<DfValue>>, ci: &[usize], row: &[Df
             check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 >= d2)
         }
         Bound::Excluded(bound) => check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 > d2),
-        Bound::Unbounded => true,
     }
 }
 
@@ -184,7 +183,6 @@ fn check_upper_bound(upper_bound: &Bound<Vec1<DfValue>>, ci: &[usize], row: &[Df
             check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 <= d2)
         }
         Bound::Excluded(bound) => check_bound(ci, row, bound, |d1: &DfValue, d2: &DfValue| d1 < d2),
-        Bound::Unbounded => true,
     }
 }
 
@@ -231,8 +229,6 @@ mod test {
     }
 
     mod update_processing {
-        use std::ops::Bound;
-
         use common::Record;
 
         use super::*;

--- a/readyset-dataflow/src/processing.rs
+++ b/readyset-dataflow/src/processing.rs
@@ -1,13 +1,14 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
-use std::ops::{Bound, RangeBounds};
 use std::{iter, mem};
 
 use dataflow_state::PointKey;
 use derive_more::From;
 use readyset_client::KeyComparison;
+use readyset_data::Bound;
 use readyset_errors::ReadySetResult;
+use readyset_util::ranges::RangeBounds;
 use readyset_util::Indices;
 use serde::{Deserialize, Serialize};
 use vec1::Vec1;

--- a/readyset-logictest/README.md
+++ b/readyset-logictest/README.md
@@ -1,0 +1,27 @@
+This crate is a Readyset-specific, rust implmentation of the [SQLite
+sqllogictest](https://sqlite.org/sqllogictest/doc/trunk/about.wiki) 
+testing suite. We follow most of the conventions of the original
+sqllogictest, so please check out it's wiki.
+
+# Supported data types
+
+Sqllogictest supports three data types:
+
+- `I` - integer
+- `T` - varchar(30)
+- `R` - real
+
+The intent is to keep things as simple as possible for this kind of test.
+We have found that to be mostly sufficient, but we've added support to
+`readyset-logictest` for a few additional data types:
+
+- `D` - date, although this is actually a `datetime` or `timestamp`
+- `M` - time, a simple clock time with no date component
+- `Z` - timestamptz, a datetime with timezone information
+- `BV` - bit vector
+
+The following types have partial support; YMMV as of this writing:
+
+- `F` - numeric, a fixed-point number
+- `B` - byte array
+

--- a/readyset-server/src/integration.rs
+++ b/readyset-server/src/integration.rs
@@ -7,7 +7,6 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::ops::Bound;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{iter, thread};
@@ -36,7 +35,7 @@ use readyset_client::consistency::Timestamp;
 use readyset_client::internal::LocalNodeIndex;
 use readyset_client::recipe::changelist::{Change, ChangeList, CreateCache};
 use readyset_client::{KeyComparison, Modification, SchemaType, ViewPlaceholder, ViewQuery};
-use readyset_data::{DfType, DfValue, Dialect};
+use readyset_data::{Bound, DfType, DfValue, Dialect, IntoBoundedRange};
 use readyset_errors::ReadySetError::{self, RpcFailed, SelectQueryCreationFailed};
 use readyset_util::eventually;
 use readyset_util::shutdown::ShutdownSender;
@@ -5227,7 +5226,10 @@ async fn post_read_ilike() {
 
     let res = reader
         .raw_lookup(ViewQuery {
-            key_comparisons: vec![KeyComparison::from_range(&(..))],
+            key_comparisons: vec![KeyComparison::Range((
+                Bound::Excluded(vec1![DfValue::MIN]),
+                Bound::Excluded(vec1![DfValue::MAX]),
+            ))],
             block: true,
             filter: Some(DfExpr::Op {
                 left: Box::new(DfExpr::Column {
@@ -7091,10 +7093,9 @@ async fn straddled_join_range_query() {
 
     let rows = q
         .multi_lookup(
-            vec![KeyComparison::Range((
-                Bound::Excluded(vec1![1i32.into(), 1i32.into()]),
-                Bound::Unbounded,
-            ))],
+            vec![KeyComparison::Range(
+                vec1![1i32.into(), 1i32.into()].range_from(),
+            )],
             true,
         )
         .await
@@ -7145,10 +7146,9 @@ async fn overlapping_range_queries() {
             let mut q = g.view("q").await.unwrap().into_reader_handle().unwrap();
             let results = q
                 .multi_lookup(
-                    vec![KeyComparison::Range((
-                        Bound::Included(vec1![DfValue::from(m * 10)]),
-                        Bound::Unbounded,
-                    ))],
+                    vec![KeyComparison::Range(
+                        vec1![DfValue::from(m * 10)].range_from_inclusive(),
+                    )],
                     true,
                 )
                 .await
@@ -7219,10 +7219,9 @@ async fn overlapping_remapped_range_queries() {
             let mut q = g.view("q").await.unwrap().into_reader_handle().unwrap();
             let results = q
                 .multi_lookup(
-                    vec![KeyComparison::Range((
-                        Bound::Included(vec1![DfValue::from(m * 10), DfValue::from(m * 10)]),
-                        Bound::Unbounded,
-                    ))],
+                    vec![KeyComparison::Range(
+                        vec1![DfValue::from(m * 10), DfValue::from(m * 10)].range_from_inclusive(),
+                    )],
                     true,
                 )
                 .await
@@ -7293,10 +7292,7 @@ async fn range_query_through_union() {
 
     let rows = q
         .multi_lookup(
-            vec![KeyComparison::Range((
-                Bound::Excluded(vec1![1.into()]),
-                Bound::Unbounded,
-            ))],
+            vec![KeyComparison::Range(vec1![1.into()].range_from())],
             true,
         )
         .await

--- a/replicators/src/noria_adapter.rs
+++ b/replicators/src/noria_adapter.rs
@@ -932,11 +932,25 @@ impl NoriaAdapter {
             table
         } else {
             // The only error we are semi "ok" to ignore for table actions is when a table is not
-            // found. Failing to execute an action for an existing table may very well get noria
-            // into an inconsistent state. This may happen if eg. a worker fails.
-            // This is Ok, since replicator task will reconnect again and retry the action as many
-            // times as needed for it to succeed, but it is not safe to continue past this point on
-            // a failure.
+            // found and should not be replicated. Failing to execute an action for an existing
+            // table may very well get noria into an inconsistent state. This may happen
+            // if eg. a worker fails. This is Ok, since replicator task will reconnect
+            // again and retry the action as many times as needed for it to succeed, but
+            // it is not safe to continue past this point on a failure.
+
+            if self.table_filter.should_be_processed(
+                table.schema.as_deref().ok_or_else(|| {
+                    internal_err!("All tables should have a schema in the replicator")
+                })?,
+                &table.name,
+            ) {
+                warn!(
+                    table_name = %table.display(nom_sql::Dialect::PostgreSQL),
+                    num_actions = actions.len(),
+                    "Could not find table, Resnapshot needed"
+                );
+                return Err(ReadySetError::ResnapshotNeeded);
+            }
             if self.warned_missing_tables.insert(table.clone()) {
                 warn!(
                     table_name = %table.display(nom_sql::Dialect::PostgreSQL),

--- a/replicators/tests/tests.rs
+++ b/replicators/tests/tests.rs
@@ -2857,3 +2857,55 @@ async fn pgsql_dont_replicate_partitioned_table() {
 
     shutdown_tx.shutdown().await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[serial_test::serial]
+#[slow]
+async fn pgsql_create_table_as() {
+    readyset_tracing::init_test_logging();
+    let url = pgsql_url();
+    let mut client = DbConnection::connect(&url).await.unwrap();
+
+    let (mut ctx, shutdown_tx) = TestHandle::start_noria(url.to_string(), None)
+        .await
+        .unwrap();
+
+    ctx.notification_channel
+        .as_mut()
+        .unwrap()
+        .snapshot_completed()
+        .await
+        .unwrap();
+
+    client
+        .query(
+            "DROP TABLE IF EXISTS tb_as_1 CASCADE;
+             CREATE TABLE tb_as_1 (x int);
+             INSERT INTO tb_as_1 (x) VALUES (1), (2), (3);
+             DROP TABLE IF EXISTS tb_as_2 CASCADE;
+             CREATE TABLE tb_as_2 AS SELECT * FROM tb_as_1;
+             DROP TABLE IF EXISTS tb_into_1 CASCADE;
+             SELECT * INTO TABLE tb_into_1 FROM tb_as_1 WHERE x < 2;
+             ",
+        )
+        .await
+        .unwrap();
+
+    ctx.check_results(
+        "tb_as_2",
+        "pgsql_create_table_as",
+        &[
+            &[DfValue::from(1)],
+            &[DfValue::from(2)],
+            &[DfValue::from(3)],
+        ],
+    )
+    .await
+    .unwrap();
+
+    ctx.check_results("tb_into_1", "pgsql_create_table_as", &[&[DfValue::from(1)]])
+        .await
+        .unwrap();
+
+    shutdown_tx.shutdown().await;
+}


### PR DESCRIPTION
Previously, we used `Bound::Unbounded` to represent range keys that were
unbounded from above or below. This produced incorrect results when NULL
values were present in the columns being queried against: Postgres and
MySQL do not include NULL values in range queries against columns with
NULL values.

This commit replaces our usage of `std::ops::Bound` with a new,
custom `Bound` type that cannot represent an unbounded range. This
ensures that NULL values will only be included in result sets if they
are explicitly queried for.

Fixes: REA-4287
Release-Note-Core: Fixed an issue where NULL values were included in
  range queries that were unbounded from below
