### PR TITLE
[skip-ci] wip: run tests with release profile

### DIFF
--- a/.buildkite/run-tests.sh
+++ b/.buildkite/run-tests.sh
@@ -10,4 +10,4 @@ upload_artifacts() {
 
 echo "+++ :rust: Run tests"
 export DISABLE_TELEMETRY=true
-cargo --locked test --all --features failure_injection --exclude readyset-clustertest --exclude benchmarks || upload_artifacts
+cargo --locked test --profile=release --all --features failure_injection --exclude readyset-clustertest --exclude benchmarks || upload_artifacts


### PR DESCRIPTION
This made vertical tests go faster, so lets try with other tests.

