### PR TITLE
readyset-psql: Mark fallback test as serial/slow

### DIFF
--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2612,6 +2612,8 @@ mod failure_injection_tests {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[serial]
+#[slow]
 async fn drop_and_recreate_demo_cache() {
     // This tests dropping and recreating the cached used by the readyset demo script.
     // There was an error returned at one point in doing this, so this test is an attempt to block


### PR DESCRIPTION
The tests in fallback.rs are serialized due to contending on the same
upstream database and are marked as slow so they don't run in CI by
default.

One of the tests was not marked as such and is likely the cause of
some flakiness we saw with the numeric_snapshot_nan test, which fails if
there are other tables than the one it expects being replicated.

