### PR TITLE
mysql: decode query text using client charset

### DIFF
--- a/mysql-srv/src/lib.rs
+++ b/mysql-srv/src/lib.rs
@@ -216,7 +216,7 @@ use database_utils::TlsMode;
 use error::{other_error, OtherErrorKind};
 use mysql_common::constants::CapabilityFlags;
 use readyset_adapter_types::{DeallocateId, ParsedCommand};
-use readyset_data::DfType;
+use readyset_data::{encoding::Encoding, DfType};
 use readyset_util::redacted::RedactedString;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net;
@@ -338,6 +338,14 @@ impl InitResult {
 // Only used internally
 #[allow(async_fn_in_trait)]
 pub trait MySqlShim<S: AsyncRead + AsyncWrite + Unpin + Send> {
+    /// Returns the encoding used by the client for query text.
+    ///
+    /// Implementations that do not track the negotiated client character set retain the previous
+    /// strict UTF-8 behavior.
+    fn client_encoding(&self) -> Encoding {
+        Encoding::Utf8
+    }
+
     /// Called when the client issues a request to prepare `query` for later execution.
     ///
     /// The provided [`StatementMetaWriter`] should be used to notify the client of the statement id
@@ -954,14 +962,8 @@ impl<B: MySqlShim<S> + Send, S: AsyncWrite + AsyncRead + Unpin + Send> MySqlInte
                 }
                 Command::Query(q) => {
                     let w = QueryResultWriter::new(&mut self.conn, false);
-                    let res = self
-                        .shim
-                        .on_query(
-                            ::std::str::from_utf8(q)
-                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                            w,
-                        )
-                        .await;
+                    let query = decode_query(self.shim.client_encoding(), q)?;
+                    let res = self.shim.on_query(&query, w).await;
 
                     match res {
                         QueryResultsResponse::Command(cmd) => {
@@ -1001,13 +1003,9 @@ impl<B: MySqlShim<S> + Send, S: AsyncWrite + AsyncRead + Unpin + Send> MySqlInte
                         conn: &mut self.conn,
                         stmts: &mut stmts,
                     };
+                    let query = decode_query(self.shim.client_encoding(), q)?;
                     self.shim
-                        .on_prepare(
-                            ::std::str::from_utf8(q)
-                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                            w,
-                            &mut self.schema_cache,
-                        )
+                        .on_prepare(&query, w, &mut self.schema_cache)
                         .await?;
                 }
                 Command::ResetStmtData(stmt) => {
@@ -1126,5 +1124,30 @@ impl<B: MySqlShim<S> + Send, S: AsyncWrite + AsyncRead + Unpin + Send> MySqlInte
         }
 
         Ok(())
+    }
+}
+
+fn decode_query(encoding: Encoding, query: &[u8]) -> io::Result<String> {
+    encoding
+        .decode(query)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_query_with_client_encoding() {
+        assert_eq!(
+            decode_query(Encoding::Latin1, b"SELECT '\xE3'").unwrap(),
+            "SELECT 'ã'"
+        );
+    }
+
+    #[test]
+    fn default_utf8_query_decoding_remains_strict() {
+        let error = decode_query(Encoding::Utf8, b"SELECT '\xE3'").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/readyset-adapter/src/backend.rs
+++ b/readyset-adapter/src/backend.rs
@@ -6580,6 +6580,7 @@ where
             proxy: _, // Basically ignored, caller will proxy unless we return an error
             set_autocommit,
             set_search_path,
+            set_client_encoding,
             set_results_encoding,
             set_timezone,
         } = Handler::handle_set_statement(set);
@@ -6641,6 +6642,10 @@ where
         if let Some(search_path) = set_search_path {
             trace!(?search_path, "Setting search_path");
             connectors.noria.set_schema_search_path(search_path);
+        }
+        if let Some(encoding) = set_client_encoding {
+            trace!(?encoding, "Setting client_encoding");
+            connectors.noria.set_client_encoding(encoding);
         }
         if let Some(encoding) = set_results_encoding {
             trace!(?encoding, "Setting results_encoding");

--- a/readyset-adapter/src/backend/noria_connector.rs
+++ b/readyset-adapter/src/backend/noria_connector.rs
@@ -299,6 +299,10 @@ pub struct NoriaConnector {
     /// in MySQL can be thought of as a schema search path that only has one element.
     schema_search_path: Vec<SqlIdentifier>,
 
+    /// The encoding used to decode query text sent by the client. Corresponds to
+    /// `character_set_client` and `SET NAMES` in MySQL.
+    client_encoding: Encoding,
+
     /// The encoding in which to return text results. Corresponds to `character_set_results` in
     /// MySQL and `SET NAMES` in both MySQL and Postgres.
     results_encoding: Encoding,
@@ -405,6 +409,7 @@ impl NoriaConnector {
             dialect,
             parse_dialect,
             schema_search_path,
+            client_encoding: Encoding::Utf8,
             results_encoding: Encoding::Utf8,
             timezone: SessionTimezone::System,
         }
@@ -906,6 +911,16 @@ impl NoriaConnector {
     /// Returns a reference to the currently configured schema search path
     pub fn schema_search_path(&self) -> &[SqlIdentifier] {
         self.schema_search_path.as_ref()
+    }
+
+    /// Set the encoding used to decode query text sent by the client.
+    pub fn set_client_encoding(&mut self, encoding: Encoding) {
+        self.client_encoding = encoding;
+    }
+
+    /// Returns the encoding used to decode query text sent by the client.
+    pub fn client_encoding(&self) -> Encoding {
+        self.client_encoding
     }
 
     /// Set the encoding for result sets

--- a/readyset-adapter/src/query_handler.rs
+++ b/readyset-adapter/src/query_handler.rs
@@ -113,6 +113,9 @@ pub struct SetBehavior {
     pub set_autocommit: Option<bool>,
     /// This `SET` statement changes the current schema search path.
     pub set_search_path: Option<Vec<SqlIdentifier>>,
+    /// This `SET` statement changes the encoding used to decode client query text. Corresponds to
+    /// `SET @@character_set_client` or `SET NAMES` in MySQL.
+    pub set_client_encoding: Option<readyset_data::encoding::Encoding>,
     /// This `SET` statement changes the encoding to be used for results. Corresponds to `SET
     /// @@character_set_results` in MySQL or `SET NAMES` in Postgres or MySQL.
     pub set_results_encoding: Option<readyset_data::encoding::Encoding>,
@@ -135,6 +138,18 @@ impl SetBehavior {
 
     pub fn set_search_path(mut self, search_path: Vec<SqlIdentifier>) -> Self {
         self.set_search_path = Some(search_path);
+        self
+    }
+
+    pub fn set_client_encoding(
+        mut self,
+        encoding: Option<readyset_data::encoding::Encoding>,
+    ) -> Self {
+        if let Some(encoding) = encoding {
+            self.set_client_encoding = Some(encoding);
+        } else {
+            self.unsupported = true;
+        }
         self
     }
 
@@ -232,6 +247,7 @@ impl Default for SetBehavior {
             proxy: true,
             set_autocommit: None,
             set_search_path: None,
+            set_client_encoding: None,
             set_results_encoding: None,
             set_timezone: None,
         }

--- a/readyset-mysql/src/backend.rs
+++ b/readyset-mysql/src/backend.rs
@@ -630,6 +630,10 @@ impl<S> MySqlShim<S> for Backend
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
+    fn client_encoding(&self) -> Encoding {
+        self.noria.connectors.noria.client_encoding()
+    }
+
     fn server_status_flags(&self) -> StatusFlags {
         self.build_status_flags()
     }
@@ -868,6 +872,7 @@ where
         )
         .increment(1);
         let encoding = readyset_data::encoding::Encoding::from_mysql_collation_id(charset);
+        self.noria.connectors.noria.set_client_encoding(encoding);
         self.noria.connectors.noria.set_results_encoding(encoding);
         Ok(())
     }

--- a/readyset-mysql/src/query_handler.rs
+++ b/readyset-mysql/src/query_handler.rs
@@ -993,8 +993,11 @@ impl QueryHandler for MySqlQueryHandler {
                             let encoding = get_encoding_for_charset(value, var_name);
                             behavior.set_results_encoding(encoding)
                         }
-                        "character_set_client" // TODO(mvzink): Remove and support reencoding queries before parsing
-                        | "character_set_connection" // TODO(mvzink): Remove and support plumbing collation through expression lowering
+                        "character_set_client" => {
+                            let encoding = get_encoding_for_charset(value, var_name);
+                            behavior.set_client_encoding(encoding)
+                        }
+                        "character_set_connection" // TODO(mvzink): Remove and support plumbing collation through expression lowering
                         | "character_set_server"
                         | "collation_connection"
                         | "collation_server" => {
@@ -1019,6 +1022,7 @@ impl QueryHandler for MySqlQueryHandler {
                 .increment(1);
 
                 behavior = behavior
+                    .set_client_encoding(encoding)
                     .set_results_encoding(encoding)
                     .unsupported(names.collation.is_some());
             }
@@ -1228,6 +1232,30 @@ mod tests {
     }
 
     #[test]
+    fn set_character_set_client_string_literal_supported() {
+        for (charset, encoding) in [
+            ("latin1", Encoding::Latin1),
+            ("utf8", Encoding::Utf8),
+            ("utf8mb4", Encoding::Utf8),
+            ("utf8mb3", Encoding::Utf8),
+        ] {
+            let stmt = SetStatement::Variable(SetVariables {
+                variables: vec![(
+                    Variable {
+                        scope: VariableScope::Session,
+                        name: "character_set_client".into(),
+                    },
+                    Expr::Literal(Literal::String(charset.into())),
+                )],
+            });
+            assert_eq!(
+                MySqlQueryHandler::handle_set_statement(&stmt),
+                SetBehavior::default().set_client_encoding(Some(encoding))
+            )
+        }
+    }
+
+    #[test]
     fn set_character_set_results_bare_name_supported() {
         for (charset, encoding) in [
             ("latin1", Encoding::Latin1),
@@ -1268,7 +1296,9 @@ mod tests {
             });
             assert_eq!(
                 MySqlQueryHandler::handle_set_statement(&stmt),
-                SetBehavior::default().set_results_encoding(Some(encoding))
+                SetBehavior::default()
+                    .set_client_encoding(Some(encoding))
+                    .set_results_encoding(Some(encoding))
             )
         }
     }


### PR DESCRIPTION
## What

- decode `COM_QUERY` and `COM_STMT_PREPARE` text using the negotiated client encoding
- track `character_set_client` separately from `character_set_results`
- make handshake/change-user and `SET NAMES` update both encodings while preserving client-only and result-only settings
- keep existing `MySqlShim` implementations strict UTF-8 by default

## Why

MySQL clients using `latin1` can send valid query bytes that are not valid UTF-8. `mysql-srv` currently applies `str::from_utf8` at the protocol boundary and closes the connection before ReadySet can parse the query.

Fixes #1665.

## Testing

- `cargo check -p mysql-srv --lib`
- `cargo test -p mysql-srv tests:: --lib` — 120 passed, 0 failed
- `cargo fmt --package mysql-srv --package readyset-adapter --package readyset-mysql -- --check`
- `git diff --check`

The broader repository graph has pre-existing Unix-only dependencies and tests on Windows; Linux CI is the authoritative full-workspace verification.
