### PR TITLE
packaging: Make NO_COLOR the default for systemd config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,10 @@ lto="fat"
 inherits = "release-fat-lto"
 debug = false
 strip = "debuginfo"
+
+[profile.release-dist-quick]
+# configs for distro release packages (i.e. deb, rpm, etc.), but without
+# fat-lto so it will build faster.  (Only use for change list builds.)
+inherits = "release"
+debug = false
+strip = "debuginfo"

--- a/readyset/debian/readyset.conf
+++ b/readyset/debian/readyset.conf
@@ -24,6 +24,10 @@ LOG_PATH=/var/lib/readyset
 ## hourly, minutely, never.
 LOG_ROTATION=daily
 
+## Disable colors in log output.  Recommended when redirecting output to log
+## file instead of stdout.
+NO_COLOR=true
+
 ## Format to use when emitting log events
 ## Possible values:
 ##   - compact: Corresponds to [`tracing_subscriber::fmt::format::Compact`]


### PR DESCRIPTION
When running as a systemd service, it makes most sense to log without
ANSI coloring.

