### PR TITLE
build: Bump readyset version number for linux pkgs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4097,7 +4097,7 @@ dependencies = [
 
 [[package]]
 name = "readyset"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/readyset/Cargo.toml
+++ b/readyset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readyset"
-version = "1.7.0"
+version = "1.8.0"
 publish = false
 authors = ["Readyset Technology, Inc. <info@readyset.io>"]
 edition = "2021"


### PR DESCRIPTION
The linux release packages get their version number from the readyset
version number in public/readyset/Cargo.toml.

