### PR TITLE
build: Compile readyset with frame pointers by default

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,7 @@
 lint = "clippy --all-targets"
 
 [build]
-rustflags = ["-C", "link-args=-llz4"]
+rustflags = ["-C", "link-args=-llz4", "-C", "force-frame-pointers=yes"]
 
 [target.'cfg(feature = "cargo-clippy")']
 rustflags = [


### PR DESCRIPTION
We don't get full stack traces for readyset.  This update will adjust
our build to add the rustflag "-C force-frame-pointers=yes" by default.

Fixes: REA-5129
