### PR TITLE
cloud: Add Stage CI/CD pipeline to deploy hotfixes into production

### DIFF
--- a/psql-srv/src/lib.rs
+++ b/psql-srv/src/lib.rs
@@ -34,7 +34,7 @@ use postgres::SimpleQueryMessage;
 use postgres_protocol::Oid;
 use postgres_types::Type;
 use protocol::Protocol;
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use readyset_sql::ast::SqlIdentifier;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_native_tls::TlsAcceptor;
@@ -102,6 +102,7 @@ pub trait PsqlBackend {
         &mut self,
         query: &str,
         parameter_data_types: &[Type],
+        statement_type: PreparedStatementType,
     ) -> Result<PrepareResponse, Error>;
 
     /// Executes a previously prepared SQL query using the provided parameters.

--- a/psql-srv/src/protocol.rs
+++ b/psql-srv/src/protocol.rs
@@ -7,7 +7,7 @@ use database_utils::TlsMode;
 use postgres::SimpleQueryMessage;
 use postgres_protocol::Oid;
 use postgres_types::{Kind, Type};
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use smallvec::smallvec;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_postgres::CommandCompleteContents;
@@ -713,22 +713,19 @@ impl Protocol {
     ) -> Result<Response<B::Resultset>, Error> {
         self.state = State::Extended;
 
-        if prepared_statement_name.is_empty() {
-            if let Some(id) = self
-                .prepared_statements
-                .remove(prepared_statement_name as &str)
-                .map(|d| d.prepared_statement_id)
-            {
-                backend.on_close(DeallocateId::Numeric(id)).await?;
-                channel.clear_statement_param_types(prepared_statement_name);
-            }
-        }
+        let statement_type = if prepared_statement_name.is_empty() {
+            PreparedStatementType::Unnamed
+        } else {
+            PreparedStatementType::Named
+        };
 
         let PrepareResponse {
             prepared_statement_id,
             param_schema,
             row_schema,
-        } = backend.on_prepare(query, &parameter_data_types).await?;
+        } = backend
+            .on_prepare(query, &parameter_data_types, statement_type)
+            .await?;
         channel.set_statement_param_types(prepared_statement_name as &str, param_schema.clone());
         self.prepared_statements.insert(
             prepared_statement_name.to_string(),
@@ -1204,7 +1201,7 @@ mod tests {
     use futures::task::Context;
     use futures::{stream, TryStreamExt};
     use postgres::error::SqlState;
-    use readyset_adapter_types::DeallocateId;
+    use readyset_adapter_types::{DeallocateId, PreparedStatementType};
     use tokio::io::ReadBuf;
     use tokio_test::block_on;
 
@@ -1310,6 +1307,7 @@ mod tests {
             &mut self,
             query: &str,
             _parameter_data_types: &[Type],
+            _statement_type: PreparedStatementType,
         ) -> Result<PrepareResponse, Error> {
             self.last_prepare = Some(query.to_string());
             if self.is_prepare_err {

--- a/psql-srv/tests/authentication.rs
+++ b/psql-srv/tests/authentication.rs
@@ -13,7 +13,7 @@ use psql_srv::{
     run_backend, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend, PsqlSrvRow,
     PsqlValue, QueryResponse, TransferFormat,
 };
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_native_tls::{native_tls, TlsAcceptor};
@@ -61,6 +61,7 @@ impl PsqlBackend for ScramSha256Backend {
         &mut self,
         _query: &str,
         _parameter_data_types: &[Type],
+        _statement_type: PreparedStatementType,
     ) -> Result<PrepareResponse, Error> {
         unreachable!()
     }

--- a/psql-srv/tests/errors.rs
+++ b/psql-srv/tests/errors.rs
@@ -10,7 +10,7 @@ use psql_srv::{
     run_backend, Column, Credentials, CredentialsNeeded, Error, PrepareResponse, PsqlBackend,
     PsqlSrvRow, PsqlValue, QueryResponse, TransferFormat,
 };
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use tokio::join;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -53,6 +53,7 @@ impl PsqlBackend for ErrorBackend {
         &mut self,
         _query: &str,
         _parameter_data_types: &[Type],
+        _statement_type: PreparedStatementType,
     ) -> Result<PrepareResponse, Error> {
         if self.0 == ErrorPosition::Prepare {
             Err(Error::InternalError("trapped in".to_owned()))

--- a/psql-srv/tests/tls.rs
+++ b/psql-srv/tests/tls.rs
@@ -9,7 +9,7 @@ use postgres_types::Type;
 use psql_srv::{
     run_backend, Credentials, CredentialsNeeded, Error, PsqlBackend, PsqlSrvRow, TransferFormat,
 };
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_native_tls::{native_tls, TlsAcceptor};
@@ -53,6 +53,7 @@ impl PsqlBackend for TestBackend {
         &mut self,
         _query: &str,
         _parameter_data_types: &[Type],
+        _statement_type: PreparedStatementType,
     ) -> Result<psql_srv::PrepareResponse, psql_srv::Error> {
         panic!() // never called
     }

--- a/readyset-adapter-types/src/lib.rs
+++ b/readyset-adapter-types/src/lib.rs
@@ -56,3 +56,9 @@ pub enum ParsedCommand {
     /// A `DEALLOCATE (PREPARE)` SQL command was invoked.
     Deallocate(DeallocateId),
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreparedStatementType {
+    Named,
+    Unnamed,
+}

--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -20,7 +20,7 @@ use readyset_adapter::backend::{
     noria_connector, QueryResult, SinglePrepareResult, UpstreamPrepare,
 };
 use readyset_adapter::upstream_database::LazyUpstream;
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use readyset_data::{DfType, DfValue, DfValueKind};
 use readyset_errors::{internal, ReadySetError};
 use readyset_util::redacted::Sensitive;
@@ -552,7 +552,7 @@ where
 
         trace!("delegate");
         let prepare_result = self
-            .prepare(query, ())
+            .prepare(query, (), PreparedStatementType::Named)
             .await
             .map(|p| (p.statement_id, p.upstream_biased()));
         let res = match prepare_result {

--- a/readyset-psql/benches/proxy.rs
+++ b/readyset-psql/benches/proxy.rs
@@ -28,7 +28,7 @@ use psql_srv::{
     Credentials, CredentialsNeeded, PrepareResponse, PsqlBackend, PsqlSrvRow, QueryResponse,
     TransferFormat,
 };
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use readyset_data::DfValue;
 use readyset_psql::ParamRef;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -176,6 +176,7 @@ impl PsqlBackend for Backend {
         &mut self,
         query: &str,
         _parameter_data_types: &[Type],
+        _statement_type: PreparedStatementType,
     ) -> Result<PrepareResponse, psql_srv::Error> {
         let stmt = self
             .upstream

--- a/readyset-psql/src/backend.rs
+++ b/readyset-psql/src/backend.rs
@@ -11,7 +11,7 @@ use ps::{PsqlValue, TransferFormat};
 use psql_srv as ps;
 use readyset_adapter::backend as cl;
 use readyset_adapter::upstream_database::LazyUpstream;
-use readyset_adapter_types::DeallocateId;
+use readyset_adapter_types::{DeallocateId, PreparedStatementType};
 use readyset_data::DfValue;
 use thiserror::Error;
 use tokio_postgres::SimpleQueryMessage;
@@ -100,9 +100,12 @@ impl Backend {
         &mut self,
         query: &str,
         parameter_data_types: &[Type],
+        statement_type: PreparedStatementType,
     ) -> Result<PrepareResponse<'_>, Error> {
         Ok(PrepareResponse(
-            self.inner.prepare(query, parameter_data_types).await?,
+            self.inner
+                .prepare(query, parameter_data_types, statement_type)
+                .await?,
         ))
     }
 
@@ -152,8 +155,9 @@ impl ps::PsqlBackend for Backend {
         &mut self,
         query: &str,
         parameter_data_types: &[Type],
+        statement_type: PreparedStatementType,
     ) -> Result<ps::PrepareResponse, ps::Error> {
-        self.prepare(query, parameter_data_types)
+        self.prepare(query, parameter_data_types, statement_type)
             .await?
             .try_into_ps()
     }

--- a/readyset-psql/src/response.rs
+++ b/readyset-psql/src/response.rs
@@ -221,6 +221,18 @@ impl<'a> TryFrom<QueryResponse<'a>> for ps::QueryResponse<Resultset> {
                     resultset: Resultset::from_stream(stream, first_row, field_types),
                 })
             }
+            Upstream(upstream::QueryResult::RowStream { first_row, stream }) => {
+                let field_types = first_row
+                    .columns()
+                    .iter()
+                    .map(|c| c.type_().clone())
+                    .collect();
+
+                Ok(ps::QueryResponse::Select {
+                    schema: vec![], // Schema isn't necessary for upstream execute results
+                    resultset: Resultset::from_row_stream(stream, first_row, field_types),
+                })
+            }
             Upstream(upstream::QueryResult::Write { num_rows_affected }) => {
                 Ok(Insert(num_rows_affected))
             }


### PR DESCRIPTION
Introduce a new CI/CD pipeline workflow for staging, including
parallelized Playwright testing for various configurations. Update
deployment scripts to support staging and production tenants, and
adjust AWS resources as required.

