### PR TITLE
build: Use fat-lto only for "main" builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,10 @@ lto="fat"
 inherits = "release-fat-lto"
 debug = false
 strip = "debuginfo"
+
+[profile.release-dist-quick]
+# configs for distro release packages (i.e. deb, rpm, etc.), but without
+# fat-lto so it will build faster.  (Only use for change list builds.)
+inherits = "release"
+debug = false
+strip = "debuginfo"


### PR DESCRIPTION
Building with fat-lto takes three times as long.  This is very
inconvenient when running change-list builds, so fat-lto should only be
used for builds on "main".

