### PR TITLE
quickstart: Resolve some dependabot issues related to urllib3

### DIFF
--- a/quickstart/requirements.txt
+++ b/quickstart/requirements.txt
@@ -1,4 +1,4 @@
 prometheus-client==0.16.0
 tabulate==0.9.0
-urllib3==1.26.14
+urllib3==1.26.19
 


### PR DESCRIPTION
Github dependabot is flagging multiple moderate security issues relating
to urllib3.  Recommendation is to upgrade:
    urllib3>=1.26.19

