### PR TITLE
packaging: Set readyset to log to stdout by default

### DIFF
--- a/readyset/pkg/common/readyset.conf
+++ b/readyset/pkg/common/readyset.conf
@@ -25,11 +25,11 @@ STORAGE_DIR=/var/lib/readyset
 ## Optional path to which to write logs.  Logs will be written to
 ## `readyset.log` within this path.  If unset, defaults to stdout.  Logs will
 ## roll over based on LOG_ROTATION (see below).
-LOG_PATH=/var/lib/readyset
+# LOG_PATH=/var/lib/readyset
 
 ## Log rotation policy to use if LOG_PATH is set.  Possible values: daily,
 ## hourly, minutely, never.
-LOG_ROTATION=daily
+# LOG_ROTATION=daily
 
 ## Disable colors in log output.  Recommended when redirecting output to log
 ## file instead of stdout.


### PR DESCRIPTION
When building distro readyset packages, change the installed config to
log to stdout by default instead of going to a log file.  This means
logs will be accessible through journalctl.  The `tracing_appender`
crate does not support size-based file rollover, which can result in
inconveniently fragmented logging.  Log access through journalctl
provides much greater flexibility.

Fixes: REA-5659
Closes: #1495
