### PR TITLE
build: Update cargo deny version

### DIFF
--- a/build/Dockerfile.cargo-deny
+++ b/build/Dockerfile.cargo-deny
@@ -1,3 +1,3 @@
-FROM 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/rust:1.78
+FROM 305232526136.dkr.ecr.us-east-2.amazonaws.com/ecr-public/docker/library/rust:1.83
 
-RUN cargo install cargo-deny --version 0.14.23 && cargo deny --version
+RUN cargo install cargo-deny --version 0.16.3 && cargo deny --version


### PR DESCRIPTION
Updating the `cargo deny` version we're using along with the rust
container it builds in to fix a dependency that has spontaneously
combusted.

