### PR TITLE
metric: counter for cached queries executed in transaction

### DIFF
--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -2749,11 +2749,20 @@ where
         match adapter_rewrites::process_query(&mut q.statement, self.noria.rewrite_params()) {
             Ok(processed_query_params) => {
                 let s = self.state.query_status_cache.query_status(q);
+                let migration_state = self.state.query_status_cache.query_migration_state(q).1;
+                let is_cached = matches!(
+                    migration_state,
+                    MigrationState::Successful | MigrationState::Inlined(_)
+                );
                 let should_try = if self.state.proxy_state.should_proxy() {
                     s.always
                 } else {
                     true
                 };
+                // we check again if the cached query is proxied, specifically due to a transaction
+                if self.in_transaction() && is_cached {
+                    metrics::counter!(recorded::CACHED_TRANSACTION_UPSTREAMED_QUERIES).increment(1);
+                }
                 (should_try, Some(s), Some(processed_query_params))
             }
             Err(e) => {

--- a/readyset-client-metrics/src/recorded.rs
+++ b/readyset-client-metrics/src/recorded.rs
@@ -136,3 +136,7 @@ pub const QUERY_STATUS_CACHE_PENDING_INLINE_MIGRATIONS: &str =
 ///     - Connection handshake and `COM_CHANGE_USER` map to `protocol`
 /// - charset: The lowercased name of the character set/collation, or the u16 numeric id
 pub const CHARACTER_SET_USAGE: &str = "readyset_mysql_character_set_usage";
+
+/// Counter: The number of queries upstreamed during transaction
+pub const CACHED_TRANSACTION_UPSTREAMED_QUERIES: &str =
+    "readyset_cached_transaction_upstreamed_queries";


### PR DESCRIPTION
Solves #1394 

The changes increment the counter after checking if a cached query is sent upstream due to it being in a transaction.

<img width="805" height="41" alt="Screenshot from 2025-08-13 18-12-13" src="https://github.com/user-attachments/assets/d357fcf1-b22f-4c17-a4e6-1fc9eeb827c6" />

The metric is exposed on `http://127.0.0.1:6033/metrics`
```
1. Create cache from Select * from tb1 where ID=1;
2.  Select * from tb1 where ID=1; (counter will not be updated)
3. Start transaction;
4. Select * from tb1 where ID=1; (counter will be updated)
```