### PR TITLE
psql-srv: Use optimized date+time encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,6 +4038,7 @@ dependencies = [
  "readyset-adapter-types",
  "readyset-data",
  "readyset-tracing",
+ "readyset-util",
  "rust_decimal",
  "serde_json",
  "sha2",

--- a/psql-srv/Cargo.toml
+++ b/psql-srv/Cargo.toml
@@ -40,6 +40,7 @@ uuid = "0.8"
 nom-sql = { path = "../nom-sql" }
 readyset-adapter-types = { path = "../readyset-adapter-types" }
 readyset-data = { path = "../readyset-data" }
+readyset-util = { path = "../readyset-util" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
This commit replaces our usage of chrono's `format()` methods with our
handwritten optimized encoding algorithms in psql-srv in the code we use
to encode rows before sending them over the wire. This significantly
improves warm read time for queries that include timestamps in their
result sets.

Release-Note-Core: Significantly improved warm read performance for
  certain queries that return timestamps
