### PR TITLE
buildkite: Make docker builds more quiet

### DIFF
--- a/.buildkite/build-image.sh
+++ b/.buildkite/build-image.sh
@@ -66,7 +66,7 @@ if [ -n "${SKIP_IF_UNCHANGED+1}" ]; then
 fi
 
 echo "--- :docker: Pulling $image:latest"
-if docker pull "$image:latest"; then
+if docker pull --quiet "$image:latest"; then
     cache_from="--cache-from=$image:latest"
 else
     echo "Failed to pull previous build of image"
@@ -77,6 +77,7 @@ build_cmd_prefix=(
     "docker" "build" \
     "-f" "$dockerfile" \
     "-t" "$image:$VERSION" \
+    "--progress" "plain" \
     "--build-arg" "BUILDKIT_INLINE_CACHE=1" \
 )
 build_cmd_suffix=(

--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -8,6 +8,9 @@ common_values:
         signal_reason: none
         limit: 3
 
+env:
+  ECR_PLUGIN_VERSION: "v2.9.0"
+
 steps:
   - label: ':clojure: Run jepsen test with --help'
     key: lein-run-test-help
@@ -18,7 +21,7 @@ steps:
     plugins:
       docker#v3.8.0:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
-      ecr#v2.7.0:
+      ecr#${ECR_PLUGIN_VERSION}:
         login: true
         retries: 3
     retry: *retry_on_agent_kill
@@ -32,7 +35,7 @@ steps:
     plugins:
       docker#v3.8.0:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
-      ecr#v2.7.0:
+      ecr#${ECR_PLUGIN_VERSION}:
         login: true
         retries: 3
     retry: *retry_on_agent_kill
@@ -46,7 +49,7 @@ steps:
     plugins:
       docker#v3.8.0:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
-      ecr#v2.7.0:
+      ecr#${ECR_PLUGIN_VERSION}:
         login: true
         retries: 3
     retry: *retry_on_agent_kill

--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -9,6 +9,10 @@ common_values:
       - exit_status: -1            # agent timed out
         signal_reason: none
         limit: 3
+
+env:
+  ECR_PLUGIN_VERSION: "v2.9.0"
+
 steps:
 
   - label: ':rust: Check rustfmt'
@@ -28,7 +32,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
-      - ecr#v2.7.0:
+      - ecr#${ECR_PLUGIN_VERSION}:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -48,7 +52,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
-      - ecr#v2.7.0:
+      - ecr#${ECR_PLUGIN_VERSION}:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -71,7 +75,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
-      - ecr#v2.7.0:
+      - ecr#${ECR_PLUGIN_VERSION}:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -104,7 +108,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           mount-buildkite-agent: true
           pull-retries: 3
-      - ecr#v2.7.0:
+      - ecr#${ECR_PLUGIN_VERSION}:
           login: true
           retries: 3
     agents:
@@ -135,7 +139,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           pull-retries: 3
-      - ecr#v2.7.0:
+      - ecr#${ECR_PLUGIN_VERSION}:
           login: true
           retries: 3
     retry: *retry_on_agent_kill
@@ -164,7 +168,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           pull-retries: 3
-      - ecr#v2.7.0:
+      - ecr#${ECR_PLUGIN_VERSION}:
           login: true
           retries: 3
     retry: *retry_on_agent_kill

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,9 @@ common_values:
         signal_reason: none
         limit: 3
 
+env:
+  ECR_PLUGIN_VERSION: "v2.9.0"
+
 steps:
   # TODO: ronh: decide what kind of linting we want in the OSS pipeline
   # - label: ':git: Lint commits'
@@ -27,7 +30,7 @@ steps:
     commands:
       - '.buildkite/build-image.sh build/Dockerfile readyset-build .'
     plugins:
-      ecr#v2.7.0:
+      ecr#${ECR_PLUGIN_VERSION}:
         login: true
         retries: 3
     retry: *retry_on_agent_kill
@@ -39,7 +42,7 @@ steps:
     env:
       VERSION: "${BUILDKITE_COMMIT}"
     plugins:
-      ecr#v2.7.0:
+      ecr#${ECR_PLUGIN_VERSION}:
         login: true
         retries: 3
     retry: *retry_on_agent_kill


### PR DESCRIPTION
Various docker build scripts generate a *lot* of output noise. In an
effort to reduce it, this update adds "quiet" flag to pulls, sets
"progress" to "plain" on builds, drops progress on "wget" pulls, etc.

