### PR TITLE
Introducing ReadySet Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ ReadySet is a transparent database cache for Postgres & MySQL that gives you the
 ![Rust](https://img.shields.io/badge/Built%20with%20Rust-grey?logo=rust&logoColor=white)
 [![Slack](https://img.shields.io/badge/Join%20Slack-gray?logo=slack&logoColor=white)](https://join.slack.com/t/readysetcommunity/shared_invite/zt-2272gtiz4-0024xeRJUPGWlRETQrGkFw)
 [![Follow us on X, formerly Twitter](https://img.shields.io/twitter/follow/ReadySet?style=social)](https://twitter.com/readysetio)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20ReadySet%20Guru-006BFF)](https://gurubase.io/g/readyset)
 
 :star: If you find ReadySet useful, please consider giving us a star on GitHub! Your support helps us continue to innovate and deliver exciting new features.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ReadySet Guru](https://gurubase.io/g/readyset) to Gurubase. ReadySet Guru uses the data from this repo and data from the [docs](https://docs.readyset.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "ReadySet Guru", which highlights that ReadySet now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ReadySet Guru in Gurubase, just let me know that's totally fine.
