### PR TITLE
build: Bump postgres version to 15 in public/build/docker-compose.yml

### DIFF
--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MYSQL_ROOT_PASSWORD=noria
       - MYSQL_DATABASE=noria
   postgres:
-    image: postgres:14
+    image: postgres:15
     environment:
       - POSTGRES_PASSWORD=noria
       - POSTGRES_DB=noria


### PR DESCRIPTION
The `docker-compose.ci-test.yml` file uses 15, which overrides
`docker-compose.yml` in CI test jobs anyhow.  So let's be consistent.

