### PR TITLE
buildkite: Upgrade docker and docker-compose plugins

### DIFF
--- a/.buildkite/pipeline.jepsen.yml
+++ b/.buildkite/pipeline.jepsen.yml
@@ -10,6 +10,8 @@ common_values:
 
 env:
   ECR_PLUGIN_VERSION: "v2.9.0"
+  DOCKER_PLUGIN_VERSION: "v5.12.0"
+  DOCKER_COMPOSE_PLUGIN_VERSION: "v5.5.0"
 
 steps:
   - label: ':clojure: Run jepsen test with --help'
@@ -19,7 +21,7 @@ steps:
       - cd jepsen
       - lein run test --help
     plugins:
-      docker#v3.8.0:
+      docker#${DOCKER_PLUGIN_VERSION}:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
       ecr#${ECR_PLUGIN_VERSION}:
         login: true
@@ -33,7 +35,7 @@ steps:
       - cd jepsen
       - lein test
     plugins:
-      docker#v3.8.0:
+      docker#${DOCKER_PLUGIN_VERSION}:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
       ecr#${ECR_PLUGIN_VERSION}:
         login: true
@@ -47,7 +49,7 @@ steps:
       - cd jepsen
       - lein clj-kondo
     plugins:
-      docker#v3.8.0:
+      docker#${DOCKER_PLUGIN_VERSION}:
         image: 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/clojure:temurin-20-lein-2.10.0-jammy
       ecr#${ECR_PLUGIN_VERSION}:
         login: true

--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -12,6 +12,8 @@ common_values:
 
 env:
   ECR_PLUGIN_VERSION: "v2.9.0"
+  DOCKER_PLUGIN_VERSION: "v5.12.0"
+  DOCKER_COMPOSE_PLUGIN_VERSION: "v5.5.0"
 
 steps:
 
@@ -23,7 +25,7 @@ steps:
     depends_on:
     - build-image
     plugins:
-      - docker#v3.8.0:
+      - docker#${DOCKER_PLUGIN_VERSION}:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
           volumes:
           - 'target:/workdir/target'
@@ -45,7 +47,7 @@ steps:
     depends_on:
     - cargo-deny-image
     plugins:
-      - docker#v3.8.0:
+      - docker#${DOCKER_PLUGIN_VERSION}:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/cargo-deny:${BUILDKITE_COMMIT}'
           environment:
           - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
@@ -66,7 +68,7 @@ steps:
     depends_on:
     - build-image
     plugins:
-      - docker#v3.8.0:
+      - docker#${DOCKER_PLUGIN_VERSION}:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
           volumes:
           - 'target:/workdir/target'
@@ -90,8 +92,9 @@ steps:
     depends_on:
     - build-image
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#${DOCKER_COMPOSE_PLUGIN_VERSION}:
           run: app
+          tty: true
           env:
           - BUILDKITE_PARALLEL_JOB
           - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
@@ -128,7 +131,7 @@ steps:
     depends_on:
     - build-image
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#${DOCKER_COMPOSE_PLUGIN_VERSION}:
           run: app
           env:
           - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
@@ -156,7 +159,7 @@ steps:
     depends_on:
     - build-image
     plugins:
-      - docker-compose#v3.7.0:
+      - docker-compose#${DOCKER_COMPOSE_PLUGIN_VERSION}:
           image: '305232526136.dkr.ecr.us-east-2.amazonaws.com/readyset-build:${BUILDKITE_COMMIT}'
           run: app
           environment:


### PR DESCRIPTION
Upgrading to 5+ versions of these plugins.  Also, pulling the version
numbers out into variables for easier updating.

Some jobs (including nextest runs) benefit from having "tty: true" so
that they still produce colorized output.

