### PR TITLE
buildkite: Shorten logs by pulling quietly

### DIFF
--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -94,7 +94,7 @@ steps:
     plugins:
       - docker-compose#${DOCKER_COMPOSE_PLUGIN_VERSION}:
           run: app
-          tty: true
+          tty: true           # nextest makes colored output if we use tty
           env:
           - BUILDKITE_PARALLEL_JOB
           - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
@@ -110,6 +110,7 @@ steps:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
           mount-buildkite-agent: true
+          quiet-pull: true    # don't log all the image pulls
           pull-retries: 3
       - ecr#${ECR_PLUGIN_VERSION}:
           login: true
@@ -133,6 +134,7 @@ steps:
     plugins:
       - docker-compose#${DOCKER_COMPOSE_PLUGIN_VERSION}:
           run: app
+          tty: true           # tests make colored output if we use tty
           env:
           - SCCACHE_BUCKET=readysettech-build-sccache-us-east-2
           - SCCACHE_REGION=us-east-2
@@ -141,6 +143,7 @@ steps:
           config:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
+          quiet-pull: true    # don't log all the image pulls
           pull-retries: 3
       - ecr#${ECR_PLUGIN_VERSION}:
           login: true
@@ -170,6 +173,7 @@ steps:
           config:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"
+          quiet-pull: true    # don't log all the image pulls
           pull-retries: 3
       - ecr#${ECR_PLUGIN_VERSION}:
           login: true


### PR DESCRIPTION
The new docker compose plugin can be set to pull images quietly.  Since
image pulling generates a *ton* of non-useful logging, I'm setting that
option where we use the plugin.

Also, there were a few more places where turning `tty` on for the test
run would produce more colorful output.

