### PR TITLE
quickstart: Fix podman support

### DIFF
--- a/quickstart/compose.mysql.yml
+++ b/quickstart/compose.mysql.yml
@@ -13,15 +13,15 @@ services:
       RS_API_KEY: ${RS_API_KEY-""}
       DEPLOYMENT_ENV: quickstart_docker
       DB_DIR: /state
-      PROMETHEUS_METRICS: true
+      PROMETHEUS_METRICS: "true"
       QUERY_LOG_MODE: verbose
       QUERY_CACHING: explicit
-      STANDALONE: true
+      STANDALONE: "true"
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:3307
       # We don't have control over whether users are using a password or not for the
       # demo/quickstart, so use the more permissive mode.
-      ALLOW_UNAUTHENTICATED_CONNECTIONS: true
+      ALLOW_UNAUTHENTICATED_CONNECTIONS: "true"
       UPSTREAM_DB_URL: mysql://root:readyset@mysql/testdb
       CONTROLLER_ADDRESS: 0.0.0.0
     volumes:

--- a/quickstart/compose.postgres.yml
+++ b/quickstart/compose.postgres.yml
@@ -13,17 +13,17 @@ services:
       RS_API_KEY: ${RS_API_KEY-""}
       DEPLOYMENT_ENV: quickstart_docker
       DB_DIR: /state
-      PROMETHEUS_METRICS: true
+      PROMETHEUS_METRICS: "true"
       QUERY_CACHING: explicit
       QUERY_LOG_MODE: verbose
-      STANDALONE: true
+      STANDALONE: "true"
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:5433
       UPSTREAM_DB_URL: postgresql://postgres:readyset@postgres/testdb
       CONTROLLER_ADDRESS: 0.0.0.0
       # We don't have control over whether users are using a password or not for the
       # demo/quickstart, so use the more permissive mode.
-      ALLOW_UNAUTHENTICATED_CONNECTIONS: true
+      ALLOW_UNAUTHENTICATED_CONNECTIONS: "true"
     volumes:
       - "readyset:/state"
     healthcheck:

--- a/quickstart/compose.yml
+++ b/quickstart/compose.yml
@@ -13,13 +13,13 @@ services:
       RS_API_KEY: ${RS_API_KEY-""}
       DEPLOYMENT_ENV: quickstart_docker
       DB_DIR: /state
-      PROMETHEUS_METRICS: true
+      PROMETHEUS_METRICS: "true"
       QUERY_CACHING: explicit
       QUERY_LOG_MODE: verbose
-      STANDALONE: true
+      STANDALONE: "true"
       DEPLOYMENT: docker_compose_deployment
       LISTEN_ADDRESS: 0.0.0.0:5433
-      ALLOW_UNAUTHENTICATED_CONNECTIONS: true
+      ALLOW_UNAUTHENTICATED_CONNECTIONS: "true"
       # We don't have control over whether users are using a password or not for the
       # demo/quickstart, so use the more permissive mode.
       # UPSTREAM_DB_URL:


### PR DESCRIPTION
Previously, our quickstart compose files were not working with `podman`
because the literal `true` in yaml was being converted to a boolean
value in Python instead of a string, which leads to env vars being set
like `ENV_VAR=True`, since the Python literal for "true" is `True`. To
fix this, this commit wraps the boolean literals in our compose files in
quotes.

