### PR TITLE
fix: preserve column collation when coercing numbers/enums to varchar/char

### DIFF
--- a/readyset-data/src/enum.rs
+++ b/readyset-data/src/enum.rs
@@ -1,7 +1,7 @@
 use readyset_errors::ReadySetResult;
 use readyset_sql::ast::EnumVariants;
 
-use crate::{integer, DfType, DfValue};
+use crate::{integer, Collation, DfType, DfValue};
 
 /// Coerce an enum value to a different type.
 ///
@@ -14,10 +14,11 @@ pub(crate) fn coerce_enum(
     from_ty: &DfType,
 ) -> ReadySetResult<DfValue> {
     if to_ty.is_any_text() {
+        let collation = to_ty.collation().unwrap_or(Collation::Utf8);
         let idx = usize::try_from(enum_value).unwrap_or(0);
 
         if idx == 0 {
-            Ok(DfValue::from(""))
+            Ok(DfValue::from_str_and_collation("", collation))
         } else if let Some(s) = enum_elements.get(idx - 1) {
             // This match is solely here to accommodate for different length specifications in
             // char/varchar types. When Nikolai's apply_str_limit function is finished and merged,
@@ -28,16 +29,16 @@ pub(crate) fn coerce_enum(
                     let mut new_string = String::with_capacity(*l as usize);
                     new_string += s;
                     new_string.extend(std::iter::repeat_n(' ', *l as usize - s.len()));
-                    Ok(DfValue::from(new_string))
+                    Ok(DfValue::from_str_and_collation(&new_string, collation))
                 }
                 DfType::Char(l, ..) | DfType::VarChar(l, ..) if (*l as usize) < s.len() => {
                     // Len is less than current string, have to truncate
-                    Ok(DfValue::from(&s[..*l as usize]))
+                    Ok(DfValue::from_str_and_collation(&s[..*l as usize], collation))
                 }
-                _ => Ok(DfValue::from(s.as_str())),
+                _ => Ok(DfValue::from_str_and_collation(s, collation)),
             }
         } else {
-            Ok(DfValue::from("")) // must be out of bounds of enum_elements
+            Ok(DfValue::from_str_and_collation("", collation))
         }
     } else {
         integer::coerce_integer(enum_value, to_ty, from_ty)

--- a/readyset-data/src/float.rs
+++ b/readyset-data/src/float.rs
@@ -140,20 +140,20 @@ pub(crate) fn coerce_f64(val: f64, to_ty: &DfType, from_ty: &DfType) -> ReadySet
             collation,
         )),
 
