### PR TITLE
df-expr: Coerce type in filters during lowering

### DIFF
--- a/dataflow-expression/src/lib.rs
+++ b/dataflow-expression/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(box_patterns, let_chains)]
+#![feature(let_chains)]
 
 mod binary_operator;
 mod eval;

--- a/dataflow-expression/src/lower.rs
+++ b/dataflow-expression/src/lower.rs
@@ -817,6 +817,12 @@ impl Expr {
                 let (left_coerce_target, right_coerce_target) =
                     op.argument_type_coercions(left.ty(), right.ty(), dialect)?;
 
+                if let (Expr::Column { ty: to_ty, .. }, Expr::Literal { val, ty: from_ty }) =
+                    (&*left, &mut *right)
+                {
+                    *val = val.coerce_to(to_ty, from_ty)?;
+                }
+
                 if let Some(ty) = left_coerce_target {
                     left = Box::new(Self::Cast {
                         expr: left,


### PR DESCRIPTION
Queries sometimes contain string expressions as stand-ins for
expressions of other types in filters, relying on type inference to
figure out how to evaluate the expression. For example, consider the
following:

```sql
CREATE TABLE t (c TIMESTAMP WITH TIME ZONE);
SELECT * FROM t WHERE t.c < '2024-04-03 00:00:00-04'
```

Although the literal in the comparison is a string, it is coerced by
Postgres into a timestamp with time zone in order to perform the
comparison.

When we encounter such expressions in queries, we currently compile
filter nodes with the original string literal and perform the coercion
to the correct type when the filter node is processing input. This can
be very costly for types like timestamps, for whom converting from a
string is a costly operation. This approach has the potential to slow
down both replays and forward processing for queries that involve
timestamps.

This commit updates our expression lowering logic to perform the
coercion to the correct type at *lowering* time, which ensures that
filter nodes are compiled with values of the correct type to begin with.
This avoids the need to do any expensive conversions during the
processing of rows.

Release-Note-Core: Fixed an issue where Readyset was performing
  unnecessary type coercions during replays and forward processing
