### PR TITLE
readyset-data: Integrate 'url' crate and refine authentication code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4370,6 +4370,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -53,6 +53,7 @@ readyset-tracing = { path = "../readyset-tracing" }
 readyset-version = { path = "../readyset-version" }
 replicators = { path = "../replicators" }
 serde_json = "1.0.89"
+url = "2.2.2"
 
 
 [dev-dependencies]


### PR DESCRIPTION
This commit addresses the following issues:
- Included the 'url' crate in Cargo.toml
- Adjusted the approach for processing user credentials from the
  upstream DB URL by using the 'url' crate to parse the URL and extract
  the username and password components.