-        DfType::VarChar(l, ..) => {
+        DfType::VarChar(l, collation) => {
             let mut val = float_to_text(val);
             val.truncate(l as usize);
-            Ok(val.to_string().into())
+            Ok(DfValue::from_str_and_collation(&val, collation))
         }
 
-        DfType::Char(l, ..) => {
+        DfType::Char(l, collation) => {
             let mut val = float_to_text(val);
             val.truncate(l as usize);
             val.extend(std::iter::repeat_n(
                 ' ',
                 (l as usize).saturating_sub(val.len()),
             ));
-            Ok(val.into())
+            Ok(DfValue::from_str_and_collation(&val, collation))
         }
 
         DfType::Blob => Ok(DfValue::ByteArray(val.to_string().into_bytes().into())),
@@ -293,20 +293,20 @@ pub(crate) fn coerce_decimal(
 
         DfType::Text(collation) => Ok(DfValue::from_str_and_collation(&val.to_string(), collation)),
 
-        DfType::VarChar(l, ..) => {
+        DfType::VarChar(l, collation) => {
             let mut val = val.to_string();
             val.truncate(l as usize);
-            Ok(val.to_string().into())
+            Ok(DfValue::from_str_and_collation(&val, collation))
         }
 
-        DfType::Char(l, ..) => {
+        DfType::Char(l, collation) => {
             let mut val = val.to_string();
             val.truncate(l as usize);
             val.extend(std::iter::repeat_n(
                 ' ',
                 (l as usize).saturating_sub(val.len()),
             ));
-            Ok(val.into())
+            Ok(DfValue::from_str_and_collation(&val, collation))
         }
 
         DfType::Blob => Ok(DfValue::ByteArray(val.to_string().into_bytes().into())),

--- a/readyset-data/src/integer.rs
+++ b/readyset-data/src/integer.rs
@@ -94,20 +94,20 @@ where
 
         DfType::Text(collation) => Ok(DfValue::from_str_and_collation(&val.to_string(), collation)),
 
-        DfType::VarChar(l, ..) => {
+        DfType::VarChar(l, collation) => {
             let mut val = val.to_string();
             val.truncate(l as usize);
-            Ok(val.to_string().into())
+            Ok(DfValue::from_str_and_collation(&val, collation))
         }
 
-        DfType::Char(l, ..) => {
+        DfType::Char(l, collation) => {
             let mut val = val.to_string();
             val.truncate(l as usize);
             val.extend(std::iter::repeat_n(
                 ' ',
                 (l as usize).saturating_sub(val.len()),
             ));
-            Ok(val.into())
+            Ok(DfValue::from_str_and_collation(&val, collation))
         }
 
         DfType::Blob => Ok(val.to_string().into_bytes().into()),

--- a/readyset-data/src/lib.rs
+++ b/readyset-data/src/lib.rs
@@ -4825,6 +4825,55 @@ mod tests {
             );
             check_comparison!(point_bytes.clone(), DfType::PostgisPolygon, point_bytes);
         }
+
+        // Regression test for #1662.
+        #[test]
+        fn number_to_char_types_preserves_collation() {
+            let collation = Collation::Utf8Ci;
+            let char_tys = [DfType::VarChar(255, collation), DfType::Char(255, collation)];
+
+            let numeric_keys = [
+                DfValue::Int(20000000000),
+                DfValue::UnsignedInt(20000000000),
+                DfValue::Double(20000000000.0),
+                DfValue::Numeric(Decimal::try_from(20000000000.0).unwrap().into()),
+            ];
+            for ty in &char_tys {
+                for key in &numeric_keys {
+                    let coerced = key.coerce_for_comparison(ty).expect("coerce failed");
+                    assert_eq!(
+                        coerced.collation(),
+                        Some(collation),
+                        "coercing {key:?} to {ty:?} dropped the column collation"
+                    );
+                }
+            }
+
+            let enum_ty = DfType::from_enum_variants(
+                ["red", "yellow", "green"].into_iter().map(Into::into),
+                None,
+            );
+            for ty in &char_tys {
+                let coerced = DfValue::Int(2).coerce_to(ty, &enum_ty).expect("coerce failed");
+                assert_eq!(
+                    coerced.collation(),
+                    Some(collation),
+                    "coercing enum label to {ty:?} dropped the column collation"
+                );
+            }
+
+            fn hash_of(value: &DfValue) -> u64 {
+                use std::hash::{DefaultHasher, Hash, Hasher};
+                let mut hasher = DefaultHasher::new();
+                value.hash(&mut hasher);
+                hasher.finish()
+            }
+            let stored = DfValue::from_str_and_collation("20000000000", collation);
+            let coerced = DfValue::Int(20000000000)
+                .coerce_for_comparison(&DfType::VarChar(255, collation))
+                .unwrap();
+            assert_eq!(hash_of(&coerced), hash_of(&stored));
+        }
     }
 
     #[test]

--- a/readyset-data/src/timestamp.rs
+++ b/readyset-data/src/timestamp.rs
@@ -625,10 +625,10 @@ impl TimestampTz {
                 &self.to_string(),
                 collation,
             )),
-            DfType::Char(l, ..) | DfType::VarChar(l, ..) => {
+            DfType::Char(l, collation) | DfType::VarChar(l, collation) => {
                 let mut string = self.to_string();
                 string.truncate(l as usize);
-                Ok(string.into())
+                Ok(DfValue::from_str_and_collation(&string, collation))
             }
 
             DfType::Blob => Ok(DfValue::ByteArray(std::sync::Arc::new(


### PR DESCRIPTION
fixes #1662

### summary

when coercing a number (or enum label) to a `VARCHAR`/`CHAR` column, the coercion arms in `integer.rs`, `float.rs`, and `timestamp.rs` used `.into()` to build the result which defaults to `Utf8` collation regardless of the column's actual collation. the reader map keys text values by their collation hash so the lookup key hashes differently from the stored key and the point lookup misses silently. the string-literal path worked because the `Text->VarChar` arm in `text.rs` already used `from_str_and_collation` but the numeric and enum paths didnt

### fix

changed those arms to use `from_str_and_collation(&val, collation)`, pulling the collation from the `DfType`:
- [`integer.rs#L97-L113`](https://github.com/bit2swaz/readyset/blob/ec42766db9008f26169cfdfdd87004c2441e5962/readyset-data/src/integer.rs#L97-L113)
- [`float.rs#L143-L157`](https://github.com/bit2swaz/readyset/blob/ec42766db9008f26169cfdfdd87004c2441e5962/readyset-data/src/float.rs#L143-L157) and [`float.rs#L296-L310`](https://github.com/bit2swaz/readyset/blob/ec42766db9008f26169cfdfdd87004c2441e5962/readyset-data/src/float.rs#L296-L310)
- [`timestamp.rs#L628-L631`](https://github.com/bit2swaz/readyset/blob/ec42766db9008f26169cfdfdd87004c2441e5962/readyset-data/src/timestamp.rs#L628-L631)
- [`enum.rs#L17-L42`](https://github.com/bit2swaz/readyset/blob/ec42766db9008f26169cfdfdd87004c2441e5962/readyset-data/src/enum.rs#L17-L42) (same issue: enum label coerced to a collated varchar)

regression test at [`lib.rs#L4831`](https://github.com/bit2swaz/readyset/blob/ec42766db9008f26169cfdfdd87004c2441e5962/readyset-data/src/lib.rs#L4831) checks that the coerced value carries the column collation and that the reader-map hash matches the stored key

verified against a local build of this branch + mysql 8.0 with the repro from the issue. `WHERE documento = 20000000000` now returns the correct row from the deep cache, absent from `SHOW PROXIED QUERIES`, `database_type="readyset"` in metrics