### PR TITLE
mysql-srv: Fix auth plugin packet construction

### DIFF
--- a/mysql-srv/src/lib.rs
+++ b/mysql-srv/src/lib.rs
@@ -448,7 +448,9 @@ impl<B: MySqlShim<W> + Send, R: AsyncRead + Unpin, W: AsyncWrite + Unpin + Send>
         init_packet.extend_from_slice(&[0x21]); // UTF8_GENERAL_CI
         init_packet.extend_from_slice(&[0x00, 0x00]); // status flags
         init_packet.extend_from_slice(&CAPABILITIES.to_le_bytes()[2..]);
-        init_packet.extend_from_slice(&[auth_data.len() as u8]);
+        // We will add a \0 byte below so we need to account for that when sending the length, since
+        // rust strings don't add the null terminator
+        init_packet.extend_from_slice(&[(auth_data.len() + 1) as u8]);
         init_packet.extend_from_slice(&[0x00; 10][..]); // filler
         init_packet.extend_from_slice(&auth_data[8..]);
         init_packet.push(0);


### PR DESCRIPTION
MySQL auth plugins have a variable length depending on their name, so
the packet expects us to encode the length of the null-terminated string
that represents the plugin. We were adding the null terminators, but not
accounting for them with when encoding the length.

