### PR TITLE
build: Disable cargo progress in CI jobs using tty

### DIFF
--- a/.buildkite/pipeline.public-common.yml
+++ b/.buildkite/pipeline.public-common.yml
@@ -105,6 +105,7 @@ steps:
           - MYSQL_HOST=mysql
           - MYSQL_PWD=noria
           - MYSQL_DB=noria
+          - CARGO_TERM_PROGRESS_WHEN=never     # disable progress bars if tty=true
           volumes:
             - 'target:/workdir/target'
           config:
@@ -141,6 +142,7 @@ steps:
           - SCCACHE_REGION=us-east-2
           - CARGO_INCREMENTAL=0
           - RUST_BACKTRACE=full
+          - CARGO_TERM_PROGRESS_WHEN=never     # disable progress bars if tty=true
           config:
             - "${GIT_PUBLIC_ROOT}build/docker-compose.yml"
             - "${GIT_PUBLIC_ROOT}build/docker-compose.ci-test.yml"


### PR DESCRIPTION
Some buildkite jobs using the docker-compose plugin have tty on because
it results in colored output.  However, if cargo detects tty, it creates
progress bars... which are wholly unnecessary in CI jobs.  This update
sets CARGO_TERM_PROGRESS_WHEN=never when enabling tty in the
docker-compose plugin.

