### PR TITLE
feat: add in_tx field for a query

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -1192,6 +1192,10 @@ where
             return PrepareMeta::Proxy;
         }
 
+        if self.state.proxy_state == ProxyState::InTransaction {
+            event.in_tx = true;
+        }
+
         let parse_result = match self.state.parsed_query_cache.get(query) {
             Some(cached_query) => Ok(cached_query.clone()),
             None => {

--- a/readyset-client-metrics/src/lib.rs
+++ b/readyset-client-metrics/src/lib.rs
@@ -86,6 +86,9 @@ pub struct QueryExecutionEvent {
 
     /// Where the query ended up executing
     pub destination: Option<QueryDestination>,
+
+    /// If the query is being executed inside a transaction
+    pub in_tx: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -225,6 +228,8 @@ impl QueryExecutionEvent {
             readyset_event: None,
             noria_error: None,
             destination: None,
+            in_tx: false,
+
         }
     }
 

--- a/replicators/src/mysql_connector/snapshot.rs
+++ b/replicators/src/mysql_connector/snapshot.rs
@@ -142,7 +142,7 @@ fn tx_opts() -> TxOpts {
 }
 
 impl MySqlReplicator<'_> {
-    /// Load all the `CREATE TABLE` statements for the tables in the MySQL database. Returns the the
+    /// Load all the `CREATE TABLE` statements for the tables in the MySQL database. Returns the
     /// transaction that holds the DDL locks for the tables and the Vector of tables that requires
     /// snapshot.
     ///


### PR DESCRIPTION
#1394 

It allows the user to know if the query was executed inside a transaction or not. 

During query preparation, the Backend ProxyState is checked and if it is ProxyState::InTransaction, then event.in_tx = true.