### PR TITLE
readyset: Set NON_BLOCKING_READS = true by default

### DIFF
--- a/readyset/src/lib.rs
+++ b/readyset/src/lib.rs
@@ -378,7 +378,7 @@ pub struct Options {
     fallback_recovery_seconds: u64,
 
     /// Whether to use non-blocking or blocking reads against the cache.
-    #[arg(long, env = "NON_BLOCKING_READS", hide = true)]
+    #[arg(long, env = "NON_BLOCKING_READS", default_value = "true", hide = true)]
     non_blocking_reads: bool,
 
     #[command(flatten)]


### PR DESCRIPTION
Non-blocking reads determines the behavior when we have a cache miss
that triggers an up-query. We have a choice of waiting for the upquery,
which will likely be more expensive latency-wise than querying upstream,
or querying upstream, which will be more load on the upstream than
waiting for the upquery.

Both behaviors could be desirable in different cases, but non-blocking
read behavior is more likely to be the desired behavior, as often
latency takes priority over load on upstream.

Release-Note-Core: Readyset now forwards queries to upstream when there
  is an upquery triggered by a cache miss by default, where previously
  it would block waiting for the upqery. This generally means queries
  that are a cache miss will have lower latency. This behavior can be
  configured with the `NON_BLOCKING_READS` startup parameter.
