### PR TITLE
build: Add thin LTO to release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ metrics-util = { git = "https://github.com/readysettech/metrics.git" }
 
 [profile.release]
 debug=true
+lto="thin"
 
 [profile.release-dist]
 # configs for distro release packages (i.e. deb, rpm, etc.)


### PR DESCRIPTION
This commit enables "thin" link time optimization on release builds. Per
my local testing, compile times are roughly equivalent to compile times
with `lto=false`, but thin LTO improves performance by ~10% when it
comes to proxying and a few selected benchmarks I ran.

On my machine, a release build with thin LTO took about 6 minutes to
complete, and a release build with fat LTO took about 20 minutes to
complete. Fat LTO only exhibited about 1-2% better performance than thin
LTO, so it doesn't seem worth the increased compile times.

Release-Note-Core: Enabled thin link time optimization in release
  builds, generally improving performance by about 10%
