### PR TITLE
partial-map: Remove stray comment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,9 +2042,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",

--- a/partial-map/src/lib.rs
+++ b/partial-map/src/lib.rs
@@ -289,7 +289,6 @@ where
     pub fn range<'a, R, Q>(
         &'a self,
         range: &R,
-        // TODO ethan here
     ) -> Result<Range<'a, K, V>, Vec<(Bound<K>, Bound<K>)>>
     where
         R: RangeBounds<Q>,


### PR DESCRIPTION
I accidentally left a TODO comment for myself in a commit that ended up
being merged to main. This commit removes it.

