### PR TITLE
system-benchmarks: Enable post-lookup support

### DIFF
--- a/system-benchmarks/benches/workload.rs
+++ b/system-benchmarks/benches/workload.rs
@@ -614,6 +614,7 @@ fn start_adapter(upstream_url: &str) -> anyhow::Result<()> {
         "standalone",
         "--allow-unauthenticated-connections",
         "--allow-full-materialization",
+        "--enable-experimental-post-lookup",
         "--upstream-db-url",
         upstream_url,
         "--durability",


### PR DESCRIPTION
Previously, our system benchmarks were running against Readyset with
post-lookup disabled. This meant that any of our benchmarks that
included queries that required post-lookup were actually proxying the
workload upstream. This led to a large discrepancy in benchmark results
between Postgres and MySQL due to Postgres handling certain aggregations
more efficiently than MySQL.

This commit fixes the issue by ensuring that our system benchmarks are
running against a Readyset instance with post-lookups enabled.

