### PR TITLE
reader-map: Rewrite quickcheck tests in proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,16 +1596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4146,29 +4136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44883e74aa97ad63db83c4bf8ca490f02b2fc02f92575e720c8551e843c945f"
-dependencies = [
- "env_logger",
- "log",
- "rand 0.7.3",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "quickcheck_macros"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608c156fd8e97febc07dc9c2e2c80bf74cfc6ef26893eae3daf8bc2bc94a4b7f"
-dependencies = [
- "proc-macro2 1.0.69",
- "quote 1.0.33",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,12 +4312,12 @@ dependencies = [
  "itertools",
  "left-right",
  "partial-map",
- "quickcheck",
- "quickcheck_macros",
+ "proptest",
  "rand 0.7.3",
  "readyset-client",
  "readyset-util",
  "smallvec",
+ "test-strategy",
  "thiserror",
  "triomphe",
 ]
@@ -5193,8 +5160,6 @@ dependencies = [
  "eui48",
  "futures",
  "proptest",
- "quickcheck",
- "rand 0.7.3",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/partial-map/src/lib.rs
+++ b/partial-map/src/lib.rs
@@ -289,7 +289,6 @@ where
     pub fn range<'a, R, Q>(
         &'a self,
         range: &R,
-        // TODO ethan here
     ) -> Result<Range<'a, K, V>, Vec<(Bound<K>, Bound<K>)>>
     where
         R: RangeBounds<Q>,

--- a/reader-map/Cargo.toml
+++ b/reader-map/Cargo.toml
@@ -19,5 +19,6 @@ thiserror = "1.0.31"
 iter-enum = "1.1.1"
 
 [dev-dependencies]
-quickcheck = "0.9"
-quickcheck_macros = "0.9"
+proptest = "1.0.0"
+test-strategy = "0.2.0"
+

--- a/reader-map/proptest-regressions/quick.txt
+++ b/reader-map/proptest-regressions/quick.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3a62f3267a92c5a31e12528a3ea72ed91d963e1c3d84dfb975756d19c1f78e11 # shrinks to input = _KeysValuesArgs { ops: [RemoveRange((Included(0), Excluded(0)))] }
+cc f4d3dbbfcf53c6e9333cd151f575f31d4f96be27f8ae4010bdbe8da1ccaaff51 # shrinks to input = _OperationsI8Args { ops: [RemoveRange((Included(0), Included(-1)))] }
+cc 8d361df8193a09078417b234807e7e22e95117f0c8d480f0a7a3d21f5f27d0bd # shrinks to input = _OperationsStringArgs { ops: [RemoveRange((Excluded("a"), Excluded(" ")))] }

--- a/readyset-psql/tests/fallback.rs
+++ b/readyset-psql/tests/fallback.rs
@@ -2805,13 +2805,20 @@ async fn numeric_snapshot_nan() {
             .into_iter()
             .filter_map(|m| {
                 if let SimpleQueryMessage::Row(r) = m {
-                    r.get(1).map(String::from)
+                    let (table, status) = (r.get(0).map(String::from).unwrap(), r.get(1).map(String::from).unwrap());
+                        // Tables from other tests can linger in the upstream, so filter this to only
+                        // numer
+                        if table.contains("numer") {
+                            Some((table, status))
+                        } else {
+                            None
+                        }
                 } else {
                     None
                 }
             })
             .last()
-            .unwrap();
+            .unwrap().1;
         AssertUnwindSafe(|| result)
     }, then_assert: |result| {
         assert!(result().contains("Not Replicated"));

--- a/readyset-util/Cargo.toml
+++ b/readyset-util/Cargo.toml
@@ -23,8 +23,6 @@ serde = { version = "1.0", features = ["derive"] }
 async-stream = "0.3.2"
 cidr = "0.2.1"
 thiserror = "1.0.26"
-quickcheck = "0.9"
-rand = "0.7"
 
 [dev-dependencies]
 test-strategy = "0.2.0"


### PR DESCRIPTION
The property tests in `reader-map/tests/quick.rs` were written using
the quickcheck crate. Given that we use proptest everywhere else, this
commit rewrites the tests in that file to use proptest, eliminating our
repository's dependency on quickcheck.

