### PR TITLE
Add support for Neon

### DIFF
--- a/quickstart/check_db_postgres.sh
+++ b/quickstart/check_db_postgres.sh
@@ -261,7 +261,7 @@ check_postgres_compliance() {
             SELECT 1
             FROM pg_roles, pg_auth_members 
             WHERE pg_roles.oid = pg_auth_members.roleid 
-            AND pg_roles.rolname = 'rds_superuser' 
+            AND pg_roles.rolname IN ('rds_superuser', 'neon_superuser')
             AND pg_auth_members.member = (
                 SELECT oid 
                 FROM pg_roles 

--- a/readyset/src/verify.rs
+++ b/readyset/src/verify.rs
@@ -294,12 +294,12 @@ async fn verify_permissions(conn: &mut DatabaseConnection, options: &Options) ->
                 )
                 .await?;
                 let has_super = has_super || {
-                    // RDS has its own representation of super.
+                    // RDS and Neon have their own representation of super.
                     let has_super: Result<String> = query_one_value(
                         conn,
                         "SELECT rolname FROM pg_roles WHERE \
                            pg_has_role(CURRENT_USER, rolname, 'member') AND \
-                           rolname = 'rds_superuser'",
+                           rolname IN ('rds_superuser', 'neon_superuser')",
                     )
                     .await;
                     has_super.is_ok()


### PR DESCRIPTION
Neon's `neon_superuser` role operates very similarly to `rds_superuser`.

Ref: https://neon.com/docs/manage/roles#the-neonsuperuser-role